### PR TITLE
Limigu Pages-deplojon al master

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.9"
 
       - name: Configure Pages
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/master'
         uses: actions/configure-pages@v5
 
       - name: Install dependencies
@@ -43,18 +43,18 @@ jobs:
         run: make html-all
 
       - name: Configure custom domain
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/master'
         run: printf '%s\n' 'stg.esperanto12.net' > eligo/retejo/CNAME
 
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v4
         with:
           path: eligo/retejo
           retention-days: 14
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: build
     permissions:


### PR DESCRIPTION
## Resumo

- Ŝanĝas Pages-specifajn paŝojn por ruliĝi nur kiam `github.ref == refs/heads/master`.
- PR-oj kaj manaj branĉaj lanĉoj plu faras `make install`, `make check` kaj `make html-all`.
- CNAME, artifact-upload kaj deploy ne plu povas ekruliĝi sur PR aŭ alia branĉo.

## Testoj

- `make check`
- `make html-all`
- `git diff --check`