### PR TITLE
Forigu malnovajn IE8-shimojn

### DIFF
--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -15,12 +15,6 @@
     <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="assets/css/main.css" rel="stylesheet">
 
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
   </head>
   <body>
 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -15,12 +15,6 @@
     <link href="{{vojprefikso}}../assets/css/main.css?v=2" rel="stylesheet">
     <link href="{{vojprefikso}}../assets/css/vortaro.css" rel="stylesheet">
 
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
   </head>
   <body>
 


### PR DESCRIPTION
## Resumo
- Forigas la malnovajn html5shiv/respond.js IE8-shimojn el la HTML-sxablonoj.
- Forigas la lastajn aktivajn referencojn al oss.maxcdn.com.

## Kontroloj
- make check
- git diff --check

## Noto
Aktivaj eksteraj sxargoj restas SimpleAnalytics kaj GoatCounter; Disqus restas dinamika en la komenteja sxablono.