### PR TITLE
Agordu produktadan Pages-disponigon por esperanto12.net

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Build HTML
         run: make html-all
 
-      - name: Configure custom domain
-        if: github.ref == 'refs/heads/master'
-        run: printf '%s\n' 'stg.esperanto12.net' > eligo/retejo/CNAME
-
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ make md LINGVO=en
 
 La Markdown-eligo estas skribata al stdout. Generado de PDF kaj EPUB bezonas Pandoc, kiel priskribite en `README.md`.
 
-La prova retejo `stg.esperanto12.net` estas konstruata per GitHub Pages el `eligo/retejo` uzante `make html-all`. Ne aldonu apartajn deplojajn skriptojn por produktado; la Pages-artefakta laborfluo estas la kanonika deplojo.
+La produkta retejo `esperanto12.net` estas disponigata per GitHub Pages el `eligo/retejo` uzante `make html-all`. PR-oj al `master` rulas kontrolon kaj HTML-kunmeton, sed ne disponigas retejon. Ne aldonu apartajn disponigajn skriptojn por produktado; la Pages-artefakta laborfluo estas la kanonika disponigo.
 
 ## Redaktado De Enhavo
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Por forigi la generitan retejan eligon:
 
     make clean
 
-La prova retejo `stg.esperanto12.net` estas publikigata per GitHub Pages el `eligo/retejo`.
+La produkta retejo `esperanto12.net` estas disponigata per GitHub Pages el `eligo/retejo`.
+PR-oj al `master` rulas la saman kontrolon kaj HTML-kunmeton, sed ne disponigas retejon.
 
 ### PDF kaj EPUB
 


### PR DESCRIPTION
## Kio
- Forigas la artefaktan `CNAME`-paŝon el la Pages-laborfluo.
- Dokumentas `esperanto12.net` kiel la produktan Pages-retejon.
- Klarigas ke PR-oj al `master` rulas kontrolon kaj HTML-kunmeton sen disponigo.

## Rimarko
La kutima domeno por GitHub Pages devas esti agordita en la deponejaj Pages-agordoj al `esperanto12.net`; ĉe Actions-bazita Pages-disponigo la artefakta `CNAME` ne estas bezonata.

## Kontroloj
- `make check`
- `make html-all`
- `git diff --check`