### PR TITLE
Kontrolu anglan eligon per make check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 /__pycache__
 /agordoj/auxtoroj-lingvoj.yml
+/eligo/md/
 /eligo/retejo/
 /pad
 /venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ make serve
 make clean
 ```
 
-`make check` instalas nenion. Se `venv/bin/python` aŭ dependecoj mankas, rulu `make install`. La virtuala medio estas `venv` defaŭlte; oni povas uzi alian per `VENV=.venv make install`.
+`make check` instalas nenion. Ĝi ĉiam kontrolas la anglan eligon, generas `eligo/md/en.md` kaj `eligo/retejo/en`, kaj kontrolas kernajn HTML-dosierojn kaj la Anki-APKG-on. Se `venv/bin/python` aŭ dependecoj mankas, rulu `make install`. La virtuala medio estas `venv` defaŭlte; oni povas uzi alian per `VENV=.venv make install`.
 
 Python-dependecoj estas mastrumataj per pip kaj pip-tools. Redaktu rektajn dependecojn en `requirements.in`, poste rulu `make lock` por regeneri la ŝlositan `requirements.txt`. Por intence ĝisdatigi ĉiujn ŝlositajn versiojn, rulu `make lock-upgrade`.
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@ VENV ?= venv
 SYSTEM_PYTHON ?= python3
 PYTHON ?= $(VENV)/bin/python
 PIP_TOOLS ?= pip-tools==7.5.3
-TMPDIR ?= /tmp
-TMP_ROOT := $(patsubst %/,%,$(TMPDIR))
-MD_OUT ?= $(TMP_ROOT)/leo-$(LINGVO).md
+CHECK_LINGVO := en
+MD_OUT ?= eligo/md/$(CHECK_LINGVO).md
 
 help:
 	@printf '%s\n' \
@@ -20,7 +19,7 @@ help:
 		'  make install         Kreas venv-on kaj instalas requirements' \
 		'  make lock            Rekreas requirements.txt el requirements.in' \
 		'  make lock-upgrade    Ĝisdatigas ĉiujn ŝlositajn Python-dependecojn' \
-		'  make check           Rulas sekuran provan kontrolon, defaŭlte LINGVO=en' \
+		'  make check           Kontrolas anglan Markdown-, HTML- kaj Anki-eligon' \
 		'  make html LINGVO=en  Generas HTML por unu lingvo' \
 		'  make html-all        Generas HTML por ĉiuj produktadaj lingvoj' \
 		'  make md LINGVO=en    Generas Markdown por unu lingvo' \
@@ -46,9 +45,11 @@ lock-upgrade: pip-tools
 
 check:
 	@test -x "$(PYTHON)" || { printf '%s\n' 'Mankas $(PYTHON). Rulu `make install` unue aŭ agordu VENV=/path/to/venv.' >&2; exit 1; }
-	@"$(PYTHON)" -c 'import yaml, jinja2, chevron, mistune'
-	@"$(PYTHON)" -m fonto.py.generu --lingvo "$(LINGVO)" --eligformo md >"$(MD_OUT)"
-	@printf 'Sukcesis: generis Markdown por %s al %s\n' "$(LINGVO)" "$(MD_OUT)"
+	@"$(PYTHON)" -c 'import yaml, jinja2, chevron, mistune, genanki'
+	@mkdir -p "$(dir $(MD_OUT))"
+	@$(MAKE) --no-print-directory md LINGVO="$(CHECK_LINGVO)" >"$(MD_OUT)"
+	@$(MAKE) --no-print-directory html LINGVO="$(CHECK_LINGVO)"
+	@"$(PYTHON)" -m fonto.py.kontrolu_eligon --lingvo "$(CHECK_LINGVO)" --md-out "$(MD_OUT)" --output-dir "$(OUTPUT_DIR)"
 
 html:
 	@"$(PYTHON)" -m fonto.py.generu --lingvo "$(LINGVO)" --eligformo html

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ La rektaj Python-dependecoj estas listigitaj en `requirements.in`. `requirements
 
     make lock
 
-Por kontroli la plej oftan generadon sen ŝanĝi dosierojn en la deponejo:
+Por kontroli la anglan Markdown-, HTML- kaj Anki-eligon:
 
     make check
+
+Tio generas `eligo/md/en.md` kaj `eligo/retejo/en`, poste kontrolas kernajn dosierojn kaj la APKG-eksporton.
 
 ### HTML
 

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+import sqlite3
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
+
+
+def fail(message):
+    raise SystemExit('Kontrolo malsukcesis: ' + message)
+
+
+def require_nonempty_file(path):
+    if not path.is_file():
+        fail('mankas dosiero ' + str(path))
+    if path.stat().st_size == 0:
+        fail('malplenas dosiero ' + str(path))
+    try:
+        with path.open('rb') as handle:
+            handle.read(1)
+    except OSError as error:
+        fail('ne eblas legi ' + str(path) + ': ' + str(error))
+
+
+def require_pattern(path, pattern):
+    require_nonempty_file(path)
+    try:
+        text = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError as error:
+        fail('ne eblas legi kiel UTF-8 ' + str(path) + ': ' + str(error))
+    if not pattern.search(text):
+        fail('mankas atendita enhavo en ' + str(path))
+
+
+def require_apkg(path):
+    require_nonempty_file(path)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = set(archive.namelist())
+            if 'collection.anki2' not in names:
+                fail('mankas collection.anki2 en ' + str(path))
+            if 'media' not in names:
+                fail('mankas media en ' + str(path))
+            collection = archive.read('collection.anki2')
+    except zipfile.BadZipFile as error:
+        fail('nevalida APKG-zip ' + str(path) + ': ' + str(error))
+
+    with tempfile.NamedTemporaryFile(suffix='.anki2') as database:
+        database.write(collection)
+        database.flush()
+        connection = None
+        try:
+            connection = sqlite3.connect(database.name)
+            notes = connection.execute('select count(*) from notes').fetchone()[0]
+            cards = connection.execute('select count(*) from cards').fetchone()[0]
+        except sqlite3.Error as error:
+            fail('ne eblas legi collection.anki2 el ' + str(path) + ': ' + str(error))
+        finally:
+            if connection:
+                connection.close()
+
+    if notes < 1:
+        fail('APKG enhavas neniun noton: ' + str(path))
+    if cards < 1:
+        fail('APKG enhavas neniun karton: ' + str(path))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lingvo', required=True)
+    parser.add_argument('--md-out', required=True)
+    parser.add_argument('--output-dir', required=True)
+    args = parser.parse_args()
+
+    lingvo = args.lingvo
+    output_dir = Path(args.output_dir)
+    md_out = Path(args.md_out)
+    lingvo_dir = output_dir / lingvo
+
+    for path in [
+        md_out,
+        output_dir / 'index.html',
+        lingvo_dir / 'index.html',
+        output_dir / 'assets' / 'css' / 'main.css',
+        output_dir / 'assets' / 'js' / 'main.js',
+        output_dir / 'vendor' / 'bootstrap' / 'css' / 'bootstrap.min.css',
+    ]:
+        require_nonempty_file(path)
+
+    require_pattern(lingvo_dir / '01' / 'gramatiko' / 'index.html', GRAMATIKO_PATTERN)
+    require_apkg(lingvo_dir / 'eksporto' / (lingvo + '.apkg'))
+
+    print('Sukcesis: kontrolis Markdown-, HTML- kaj Anki-eligon por ' + lingvo)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Kio
- `make check` nun konstruas la anglan Markdown-eligon al `eligo/md/en.md`.
- `make check` konstruas la anglan retejan eligon per la ordinara HTML-generatoro.
- Aldonas kontrolmodulon por kernaj HTML/assets-dosieroj, la gramatika `Alphabet`-enhavo kaj legebla Anki-APKG.
- Ignoras `eligo/md/` kaj dokumentas la plivastigitan kontrolon.

## Kontroloj
- `make help`
- `make install`
- `make check`
- `test -s eligo/md/en.md`
- `test -s eligo/retejo/en/index.html`
- `test -s eligo/retejo/en/01/gramatiko/index.html`
- `test -s eligo/retejo/en/eksporto/en.apkg`
- Regex-kontrolo por `<div dir="ltr">\s*<h3>Alphabet</h3>`
- `venv/bin/python -m py_compile fonto/py/kontrolu_eligon.py`
- `git diff --check`