### PR TITLE
Sekurigu YAML-legadon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ lock-upgrade: pip-tools
 check:
 	@test -x "$(PYTHON)" || { printf '%s\n' 'Mankas $(PYTHON). Rulu `make install` unue aŭ agordu VENV=/path/to/venv.' >&2; exit 1; }
 	@"$(PYTHON)" -c 'import yaml, jinja2, chevron, mistune, genanki'
+	@"$(PYTHON)" -m fonto.py.kontrolu_yaml
 	@$(MAKE) --no-print-directory clean
 	@mkdir -p "$(dir $(MD_OUT))"
 	@$(MAKE) --no-print-directory md LINGVO="$(CHECK_LINGVO)" >"$(MD_OUT)"

--- a/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/04.yml
+++ b/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/04.yml
@@ -52,7 +52,7 @@
     - ĉambro: hefi-trano
     - ','
     - kiam: raha
-    - estas: no 
+    - estas: "no"
     - malvarme: mangatsiaka
     - '?'
 -

--- a/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/07.yml
+++ b/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/07.yml
@@ -66,7 +66,7 @@
   demando: "Aiza ny rano nalainao ?"
   rektatraduko: 
     - Kie: Aiza
-    - estas: no
+    - estas: "no"
     - la: ny
     - akvo: rano
     - ',' 

--- a/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/09.yml
+++ b/enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/09.yml
@@ -34,7 +34,7 @@
     - ',' 
     - se: raha
     - vi: ianao / ianareo
-    - havus: no
+    - havus: "no"
     - sufiĉe: ampy
     - da: ny
     - mono: vola

--- a/fonto/py/generu.py
+++ b/fonto/py/generu.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import yaml
-from yaml.resolver import Resolver
 import glob
 import re
 import os
@@ -11,15 +10,10 @@ import argparse
 from . import html as html_generilo
 from . import md as md_generilo
 
-# remove resolver entries for On/Off/Yes/No
-# https://stackoverflow.com/a/36470466/52023
-for ch in "OoYyNn":
-    if len(Resolver.yaml_implicit_resolvers[ch]) == 1:
-        del Resolver.yaml_implicit_resolvers[ch]
-    else:
-        Resolver.yaml_implicit_resolvers[ch] = [x for x in
-                                                Resolver.yaml_implicit_resolvers[ch] if
-                                                x[0] != 'tag:yaml.org,2002:bool']
+
+def legi_yaml(path):
+    with open(path, encoding='utf-8-sig') as dosiero:
+        return yaml.safe_load(dosiero)
 
 
 def transpose_headlines(markdown, level):
@@ -52,7 +46,7 @@ def load(language, gramatiko_transpose_headlines=2):
         dirs, filename = os.path.split(path)
         root, extension = os.path.splitext(filename)
         vortspeco = root.replace('_', ' ')
-        vortlisto = yaml.load(open(path).read(), yaml.Loader)
+        vortlisto = legi_yaml(path)
         for esperante in vortlisto:
             fontlingve = vortlisto[esperante]
             vortlisto[esperante] = {
@@ -61,19 +55,18 @@ def load(language, gramatiko_transpose_headlines=2):
             }
         enhavo['vortaro'].update(vortlisto)
 
-    enhavo['finajxoj'] = yaml.load(open('enhavo/netradukenda/radikaj_finajxoj.yml').read(), yaml.Loader)
+    enhavo['finajxoj'] = legi_yaml('enhavo/netradukenda/radikaj_finajxoj.yml')
 
     enhavo['ordoj'] = {}
-    enhavo['ordoj']['cifero'] = yaml.load(open('enhavo/netradukenda/ordoj/cifero.yml'), yaml.Loader)
-    enhavo['ordoj']['monato'] = yaml.load(open('enhavo/netradukenda/ordoj/monato.yml'), yaml.Loader)
-    enhavo['ordoj']['sezono'] = yaml.load(open('enhavo/netradukenda/ordoj/sezono.yml'), yaml.Loader)
-    enhavo['ordoj']['tago_en_la_semajno'] = yaml.load(open('enhavo/netradukenda/ordoj/tago_en_la_semajno.yml'),
-                                                      yaml.Loader)
+    enhavo['ordoj']['cifero'] = legi_yaml('enhavo/netradukenda/ordoj/cifero.yml')
+    enhavo['ordoj']['monato'] = legi_yaml('enhavo/netradukenda/ordoj/monato.yml')
+    enhavo['ordoj']['sezono'] = legi_yaml('enhavo/netradukenda/ordoj/sezono.yml')
+    enhavo['ordoj']['tago_en_la_semajno'] = legi_yaml('enhavo/netradukenda/ordoj/tago_en_la_semajno.yml')
 
     enhavo['fasado'] = {}
     paths = glob.glob('enhavo/tradukenda/' + language + '/fasado/*.yml')
     for path in paths:
-        tradukajxoj = yaml.load(open(path).read(), yaml.Loader)
+        tradukajxoj = legi_yaml(path)
         enhavo['fasado'].update(tradukajxoj)
 
     path = 'enhavo/tradukenda/' + language + '/enkonduko.md'
@@ -102,7 +95,7 @@ def load(language, gramatiko_transpose_headlines=2):
         }
 
         path = 'enhavo/netradukenda/tekstoj/' + i_padded + '.yml'
-        leciono['teksto'] = yaml.load(open(path).read(), yaml.Loader)
+        leciono['teksto'] = legi_yaml(path)
 
         # Create a string of the lesson titles.
         titolo_string = ''
@@ -119,7 +112,7 @@ def load(language, gramatiko_transpose_headlines=2):
         leciono['vortoj']['pliaj'] = []
 
         path = 'enhavo/netradukenda/vortoj/' + i_padded + '.yml'
-        leciono['vortoj']['pliaj'] = yaml.load(open(path).read(), yaml.Loader)
+        leciono['vortoj']['pliaj'] = legi_yaml(path)
 
         for paragrafo in leciono['teksto']['paragrafoj']:
             for vorto in paragrafo:
@@ -144,13 +137,13 @@ def load(language, gramatiko_transpose_headlines=2):
         ekzercoj = {}
 
         path = 'enhavo/tradukenda/' + language + '/ekzercoj/traduku/' + i_padded + '.yml'
-        ekzercoj['Traduku'] = yaml.load(open(path), yaml.Loader)
+        ekzercoj['Traduku'] = legi_yaml(path)
 
         path = 'enhavo/tradukenda/' + language + '/ekzercoj/traduku-kaj-respondu/' + i_padded + '.yml'
-        ekzercoj['Traduku kaj respondu'] = yaml.load(open(path), yaml.Loader)
+        ekzercoj['Traduku kaj respondu'] = legi_yaml(path)
 
         path = 'enhavo/netradukenda/ekzercoj/kompletigu-la-frazojn/' + i_padded + '.yml'
-        ekzercoj['Kompletigu la frazojn'] = yaml.load(open(path), yaml.Loader)
+        ekzercoj['Kompletigu la frazojn'] = legi_yaml(path)
 
         # Covert from dict to list.
         leciono['ekzercoj'] = ekzercoj
@@ -210,7 +203,7 @@ def get_cmdline_arguments():
 
 def main():
     args = get_cmdline_arguments()
-    lingvoj = yaml.load(open('agordoj/lingvoj.yml').read(), yaml.Loader)
+    lingvoj = legi_yaml('agordoj/lingvoj.yml')
     if args.eligformo == 'html':
         # if args.lingvo not in lingvoj.keys():
         #    sys.exit("'" + args.lingvo + "' ne estas havebla lingvokodo.")

--- a/fonto/py/kontrolu_yaml.py
+++ b/fonto/py/kontrolu_yaml.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import yaml
+from yaml.constructor import ConstructorError
+
+from .generu import legi_yaml
+
+
+def fail(message):
+    raise SystemExit('YAML-kontrolo malsukcesis: ' + message)
+
+
+def require(condition, message):
+    if not condition:
+        fail(message)
+
+
+def collect_values(data, key):
+    if isinstance(data, dict):
+        for item_key, value in data.items():
+            if item_key == key:
+                yield value
+            yield from collect_values(value, key)
+    elif isinstance(data, list):
+        for item in data:
+            yield from collect_values(item, key)
+
+
+def check_safe_load_blocks_python_tags():
+    try:
+        yaml.safe_load('x: !!python/name:os.system\n')
+    except ConstructorError:
+        return
+    fail('yaml.safe_load akceptis Python-specifan YAML-etikedon')
+
+
+def check_bool_like_scalars():
+    data = yaml.safe_load(
+        'yes_value: yes\n'
+        'no_value: no\n'
+        'on_value: on\n'
+        'off_value: off\n'
+        'true_value: true\n'
+        'false_value: false\n'
+        'quoted_no: "no"\n'
+    )
+    require(data['yes_value'] is True, 'unquoted yes ne fariĝis True')
+    require(data['no_value'] is False, 'unquoted no ne fariĝis False')
+    require(data['on_value'] is True, 'unquoted on ne fariĝis True')
+    require(data['off_value'] is False, 'unquoted off ne fariĝis False')
+    require(data['true_value'] is True, 'unquoted true ne fariĝis True')
+    require(data['false_value'] is False, 'unquoted false ne fariĝis False')
+    require(data['quoted_no'] == 'no', 'quoted "no" ne restis teksto')
+
+
+def check_malagasy_no_values():
+    checks = [
+        ('enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/04.yml', 'estas'),
+        ('enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/07.yml', 'estas'),
+        ('enhavo/tradukenda/mg/ekzercoj/traduku-kaj-respondu/09.yml', 'havus'),
+    ]
+    for path, key in checks:
+        values = list(collect_values(legi_yaml(path), key))
+        require('no' in values, path + ' ne enhavas tekstan "no" por ' + key)
+        require(False not in values, path + ' ankoraŭ enhavas bulean False por ' + key)
+
+
+def main():
+    check_safe_load_blocks_python_tags()
+    check_bool_like_scalars()
+    check_malagasy_no_values()
+    print('Sukcesis: kontrolis sekuran YAML-legadon')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Resumo
- Forigas la projektspecifan YAML-bulean Resolver-mutacion.
- Uzas yaml.safe_load por ĉiuj generatoraj YAML-legoj.
- Citas tri madagaskarajn no-valorojn, kiuj devas resti tekstoj.
- Aldonas YAML-sekurecan kontrolon al make check.

## Kontroloj
- venv/bin/python -m fonto.py.kontrolu_yaml
- make check
- make html LINGVO=mg
- make html LINGVO=en
- make html-all
- git diff --check
- rg "yaml\\.load|yaml\\.Loader|yaml\\.resolver|Resolver" fonto/py