### PR TITLE
Ĝisdatigu GitHub Actions al Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Configure Pages
         if: github.ref == 'refs/heads/master'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: make install
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: eligo/retejo
           retention-days: 14
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.9"
 
       - name: Configure Pages
         if: github.ref == 'refs/heads/master'
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@v6.0.0
 
       - name: Install dependencies
         run: make install
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: eligo/retejo
           retention-days: 14
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
## Kio
- Ĝisdatigas Pages-workflow-agojn al Node-24-kongruaj major-versioj.
- Ŝanĝas `actions/checkout` al v5, `actions/setup-python` al v6, `actions/configure-pages` al v6, `actions/upload-pages-artifact` al v5 kaj `actions/deploy-pages` al v5.

## Kial
- GitHub avertas, ke Node 20 por JavaScript Actions estas malaktualigata kaj tiuj agoj estas devige rulataj per Node 24.

## Kontroloj
- `make check`
- `git diff --check`
- Statika kontrolo de `.github/workflows/pages.yml`