### PR TITLE
Germanlingvaj verboj

### DIFF
--- a/enhavo/tradukenda/de/vortaro/radiko.yml
+++ b/enhavo/tradukenda/de/vortaro/radiko.yml
@@ -33,7 +33,7 @@ branĉ:
 bru: Lärm
 buŝ: Mund
 cert: sicher(lich)
-dank: Dank
+dank: danken
 daŭr: dauern
 decid: entscheiden
 demand: fragen
@@ -72,7 +72,7 @@ far:
 fart: sich fühlen 
 feliĉ: glücklich
 ferm: schließen
-fin: Ende
+fin: beenden
 flank: Seite
 foj: Mal
 forges: vergessen

--- a/enhavo/tradukenda/de/vortaro/radiko.yml
+++ b/enhavo/tradukenda/de/vortaro/radiko.yml
@@ -59,8 +59,7 @@ efektiv:
 ekskurs: Ausflug
 esper: hoffen
 est:
-- sein (Verb
-- Wortstamm) 
+- sein (Verb)
 facil: leicht
 fakt: Tatsache
 fakt: tatsächlich

--- a/enhavo/tradukenda/de/vortaro/radiko.yml
+++ b/enhavo/tradukenda/de/vortaro/radiko.yml
@@ -58,8 +58,7 @@ efektiv:
 - tatsächlich
 ekskurs: Ausflug
 esper: hoffen
-est:
-- sein (Verb)
+est: sein (Verb)
 facil: leicht
 fakt: Tatsache
 fakt: tatsächlich


### PR DESCRIPTION
* Übersetze _"dank·i"_ und _"fin·i"_ als Verben (Endungen [gemäß `enhavo/netradukenda/radikaj_finajxoj.yml`](https://github.com/Esperanto/kurso-zagreba-metodo/blob/46ff4cf47d7af6333f4bc87f7b81261a53dcc153/enhavo/netradukenda/radikaj_finajxoj.yml#L33) [jeweils _"-i"_](https://github.com/Esperanto/kurso-zagreba-metodo/blob/46ff4cf47d7af6333f4bc87f7b81261a53dcc153/enhavo/netradukenda/radikaj_finajxoj.yml#L68))
* _"esti"_: Entferne Hinweis "Wortstamm", da Vokabeln samt Wortart-Endung angezeigt werden. (Bei _"est·i"_ mit dem _"-i"_ für Verb im Infinitiv)