### PR TITLE
Faute de sens

### DIFF
--- a/enhavo/tradukenda/fr/ekzercoj/traduku-kaj-respondu/01.yml
+++ b/enhavo/tradukenda/fr/ekzercoj/traduku-kaj-respondu/01.yml
@@ -1,10 +1,10 @@
 - 
-  demando: Qui est ta petite amie ?
+  demando: Qui est ton amie ?
   rektatraduko:
     - Kiu: Qui
     - estas: est
     - via: ta
-    - amikino: petite amie
+    - amikino: amie
     - '?'
 - 
   demando: Est-ce que ton amie Anna écrit maintenant dans la chambre ?


### PR DESCRIPTION
Erreur : amik'in'o = amie et non pas "petite amie".

girlfriend = petite amie = koramikino
amikino = (she)friend = amie