### PR TITLE
Aldonu GoatCounter-nombrilon

### DIFF
--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -143,5 +143,6 @@
 		<!-- 100% privacy-first analytics -->
     <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
     <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"/></noscript>
+    <script data-goatcounter="https://e12.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   </body>
 </html>

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -179,6 +179,7 @@
 		<!-- 100% privacy-first analytics -->
 <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"/></noscript>
+<script data-goatcounter="https://e12.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
## Kio
- Aldonas la GoatCounter-skripton al la ĉefpaĝa ŝablono.
- Aldonas la saman skripton al la ĝenerala HTML-aranĝo por ĉiuj generitaj paĝoj.

## Kontroloj
- `make html LINGVO=en`
- `git diff --check`
- Kontrolita eligo en `eligo/retejo/index.html`, `eligo/retejo/en/index.html` kaj `eligo/retejo/en/01/index.html`