### PR TITLE
Aldonu lokan HTML-servilon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ make check
 make html LINGVO=en
 make html-all
 make md LINGVO=en
+make serve
 ```
 
 `make check` instalas nenion. Se `venv/bin/python` aŭ dependecoj mankas, rulu `make install`. La virtuala medio estas `venv` defaŭlte; oni povas uzi alian per `VENV=.venv make install`.
@@ -45,6 +46,14 @@ make html LINGVO=en
 ```
 
 Tio skribas al `html_generiloj/output/en`.
+
+Por antaŭrigardi jam generitan HTML-on loke, rulu:
+
+```sh
+make serve
+```
+
+Tio nur servas la ekzistantan enhavon de `html_generiloj/output`; ĝi ne regeneras dosierojn.
 
 Generu Markdown:
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: help venv install check html html-all md
+.PHONY: help venv install check html html-all md serve
 
 LINGVO ?= en
 HTML_LINGVOJ ?= ar ca cs da de el en es fa fr frp ga he hi hr hu id it ja kk km ko lo mg ms my nl pl pt ro ru sk sl sv sw th tr uk ur vi yo zh zh-tw
+HOST ?= 127.0.0.1
+PORT ?= 8000
+OUTPUT_DIR ?= html_generiloj/output
 VENV ?= venv
 SYSTEM_PYTHON ?= python3
 PYTHON ?= $(VENV)/bin/python
@@ -17,7 +20,8 @@ help:
 		'  make check           Rulas sekuran provan kontrolon, defaŭlte LINGVO=en' \
 		'  make html LINGVO=en  Generas HTML por unu lingvo' \
 		'  make html-all        Generas HTML por ĉiuj produktadaj lingvoj' \
-		'  make md LINGVO=en    Generas Markdown por unu lingvo'
+		'  make md LINGVO=en    Generas Markdown por unu lingvo' \
+		'  make serve           Servas HTML loke ĉe http://127.0.0.1:8000'
 
 venv:
 	@if [ ! -x "$(PYTHON)" ]; then \
@@ -44,3 +48,6 @@ html-all:
 
 md:
 	@"$(PYTHON)" generate.py --lingvo "$(LINGVO)" --eligformo md
+
+serve:
+	@"$(PYTHON)" -m http.server "$(PORT)" --bind "$(HOST)" --directory "$(OUTPUT_DIR)"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Por generi la tutan produktadan HTML-eligon:
 
     make html-all
 
+Por antaŭrigardi jam generitan HTML-on loke:
+
+    make serve
+
+Tio servas `html_generiloj/output` ĉe `http://127.0.0.1:8000`.
+
 La prova retejo `stg.esperanto12.net` estas publikigata per GitHub Pages el `html_generiloj/output`. Antaŭ ebla produktada DNS-transiro al GitHub Pages, `maintenance/gxisdatigu-eligon.sh` restas nur hereda servila rezervo.
 
 ### PDF kaj EPUB


### PR DESCRIPTION
## Resumo

Aldonas `make serve` por antaŭrigardi la jam generitan HTML-eligon loke el `html_generiloj/output`.

## Ŝanĝoj

- Aldonas agordeblajn variablojn `HOST`, `PORT` kaj `OUTPUT_DIR`.
- Aldonas `make serve`, defaŭlte ĉe `http://127.0.0.1:8000`.
- Dokumentas la novan komandon en `README.md` kaj `AGENTS.md`.

## Kontroloj

- `make help`
- `make html LINGVO=en`
- `make serve PORT=8765`
- `curl -I http://127.0.0.1:8765/`
- `curl -I http://127.0.0.1:8765/en/`
- `curl -I http://127.0.0.1:8765/vendor/bootstrap/css/bootstrap.min.css`