### PR TITLE
Ĝisdatigu Mistune por sekureco

### DIFF
--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -170,7 +170,7 @@ def copy_static_files(versio):
 
 def generate_html(lingvo, enhavo, args):
     eligo = {}
-    md = mistune.Markdown()
+    md = mistune.create_markdown()
     versio = get_version_hash()
     enhavo['versio'] = versio
     copy_static_files(versio)

--- a/fonto/py/md.py
+++ b/fonto/py/md.py
@@ -9,7 +9,7 @@ from markupsafe import Markup
 
 
 def kreu_md(enhavo, printendaj):
-    md = mistune.Markdown()
+    md = mistune.create_markdown()
 
     env = jinja2.Environment()
     env.filters['markdown'] = lambda text: Markup(md(text))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,11 @@ markupsafe==2.0.1
     # via
     #   -r requirements.in
     #   jinja2
-mistune==0.8.4
+mistune==3.2.1
     # via -r requirements.in
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   genanki
+typing-extensions==4.15.0
+    # via mistune


### PR DESCRIPTION
## Kio
- Ĝisdatigas `mistune` de `0.8.4` al `3.2.1` en la ŝlosita `requirements.txt`.
- Aldonas `typing-extensions`, bezonatan de Mistune 3.
- Adaptas la HTML- kaj Markdown-generatorojn al `mistune.create_markdown()`, por eviti la antaŭan AST-eligan regresion.

## Kontroloj
- `make install`
- `make check`
- `test -s eligo/md/en.md`
- `test -s eligo/retejo/en/eksporto/en.apkg`
- Regex-kontrolo por `<div dir="ltr">\s*<h3>Alphabet</h3>`
- Serĉo ke la gramatika paĝo ne plu enhavas Mistune-AST-fragmentojn
- `git diff --check`