### PR TITLE
Purigu retejan eligon dum make check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ make serve
 make clean
 ```
 
-`make check` instalas nenion. Ĝi ĉiam kontrolas la anglan eligon, generas `eligo/md/en.md` kaj `eligo/retejo/en`, kaj kontrolas kernajn HTML-dosierojn kaj la Anki-APKG-on. Se `venv/bin/python` aŭ dependecoj mankas, rulu `make install`. La virtuala medio estas `venv` defaŭlte; oni povas uzi alian per `VENV=.venv make install`.
+`make check` instalas nenion. Ĝi ĉiam kontrolas la anglan eligon, unue forigas `eligo/retejo`, generas `eligo/md/en.md` kaj `eligo/retejo/en`, kaj kontrolas kernajn HTML-dosierojn kaj la Anki-APKG-on. Se `venv/bin/python` aŭ dependecoj mankas, rulu `make install`. La virtuala medio estas `venv` defaŭlte; oni povas uzi alian per `VENV=.venv make install`.
 
 Python-dependecoj estas mastrumataj per pip kaj pip-tools. Redaktu rektajn dependecojn en `requirements.in`, poste rulu `make lock` por regeneri la ŝlositan `requirements.txt`. Por intence ĝisdatigi ĉiujn ŝlositajn versiojn, rulu `make lock-upgrade`.
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 		'  make install         Kreas venv-on kaj instalas requirements' \
 		'  make lock            Rekreas requirements.txt el requirements.in' \
 		'  make lock-upgrade    Ĝisdatigas ĉiujn ŝlositajn Python-dependecojn' \
-		'  make check           Kontrolas anglan Markdown-, HTML- kaj Anki-eligon' \
+		'  make check           Purigas kaj kontrolas anglan Markdown-, HTML- kaj Anki-eligon' \
 		'  make html LINGVO=en  Generas HTML por unu lingvo' \
 		'  make html-all        Generas HTML por ĉiuj produktadaj lingvoj' \
 		'  make md LINGVO=en    Generas Markdown por unu lingvo' \
@@ -46,6 +46,7 @@ lock-upgrade: pip-tools
 check:
 	@test -x "$(PYTHON)" || { printf '%s\n' 'Mankas $(PYTHON). Rulu `make install` unue aŭ agordu VENV=/path/to/venv.' >&2; exit 1; }
 	@"$(PYTHON)" -c 'import yaml, jinja2, chevron, mistune, genanki'
+	@$(MAKE) --no-print-directory clean
 	@mkdir -p "$(dir $(MD_OUT))"
 	@$(MAKE) --no-print-directory md LINGVO="$(CHECK_LINGVO)" >"$(MD_OUT)"
 	@$(MAKE) --no-print-directory html LINGVO="$(CHECK_LINGVO)"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Por kontroli la anglan Markdown-, HTML- kaj Anki-eligon:
 
     make check
 
-Tio generas `eligo/md/en.md` kaj `eligo/retejo/en`, poste kontrolas kernajn dosierojn kaj la APKG-eksporton.
+Tio unue forigas `eligo/retejo`, poste generas `eligo/md/en.md` kaj `eligo/retejo/en`, kaj fine kontrolas kernajn dosierojn kaj la APKG-eksporton.
 
 ### HTML
 


### PR DESCRIPTION
## Kio
- `make check` nun vokas `make clean` antaŭ la angla Markdown/HTML/Anki-kontrolo.
- Ĝisdatigas la help-tekston kaj dokumentadon por montri ke `eligo/retejo` estas forigata komence.

## Kontroloj
- `make help`
- `make check`
- `git diff --check`