### PR TITLE
Ne proponu PWA-on en HTML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ make html LINGVO=en
 
 Tio skribas al `eligo/retejo/en`.
 
-`make html` kaj `make html-all` kreas ankaŭ PWA-dosierojn (`manifest.webmanifest`, `pwa/registru.js`, `pwa/images/` kaj `sw.js`). La service worker estas generita el la efektivaj dosieroj en `eligo/retejo`; ne redaktu `eligo/retejo/sw.js` permane. Post `make html-all`, rulu `make check-pwa` por certigi, ke ĉiuj produktadaj lingvoj kaj ĉiuj generitaj lokaj dosieroj estas en la offline-precache-listo.
+`make html` kaj `make html-all` kreas ankaŭ PWA-dosierojn (`manifest.webmanifest`, `pwa/registru.js`, `pwa/images/` kaj `sw.js`). Tiuj dosieroj estas provizore ne ligitaj el la HTML, do la retejo nuntempe ne proponas instaleblan PWA-on al vizitantoj. Ne redaktu `eligo/retejo/sw.js` permane. Post `make html-all`, rulu `make check-pwa` por kontroli la nepublike proponatan PWA-eligon.
 
 Por antaŭrigardi jam generitan HTML-on loke, rulu:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Por generi la tutan produktadan HTML-eligon:
 
     make html-all
 
-Tio ankaŭ kreas PWA-manifeston, ikonojn, registrilon kaj radikan `sw.js`. La service worker antaŭkaŝmemorigas la tutan enhavon de `eligo/retejo`, tiel ke ĉiuj produktadaj lingvoj, sonoj, bildoj, vendor-dosieroj kaj Anki-eksportoj estu haveblaj offline post instalado/kaŝmemorigo.
+Tio ankaŭ kreas PWA-manifeston, ikonojn, registrilon kaj radikan `sw.js`. Tiuj dosieroj estas provizore ne ligitaj el la HTML, do la retejo nuntempe ne proponas instaleblan PWA-on al vizitantoj.
 
 Por kontroli, ke la PWA-manifesto validas kaj ke ĉiu generita dosiero troviĝas en la offline-listo:
 

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#198754">
-    <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="apple-touch-icon" href="/pwa/images/ecbc30ce-3901-d33d-412d-10551879846f.webPlatform.png">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>
   Esperanto in 12 Lessons
@@ -137,8 +134,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/0.11.1/typeahead.bundle.min.js"></script>
     -->
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
-
-    <script defer src="/pwa/registru.js"></script>
 
     <!-- Umami -->
     <!-- 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#198754">
-    <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="apple-touch-icon" href="/pwa/images/ecbc30ce-3901-d33d-412d-10551879846f.webPlatform.png">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>
 			{% block title %}
@@ -174,7 +171,6 @@
     <script src="{{vojprefikso}}../assets/js/main.js"></script>
     <script src="{{vojprefikso}}js/vortlisto.js"></script>
     <script src="{{vojprefikso}}../assets/js/vortaro.js"></script>
-    <script defer src="/pwa/registru.js"></script>
 
     <!-- Umami -->
     <!-- 

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -9,8 +9,6 @@ from pathlib import Path
 
 
 GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
-PWA_MANIFEST_PATTERN = re.compile(r'/manifest\.webmanifest')
-PWA_REGISTER_PATTERN = re.compile(r'/pwa/registru\.js')
 PWA_SERVICE_WORKER_PATTERN = re.compile(r'const PRECACHE_URLS = \[')
 
 
@@ -100,10 +98,6 @@ def main():
     ]:
         require_nonempty_file(path)
 
-    require_pattern(output_dir / 'index.html', PWA_MANIFEST_PATTERN)
-    require_pattern(output_dir / 'index.html', PWA_REGISTER_PATTERN)
-    require_pattern(lingvo_dir / 'index.html', PWA_MANIFEST_PATTERN)
-    require_pattern(lingvo_dir / 'index.html', PWA_REGISTER_PATTERN)
     require_pattern(output_dir / 'sw.js', PWA_SERVICE_WORKER_PATTERN)
     require_pattern(lingvo_dir / '01' / 'gramatiko' / 'index.html', GRAMATIKO_PATTERN)
     require_apkg(lingvo_dir / 'eksporto' / (lingvo + '.apkg'))

--- a/fonto/py/kontrolu_pwa.py
+++ b/fonto/py/kontrolu_pwa.py
@@ -62,14 +62,6 @@ def check_manifest(output_dir, precache_urls):
         require(src in precache_urls, 'ikono mankas en precache: ' + src)
 
 
-def check_html_links(output_dir):
-    for path in [output_dir / 'index.html', output_dir / 'en' / 'index.html']:
-        require_nonempty_file(path)
-        text = path.read_text(encoding='utf-8')
-        require('/manifest.webmanifest' in text, 'mankas manifest-ligilo en ' + str(path))
-        require('/pwa/registru.js' in text, 'mankas PWA-registrilo en ' + str(path))
-
-
 def check_precache_completeness(output_dir, precache_urls):
     expected_urls = set(pwa.collect_precache_urls(output_dir))
     missing = sorted(expected_urls - precache_urls)
@@ -111,7 +103,6 @@ def main():
     require('/pwa/registru.js' in precache_urls, 'registrilo mankas en precache')
 
     check_manifest(output_dir, precache_urls)
-    check_html_links(output_dir)
     check_languages(output_dir, args.lingvoj, precache_urls)
     check_precache_completeness(output_dir, precache_urls)
 


### PR DESCRIPTION
## Resumo
- Forigas manifest-, apple-touch-icon-, theme-color- kaj PWA-registrilajn referencojn el la HTML-ŝablonoj.
- Ĝisdatigas kontrolojn tiel ke ili ne plu postulas PWA-ligilojn en HTML.
- Klarigas en README kaj AGENTS, ke la PWA-dosieroj ankoraŭ povas esti generitaj sed provizore ne estas proponataj al vizitantoj.

## Kontroloj
- venv/bin/python -m compileall -q fonto/py
- make check
- make html-all
- make check-pwa
- rg -n manifest.webmanifest pwa/registru apple-touch-icon theme-color eligo/retejo --glob *.html
- git diff --check