### PR TITLE
Plirapidigu kaj purigu Python-generilojn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,7 @@ html:
 	@"$(PYTHON)" -m fonto.py.generu --lingvo "$(LINGVO)" --eligformo html
 
 html-all:
-	@set -e; for lingvo in $(HTML_LINGVOJ); do \
-		printf 'Generas HTML por %s\n' "$$lingvo"; \
-		"$(PYTHON)" -m fonto.py.generu --lingvo "$$lingvo" --eligformo html; \
-	done
+	@"$(PYTHON)" -m fonto.py.generu --lingvoj $(HTML_LINGVOJ) --eligformo html
 
 md:
 	@"$(PYTHON)" -m fonto.py.generu --lingvo "$(LINGVO)" --eligformo md

--- a/fonto/py/generu.py
+++ b/fonto/py/generu.py
@@ -2,50 +2,52 @@
 # -*- coding: utf-8 -*-
 
 import yaml
-import glob
 import re
-import os
 import argparse
+from pathlib import Path
 
 from . import html as html_generilo
 from . import md as md_generilo
 
 
+ROOT_DIR = Path(__file__).resolve().parents[2]
+AGORDOJ_DIR = ROOT_DIR / 'agordoj'
+ENHAVO_DIR = ROOT_DIR / 'enhavo'
+LECION_NUMEROJ = range(1, 13)
+YAML_LOADER = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+
+
 def legi_yaml(path):
-    with open(path, encoding='utf-8-sig') as dosiero:
-        return yaml.safe_load(dosiero)
+    with Path(path).open(encoding='utf-8-sig') as dosiero:
+        return yaml.load(dosiero, Loader=YAML_LOADER)
+
+
+def legi_tekston(path):
+    return Path(path).read_text(encoding='utf-8-sig')
 
 
 def transpose_headlines(markdown, level):
-    prefix = ''
-    for i in range(level):
-        prefix += '#'
-    markdown = re.sub(r'^#', '#' + prefix, markdown)
-    markdown = re.sub(r'\n#', '\n#' + prefix, markdown)
-    return markdown
+    prefix = '#' * level
+    return re.sub(r'(^|\n)(#+)', lambda match: match.group(1) + prefix + match.group(2), markdown)
 
 
 def get_markdown_headlines(s):
-    headlines = []
-    for match in re.finditer(r'(^|\n)# (.+)\n', s):
-        headlines.append(match.group(2).strip())
-
-    return headlines
+    return [match.group(2).strip() for match in re.finditer(r'(^|\n)# (.+)\n', s)]
 
 
 def load(language, gramatiko_transpose_headlines=2):
     enhavo = {'lingvo': language, 'vortaro': {}}
 
-    paths = glob.glob('enhavo/tradukenda/' + language + '/vortaro/*.yml')
+    tradukenda_dir = ENHAVO_DIR / 'tradukenda' / language
+    netradukenda_dir = ENHAVO_DIR / 'netradukenda'
+    paths = sorted((tradukenda_dir / 'vortaro').glob('*.yml'))
     # Provo solvi
     # https://github.com/Esperanto/kurso-zagreba-metodo/issues/36
     # sed kauzas aliajn problemojn.
     # paths.append('enhavo/tradukenda/en/vortaro/vorto.yml')
     # print(paths)
     for path in paths:
-        dirs, filename = os.path.split(path)
-        root, extension = os.path.splitext(filename)
-        vortspeco = root.replace('_', ' ')
+        vortspeco = path.stem.replace('_', ' ')
         vortlisto = legi_yaml(path)
         for esperante in vortlisto:
             fontlingve = vortlisto[esperante]
@@ -55,33 +57,33 @@ def load(language, gramatiko_transpose_headlines=2):
             }
         enhavo['vortaro'].update(vortlisto)
 
-    enhavo['finajxoj'] = legi_yaml('enhavo/netradukenda/radikaj_finajxoj.yml')
+    enhavo['finajxoj'] = legi_yaml(netradukenda_dir / 'radikaj_finajxoj.yml')
 
     enhavo['ordoj'] = {}
-    enhavo['ordoj']['cifero'] = legi_yaml('enhavo/netradukenda/ordoj/cifero.yml')
-    enhavo['ordoj']['monato'] = legi_yaml('enhavo/netradukenda/ordoj/monato.yml')
-    enhavo['ordoj']['sezono'] = legi_yaml('enhavo/netradukenda/ordoj/sezono.yml')
-    enhavo['ordoj']['tago_en_la_semajno'] = legi_yaml('enhavo/netradukenda/ordoj/tago_en_la_semajno.yml')
+    ordoj_dir = netradukenda_dir / 'ordoj'
+    enhavo['ordoj']['cifero'] = legi_yaml(ordoj_dir / 'cifero.yml')
+    enhavo['ordoj']['monato'] = legi_yaml(ordoj_dir / 'monato.yml')
+    enhavo['ordoj']['sezono'] = legi_yaml(ordoj_dir / 'sezono.yml')
+    enhavo['ordoj']['tago_en_la_semajno'] = legi_yaml(ordoj_dir / 'tago_en_la_semajno.yml')
 
     enhavo['fasado'] = {}
-    paths = glob.glob('enhavo/tradukenda/' + language + '/fasado/*.yml')
-    for path in paths:
+    for path in sorted((tradukenda_dir / 'fasado').glob('*.yml')):
         tradukajxoj = legi_yaml(path)
         enhavo['fasado'].update(tradukajxoj)
 
-    path = 'enhavo/tradukenda/' + language + '/enkonduko.md'
-    enkonduko = open(path).read()
+    path = tradukenda_dir / 'enkonduko.md'
+    enkonduko = legi_tekston(path)
     # enkonduko = transpose_headlines(enkonduko, 1)
     enhavo['enkonduko'] = enkonduko
 
-    path = 'enhavo/tradukenda/' + language + '/post.md'
-    enhavo['post'] = open(path).read()
+    path = tradukenda_dir / 'post.md'
+    enhavo['post'] = legi_tekston(path)
     enhavo['post'] = transpose_headlines(enhavo['post'], 2)
 
     lecionoj = []
-    vortoj = {}
+    vortoj = set()
 
-    for i in range(1, 13):
+    for i in LECION_NUMEROJ:
         leciono = {
             'teksto': None,
             'gramatiko': None,
@@ -94,37 +96,33 @@ def load(language, gramatiko_transpose_headlines=2):
             'cxene': i_padded
         }
 
-        path = 'enhavo/netradukenda/tekstoj/' + i_padded + '.yml'
+        path = netradukenda_dir / 'tekstoj' / (i_padded + '.yml')
         leciono['teksto'] = legi_yaml(path)
 
-        # Create a string of the lesson titles.
-        titolo_string = ''
-        for radikoj in leciono['teksto']['titolo']:
-            if radikoj:
-                titolo_string += ''.join(radikoj)
-            else:
-                titolo_string += ' '
-
-        leciono['teksto']['titolo_string'] = titolo_string
+        leciono['teksto']['titolo_string'] = ''.join(
+            ''.join(radikoj) if radikoj else ' '
+            for radikoj in leciono['teksto']['titolo']
+        )
 
         leciono['vortoj'] = {}
         leciono['vortoj']['teksto'] = []
         leciono['vortoj']['pliaj'] = []
 
-        path = 'enhavo/netradukenda/vortoj/' + i_padded + '.yml'
+        path = netradukenda_dir / 'vortoj' / (i_padded + '.yml')
         leciono['vortoj']['pliaj'] = legi_yaml(path)
 
         for paragrafo in leciono['teksto']['paragrafoj']:
             for vorto in paragrafo:
-                if type(vorto) is list:
+                if isinstance(vorto, list):
                     for radiko in vorto:
-                        if not radiko.lower() in vortoj:
+                        radiko_lower = radiko.lower()
+                        if radiko_lower not in vortoj:
                             leciono['vortoj']['teksto'].append(radiko)
-                            vortoj[radiko.lower()] = True
+                            vortoj.add(radiko_lower)
 
-        path = 'enhavo/tradukenda/' + language + '/gramatiko/' + i_padded + '.md'
+        path = tradukenda_dir / 'gramatiko' / (i_padded + '.md')
 
-        gramatiko_teksto = open(path).read()
+        gramatiko_teksto = legi_tekston(path)
         gramatiko_titoloj = get_markdown_headlines(gramatiko_teksto)
         gramatiko_teksto = transpose_headlines(gramatiko_teksto, gramatiko_transpose_headlines)
 
@@ -136,16 +134,15 @@ def load(language, gramatiko_transpose_headlines=2):
 
         ekzercoj = {}
 
-        path = 'enhavo/tradukenda/' + language + '/ekzercoj/traduku/' + i_padded + '.yml'
+        path = tradukenda_dir / 'ekzercoj' / 'traduku' / (i_padded + '.yml')
         ekzercoj['Traduku'] = legi_yaml(path)
 
-        path = 'enhavo/tradukenda/' + language + '/ekzercoj/traduku-kaj-respondu/' + i_padded + '.yml'
+        path = tradukenda_dir / 'ekzercoj' / 'traduku-kaj-respondu' / (i_padded + '.yml')
         ekzercoj['Traduku kaj respondu'] = legi_yaml(path)
 
-        path = 'enhavo/netradukenda/ekzercoj/kompletigu-la-frazojn/' + i_padded + '.yml'
+        path = netradukenda_dir / 'ekzercoj' / 'kompletigu-la-frazojn' / (i_padded + '.yml')
         ekzercoj['Kompletigu la frazojn'] = legi_yaml(path)
 
-        # Covert from dict to list.
         leciono['ekzercoj'] = ekzercoj
 
         lecionoj.append(leciono)
@@ -157,12 +154,17 @@ def load(language, gramatiko_transpose_headlines=2):
 
 def get_cmdline_arguments():
     ap = argparse.ArgumentParser()
-    ap.add_argument(
+    lingvo_group = ap.add_mutually_exclusive_group(required=True)
+    lingvo_group.add_argument(
         "-l",
         "--lingvo",
         help="Kreu eligon por tiu lingvo.",
-        type=str,
-        required=True
+        type=str
+    )
+    lingvo_group.add_argument(
+        "--lingvoj",
+        help="Kreu HTML-eligon por pluraj lingvoj per unu Python-procezo.",
+        nargs='+'
     )
     ap.add_argument(
         "-ef",
@@ -197,24 +199,37 @@ def get_cmdline_arguments():
         type=str
     )
     args = ap.parse_args()
+    if args.eligformo == 'md' and args.lingvoj:
+        ap.error('--lingvoj estas uzebla nur kun --eligformo html')
 
     return args
 
 
+def kompletigu_enhavon(lingvo, lingvoj, gramatiko_transpose_headlines=2):
+    enhavo = load(lingvo, gramatiko_transpose_headlines)
+    enhavo['lingvoj'] = lingvoj
+    enhavo['tekstodirekto'] = lingvoj[lingvo].get('tekstodirekto', 'ltr')
+    return enhavo
+
+
+def generu_html_por_lingvoj(args, lingvoj):
+    por_generi = args.lingvoj or [args.lingvo]
+    for index, lingvo in enumerate(por_generi):
+        if args.lingvoj:
+            print('Generas HTML por ' + lingvo, flush=True)
+        enhavo = kompletigu_enhavon(lingvo, lingvoj)
+        html_generilo.generate_html(lingvo, enhavo, args, kopiu_statikan=(index == 0))
+
+
 def main():
     args = get_cmdline_arguments()
-    lingvoj = legi_yaml('agordoj/lingvoj.yml')
+    lingvoj = legi_yaml(AGORDOJ_DIR / 'lingvoj.yml')
     if args.eligformo == 'html':
         # if args.lingvo not in lingvoj.keys():
         #    sys.exit("'" + args.lingvo + "' ne estas havebla lingvokodo.")
-        enhavo = load(args.lingvo)
-        enhavo['lingvoj'] = lingvoj
-        enhavo['tekstodirekto'] = lingvoj[args.lingvo].get('tekstodirekto', 'ltr')
-        html_generilo.generate_html(args.lingvo, enhavo, args)
+        generu_html_por_lingvoj(args, lingvoj)
     if args.eligformo == 'md':
-        enhavo = load(args.lingvo, 3)
-        enhavo['lingvoj'] = lingvoj
-        enhavo['tekstodirekto'] = lingvoj[args.lingvo].get('tekstodirekto', 'ltr')
+        enhavo = kompletigu_enhavon(args.lingvo, lingvoj, 3)
         md_generilo.kreu_md(enhavo, printendaj={'partoj': args.printendaj_partoj,
                                                 'lecionoj': args.printendaj_lecionoj})
 

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -3,7 +3,6 @@
 
 import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 
@@ -28,11 +27,9 @@ def render_page(name, enhavo, vojprefikso, env):
 
 
 def write_file(filename, content):
-    dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
-    with open(filename, 'w') as f:
-        f.write(content)
+    path = Path(filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding='utf-8')
 
 
 def get_version_hash():
@@ -120,17 +117,16 @@ def create_anki(enhavo):
         'Learn Esperanto: ' + enhavo['lingvo']
     )
 
-    aldonitaj = []
+    aldonitaj = set()
 
     # Unue aldonu laux lecionoj.
-    for leciono_index_0 in range(len(enhavo['lecionoj'])):
-        leciono = enhavo['lecionoj'][leciono_index_0]
+    for leciono_index_0, leciono in enumerate(enhavo['lecionoj']):
         for radiko in leciono['vortoj']['teksto']:
             if radiko.lower() in enhavo['vortaro']:
                 radiko = radiko.lower()
-            leciono = str(leciono_index_0 + 1)
-            aldonu_karton(deck, model, enhavo, radiko, leciono)
-            aldonitaj.append(radiko)
+            leciono_numero = str(leciono_index_0 + 1)
+            aldonu_karton(deck, model, enhavo, radiko, leciono_numero)
+            aldonitaj.add(radiko)
 
     # Nun aldonu la reston.
     for radiko in enhavo['vortaro']:
@@ -142,7 +138,7 @@ def create_anki(enhavo):
 
 
 def render_cxefpagxo(versio):
-    env = jinja2.Environment()
+    env = jinja2.Environment(auto_reload=False)
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))
     return env.get_template('cxefpagxo.html').render(versio=versio)
 
@@ -168,20 +164,21 @@ def copy_static_files(versio):
         shutil.copytree(fonto, celo)
 
 
-def generate_html(lingvo, enhavo, args):
+def generate_html(lingvo, enhavo, args, kopiu_statikan=True):
     eligo = {}
     md = mistune.create_markdown()
     versio = get_version_hash()
     enhavo['versio'] = versio
-    copy_static_files(versio)
+    if kopiu_statikan:
+        copy_static_files(versio)
 
-    env = jinja2.Environment()
+    env = jinja2.Environment(auto_reload=False)
     env.filters['markdown'] = lambda text: Markup(md(text))
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))
 
-    output_path = os.path.join(str(OUTPUT_DIR), lingvo, '')
+    output_path = OUTPUT_DIR / lingvo
 
     tabs = [
         ('teksto', '', enhavo['fasado']['Teksto']),
@@ -203,18 +200,18 @@ def generate_html(lingvo, enhavo, args):
         tabs=tabs,
     )
 
-    eligo[output_path + 'index.html'] = rendered
+    eligo[output_path / 'index.html'] = rendered
 
     # vortaro.js
     rendered = env.get_template('vortlisto.js').render(
         enhavo=enhavo,
     )
-    eligo[output_path + 'js/vortlisto.js'] = rendered
+    eligo[output_path / 'js' / 'vortlisto.js'] = rendered
 
-    eligo[output_path + 'eksporto/' + enhavo['lingvo'] + '.apkg'] = create_anki(enhavo)
+    eligo[output_path / 'eksporto' / (enhavo['lingvo'] + '.apkg')] = create_anki(enhavo)
 
     for tab_page in ['tabelvortoj', 'prepozicioj', 'konjunkcioj', 'afiksoj', 'diversajxoj', 'auxtoroj', 'post']:
-        eligo[output_path + tab_page + '/index.html'] = render_page(tab_page, enhavo, vojprefikso, env)
+        eligo[output_path / tab_page / 'index.html'] = render_page(tab_page, enhavo, vojprefikso, env)
 
     paths = []
     for i in range(1, 13):
@@ -225,7 +222,7 @@ def generate_html(lingvo, enhavo, args):
 
     for i in range(1, 13):
         i_padded = str(i).zfill(2)
-        leciono_dir = output_path + i_padded
+        leciono_dir = output_path / i_padded
 
         for tab, href, caption in tabs:
 
@@ -253,15 +250,15 @@ def generate_html(lingvo, enhavo, args):
                 identigilo=i_padded + '/' + href
             )
 
-            eligo[leciono_dir + '/' + href + '/' + '/index.html'] = tab_rendered
+            eligo[leciono_dir / href / 'index.html'] = tab_rendered
 
     # Forigu nunan dosierujon.
     shutil.rmtree(output_path, ignore_errors=True)
 
     # Kreu novajn dosierojn
-    for vojo in eligo.keys():
-        if re.search(r'\.apkg$', vojo):
-            write_file(vojo, '')
-            genanki.Package(eligo[vojo]).write_to_file(vojo)
+    for vojo, eliga_enhavo in eligo.items():
+        if vojo.suffix == '.apkg':
+            vojo.parent.mkdir(parents=True, exist_ok=True)
+            genanki.Package(eliga_enhavo).write_to_file(str(vojo))
             continue
-        write_file(vojo, eligo[vojo])
+        write_file(vojo, eliga_enhavo)

--- a/fonto/py/kontrolu_yaml.py
+++ b/fonto/py/kontrolu_yaml.py
@@ -3,7 +3,7 @@
 import yaml
 from yaml.constructor import ConstructorError
 
-from .generu import legi_yaml
+from .generu import legi_yaml, YAML_LOADER
 
 
 def fail(message):
@@ -26,23 +26,26 @@ def collect_values(data, key):
             yield from collect_values(item, key)
 
 
-def check_safe_load_blocks_python_tags():
+def check_safe_yaml_loader_blocks_python_tags():
     try:
-        yaml.safe_load('x: !!python/name:os.system\n')
+        yaml.load('x: !!python/name:os.system\n', Loader=YAML_LOADER)
     except ConstructorError:
         return
-    fail('yaml.safe_load akceptis Python-specifan YAML-etikedon')
+    fail('la sekura YAML-loader akceptis Python-specifan YAML-etikedon')
 
 
 def check_bool_like_scalars():
-    data = yaml.safe_load(
-        'yes_value: yes\n'
-        'no_value: no\n'
-        'on_value: on\n'
-        'off_value: off\n'
-        'true_value: true\n'
-        'false_value: false\n'
-        'quoted_no: "no"\n'
+    data = yaml.load(
+        (
+            'yes_value: yes\n'
+            'no_value: no\n'
+            'on_value: on\n'
+            'off_value: off\n'
+            'true_value: true\n'
+            'false_value: false\n'
+            'quoted_no: "no"\n'
+        ),
+        Loader=YAML_LOADER
     )
     require(data['yes_value'] is True, 'unquoted yes ne fariĝis True')
     require(data['no_value'] is False, 'unquoted no ne fariĝis False')
@@ -66,7 +69,7 @@ def check_malagasy_no_values():
 
 
 def main():
-    check_safe_load_blocks_python_tags()
+    check_safe_yaml_loader_blocks_python_tags()
     check_bool_like_scalars()
     check_malagasy_no_values()
     print('Sukcesis: kontrolis sekuran YAML-legadon')

--- a/fonto/py/md.py
+++ b/fonto/py/md.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import re
+from pathlib import Path
 
 import jinja2
 import mistune
 from markupsafe import Markup
 
 
+FONTO_DIR = Path(__file__).resolve().parents[1]
+
+
 def kreu_md(enhavo, printendaj):
     md = mistune.create_markdown()
 
-    env = jinja2.Environment()
+    env = jinja2.Environment(auto_reload=False)
     env.filters['markdown'] = lambda text: Markup(md(text))
     env.trim_blocks = True
     env.lstrip_blocks = True
-    env.loader = jinja2.FileSystemLoader('fonto/md/')
+    env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'md'))
 
     # Ŝanĝu __ al **, ĉar nur tio Pandoc ŝajne komprenas.
-    for i in range(len(enhavo['lecionoj'])):
-        enhavo['lecionoj'][i]['gramatiko']['teksto'] = re.sub('__', '**', enhavo['lecionoj'][i]['gramatiko']['teksto'])
+    for leciono in enhavo['lecionoj']:
+        leciono['gramatiko']['teksto'] = leciono['gramatiko']['teksto'].replace('__', '**')
 
     rendered = env.get_template('arangxo.md').render(enhavo=enhavo, printendaj=printendaj)
     print(rendered)


### PR DESCRIPTION
## Resumo
- Rulas make html-all per unu Python-procezo por ĉiuj lingvoj.
- Uzas sekuran C-YAML-loader kiam disponebla.
- Malŝaltas nenecesan Jinja-template-reŝargadon.
- Purigas vojojn, loopojn kaj APKG-skribadon.

## Kontroloj
- venv/bin/python -m compileall -q fonto/py
- venv/bin/python -m fonto.py.kontrolu_yaml
- make check
- /usr/bin/time -p make html LINGVO=en
- /usr/bin/time -p make html-all
- git diff --check