### PR TITLE
Forigu lokan genanki-submodulon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "genanki"]
-	path = vendor/genanki
-	url = https://github.com/georgjaehnig/genanki

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ La projekta lingvo kaj la dokumentaro videbla al uzantoj estas plejparte Esperan
 - `fonto/html/` kaj `fonto/md/`: ŝablonoj por HTML kaj Markdown.
 - `fonto/css/`, `fonto/js/`, `fonto/bildoj/` kaj `fonto/sonoj/`: statikaj fontdosieroj kopiataj al la reteja eligo.
 - `eligo/retejo/`: generita HTML-retejo. Ne versikontrolu ĝin.
-- `vendor/`: vendorigitaj eksteraj bibliotekoj, inkluzive de `bootstrap`, `jquery`, `typeahead` kaj `genanki`. Evitu tuŝi ilin krom se la tasko specife temas pri tiu subarbo.
+- `vendor/`: vendorigitaj eksteraj bibliotekoj, inkluzive de `bootstrap`, `jquery` kaj `typeahead`. Evitu tuŝi ilin krom se la tasko specife temas pri tiu subarbo.
 - `iloj/`: prizorgaj helpiloj.
 
 ## Agordo Kaj Komandoj

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import subprocess
 
-# sys.path = ['./genanki'] + sys.path
 import genanki
 import jinja2
 from markupsafe import Markup


### PR DESCRIPTION
## Kio
- Forigas la malnovan `vendor/genanki`-submodulon kaj `.gitmodules`.
- Forigas la neuzatan komentitan `sys.path`-hakon por loka genanki.
- Ĝisdatigas `AGENTS.md`, ĉar `genanki` nun venas nur el la Python-dependecoj.

## Kontroloj
- `make check`
- `make html LINGVO=en`
- `git diff --check`
- Serĉo pri lokaj genanki-submodulaj spuroj sen rezultoj