### PR TITLE
korrigiere deutsche Übersetzung von Aufg. 6

### DIFF
--- a/enhavo/tradukenda/de/ekzercoj/traduku-kaj-respondu/06.yml
+++ b/enhavo/tradukenda/de/ekzercoj/traduku-kaj-respondu/06.yml
@@ -61,7 +61,7 @@
     - Ĉu: Ob 
     - la: das
     - libreto: Büchlein 
-    - estis: was
+    - estis: war
     - utila: nützlich 
     - al: zu 
     - vi: dir


### PR DESCRIPTION
Germana "was" estus esperante "kio", ne kiel en la angla esperante "estis".
Esperanta "estis" germane estas "war".