### PR TITLE
de: Übung 1: mehr (und direktere) Bedeutungen von "enskribi"

### DIFF
--- a/enhavo/tradukenda/de/ekzercoj/traduku/01.yml
+++ b/enhavo/tradukenda/de/ekzercoj/traduku/01.yml
@@ -3,7 +3,10 @@
 - esperantistino: Esperantistin
 - instruisto: Lehrer
 - hotelĉambro: Hotelzimmer
-- enskribi: einschreiben
+- enskribi:
+  - hineinschreiben
+  - hinein schreiben
+  - einschreiben
 - skribotablo: Schreibtisch
 - lingvisto: 
   - Linguist

--- a/enhavo/tradukenda/de/ekzercoj/traduku/01.yml
+++ b/enhavo/tradukenda/de/ekzercoj/traduku/01.yml
@@ -6,6 +6,8 @@
 - enskribi:
   - hineinschreiben
   - hinein schreiben
+  - reinschreiben
+  - rein schreiben
   - einschreiben
 - skribotablo: Schreibtisch
 - lingvisto: 


### PR DESCRIPTION
"einschreiben" hat im Deutschen normalerweise eine der folgenden Bedeutungen:
- bei einer Universität / für ein Studium anmelden (immatrikulieren)
- für einen Kurs o.Ä. anmelden
- einen Brief "per [Einschreiben](https://de.wikipedia.org/wiki/Einschreiben)" (=mit Zustellungsnachweis) versenden

Während "enskribi" in Esperanto zwar mindestens die ersten beiden Bedeutungen haben kann (das mit dem Brief drückt man wohl anders aus), hat es noch weitere Bedeutungen, die vom deutschen Verb "einschreiben" nicht mit abgedeckt wird: In etwas schreiben, in ein Dokument / Werk **hinein** schreiben. (Umgangssprachlich: (In etwas) reinschreiben.)