### PR TITLE
Gxisdatigu npm-dependecojn por sekureco

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ check:
 	@test -x "$(PYTHON)" || { printf '%s\n' 'Mankas $(PYTHON). Rulu `make install` unue aŭ agordu VENV=/path/to/venv.' >&2; exit 1; }
 	@test -f "$(NODE_MODULES)/bootstrap/dist/css/bootstrap.min.css" \
 		&& test -f "$(NODE_MODULES)/jquery/dist/jquery.min.js" \
-		&& test -f "$(NODE_MODULES)/jquery-ui-bundle/jquery-ui.min.js" \
+		&& test -f "$(NODE_MODULES)/jquery-ui-dist/jquery-ui.min.js" \
 		&& test -f "$(NODE_MODULES)/typeahead.js/dist/typeahead.bundle.min.js" || { printf '%s\n' 'Mankas npm-dependecoj en $(NODE_MODULES). Rulu `make install` unue.' >&2; exit 1; }
 	@"$(PYTHON)" -c 'import yaml, jinja2, chevron, mistune, genanki'
 	@"$(PYTHON)" -m fonto.py.kontrolu_yaml

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -12,12 +12,7 @@
 		</title>
 
 
-    <!-- Bootstrap -->
-    <!-- Latest compiled and minified CSS -->
-    <!--
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
-    -->
-        <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="assets/css/main.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -115,32 +110,13 @@
     </div>
 
 
-    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<!--
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.3/jquery-ui.min.js"></script>
--->
-
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
-    <!-- Latest compiled and minified JavaScript -->
-    <!-- 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-    -->
     <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
 
-    <!-- Typeahead for Vortaro -->
-    <!-- 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/0.11.1/typeahead.bundle.min.js"></script>
-    -->
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
 
-    <!-- Umami -->
-    <!-- 
-		<script defer src="http://nabo.jaehnig.org:3000/script.js" data-website-id="d0293209-d2e6-4c27-93da-c15b47ab18aa"></script>
-    -->
-
-		<!-- 100% privacy-first analytics -->
+			<!-- 100% privacy-first analytics -->
     <script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
     <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"/></noscript>
     <script data-goatcounter="https://e12.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -15,7 +15,7 @@
     <!-- Bootstrap -->
     <!-- Latest compiled and minified CSS -->
     <!--
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">   
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     -->
         <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="assets/css/main.css" rel="stylesheet">
@@ -117,15 +117,15 @@
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 <!--
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.3/jquery-ui.min.js"></script>
 -->
 
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
     <!-- Latest compiled and minified JavaScript -->
     <!-- 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     -->
     <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -14,7 +14,7 @@
     <!-- Bootstrap -->
     <!-- Latest compiled and minified CSS -->
     <!--
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">   
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
     -->
         <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{vojprefikso}}../assets/css/main.css?v=2" rel="stylesheet">
@@ -150,15 +150,15 @@
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 <!--
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.3/jquery-ui.min.js"></script>
 -->
 
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
     <!-- Latest compiled and minified JavaScript -->
     <!-- 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     -->
     <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -11,12 +11,7 @@
 		</title>
 
 
-    <!-- Bootstrap -->
-    <!-- Latest compiled and minified CSS -->
-    <!--
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
-    -->
-        <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{vojprefikso}}../assets/css/main.css?v=2" rel="stylesheet">
     <link href="{{vojprefikso}}../assets/css/vortaro.css" rel="stylesheet">
 
@@ -148,36 +143,18 @@
     </div>
 
 
-    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<!--
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.3/jquery-ui.min.js"></script>
--->
-
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
-    <!-- Latest compiled and minified JavaScript -->
-    <!-- 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-    -->
     <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
 
-    <!-- Typeahead for Vortaro -->
-    <!-- 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/0.11.1/typeahead.bundle.min.js"></script>
-    -->
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
 
     <script src="{{vojprefikso}}../assets/js/main.js"></script>
     <script src="{{vojprefikso}}js/vortlisto.js"></script>
     <script src="{{vojprefikso}}../assets/js/vortaro.js"></script>
 
-    <!-- Umami -->
-    <!-- 
-		<script defer src="http://nabo.jaehnig.org:3000/script.js" data-website-id="d0293209-d2e6-4c27-93da-c15b47ab18aa"></script>
-    -->
-		<!-- 100% privacy-first analytics -->
-<script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+			<!-- 100% privacy-first analytics -->
+	<script async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
 <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"/></noscript>
 <script data-goatcounter="https://e12.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 

--- a/fonto/js/main.js
+++ b/fonto/js/main.js
@@ -1,9 +1,16 @@
 $(document).ready(function(){
+  var popoverWhiteList = $.extend(
+    {},
+    $.fn.tooltip.Constructor.DEFAULTS.whiteList,
+    { table: [], tbody: [], tr: [], td: [] }
+  );
+
   $('[data-toggle="tooltip"]').tooltip(); 
   $('[data-toggle="popover"]').popover({
     placement: 'bottom',
     trigger: 'hover',
-    html: true 
+    html: true,
+    whiteList: popoverWhiteList
   }); 
   $('.container table').addClass('table'); 
 });

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -185,7 +185,7 @@ def copy_static_files(versio):
             OUTPUT_DIR / 'vendor' / 'jquery' / 'jquery.min.js',
         ),
         (
-            NODE_MODULES_DIR / 'jquery-ui-bundle' / 'jquery-ui.min.js',
+            NODE_MODULES_DIR / 'jquery-ui-dist' / 'jquery-ui.min.js',
             OUTPUT_DIR / 'vendor' / 'jquery' / 'jquery-ui.min.js',
         ),
         (

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
 PWA_SERVICE_WORKER_PATTERN = re.compile(r'const PRECACHE_URLS = \[')
-BOOTSTRAP_PATTERN = re.compile(r'Bootstrap v3\.3\.6')
-JQUERY_PATTERN = re.compile(r'jQuery v1\.11\.3')
-JQUERY_UI_PATTERN = re.compile(r'jQuery UI - v1\.11\.4')
+BOOTSTRAP_PATTERN = re.compile(r'Bootstrap v3\.4\.1')
+JQUERY_PATTERN = re.compile(r'jQuery v3\.7\.1')
+JQUERY_UI_PATTERN = re.compile(r'jQuery UI - v1\.13\.3')
 TYPEAHEAD_PATTERN = re.compile(r'typeahead\.js 0\.11\.1')
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "name": "kurso-zagreba-metodo",
       "dependencies": {
-        "bootstrap": "3.3.6",
-        "jquery": "1.11.3",
-        "jquery-ui-bundle": "1.11.4",
+        "bootstrap": "3.4.1",
+        "jquery": "3.7.1",
+        "jquery-ui-dist": "1.13.3",
         "typeahead.js": "0.11.1"
       },
       "devDependencies": {
@@ -35,13 +35,13 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.6.tgz",
-      "integrity": "sha512-XC+LTYJoVYHIalmjNcznwlZHY+YLhMJ9NPs8M2aEweugK7wMrto3h79POn7O5Vj/woDU/tjzmjyUbAd1HzSXIw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
       "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.1"
+        "node": ">=6"
       }
     },
     "node_modules/fsevents": {
@@ -60,16 +60,19 @@
       }
     },
     "node_modules/jquery": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.11.3.tgz",
-      "integrity": "sha512-pHM/XLofp0FJc0/0AsRm8q/5ob+a1kno+vfclXGozaMBPv3qD7Xq19loECVcBB4MOLdygnyneQMPTsH5QiVNBQ==",
-      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes."
-    },
-    "node_modules/jquery-ui-bundle": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/jquery-ui-bundle/-/jquery-ui-bundle-1.11.4.tgz",
-      "integrity": "sha512-ihmTNIY3V2qvgtM4PPB2sg58fsojb37soOIjjHFNun4zLx7jZpsyjI8Lr7LJz/Mhk9MTBZLMF+lXFq2LRYi/Xg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
+    },
+    "node_modules/jquery-ui-dist": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.13.3.tgz",
+      "integrity": "sha512-qeTR3SOSQ0jgxaNXSFU6+JtxdzNUSJKgp8LCzVrVKntM25+2YBJW1Ea8B2AwjmmSHfPLy2dSlZxJQN06OfVFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": ">=1.8.0 <4.0.0"
+      }
     },
     "node_modules/playwright": {
       "version": "1.61.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "node": "24.14.1"
   },
   "dependencies": {
-    "bootstrap": "3.3.6",
-    "jquery": "1.11.3",
-    "jquery-ui-bundle": "1.11.4",
+    "bootstrap": "3.4.1",
+    "jquery": "3.7.1",
+    "jquery-ui-dist": "1.13.3",
     "typeahead.js": "0.11.1"
   },
   "devDependencies": {

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -14,7 +14,7 @@ test('vortaro montras tradukon dum tajpado', async ({ page }) => {
   await expect(suggestion).toBeVisible();
 });
 
-test('ŝvebi super teksta vorto montras tradukan ŝprucfenestron', async ({ page }) => {
+test('ŝvebi super tekstaj vortoj montras tradukajn ŝprucfenestrojn', async ({ page }) => {
   await page.goto('/en/01/');
 
   await page.getByRole('heading', { name: /1\.\s*Amiko Marko/ })
@@ -28,4 +28,14 @@ test('ŝvebi super teksta vorto montras tradukan ŝprucfenestron', async ({ page
   });
 
   await expect(popover).toBeVisible();
+
+  await page.getByRole('link', { name: 'estas' }).first().hover();
+
+  const verbPopover = page.locator('.popover').filter({
+    hasText: 'to be',
+  }).filter({
+    hasText: 'Verb in present tense',
+  });
+
+  await expect(verbPopover).toBeVisible();
 });


### PR DESCRIPTION
## Resumo
- ĝisdatigas Bootstrap de 3.3.6 al 3.4.1
- ĝisdatigas jQuery de 1.11.3 al 3.7.1
- anstataŭigas `jquery-ui-bundle` per `jquery-ui-dist` 1.13.3
- konservas Bootstrap-popover-enhavon per mallarĝa sanitizer-whitelist por la generitaj tabeloj

## Kontroloj
- `npm ci --ignore-scripts`
- `make check-ui`
- `make check`
- `git diff --check`
- `npm audit --json` nun restigas nur Bootstrap 3.4.1; plena audit-pureco bezonas rompan Bootstrap 5-migradon