### PR TITLE
Gxisdatigu Bootstrap por sekureco

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ lock-upgrade: pip-tools
 check:
 	@test -x "$(PYTHON)" || { printf '%s\n' 'Mankas $(PYTHON). Rulu `make install` unue aŭ agordu VENV=/path/to/venv.' >&2; exit 1; }
 	@test -f "$(NODE_MODULES)/bootstrap/dist/css/bootstrap.min.css" \
+		&& test -f "$(NODE_MODULES)/bootstrap/dist/js/bootstrap.bundle.min.js" \
 		&& test -f "$(NODE_MODULES)/jquery/dist/jquery.min.js" \
 		&& test -f "$(NODE_MODULES)/jquery-ui-dist/jquery-ui.min.js" \
 		&& test -f "$(NODE_MODULES)/typeahead.js/dist/typeahead.bundle.min.js" || { printf '%s\n' 'Mankas npm-dependecoj en $(NODE_MODULES). Rulu `make install` unue.' >&2; exit 1; }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -55,6 +55,43 @@ a[data-bs-toggle="popover"]:focus {
 }
 
 /* Ekzercoj */
+.form-group {
+  margin-bottom: 15px;
+}
+.form-horizontal .form-group {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+.form-horizontal .control-label {
+  font-weight: 700;
+  padding-top: 7px;
+}
+.form-horizontal .col-sm-10 {
+  position: relative;
+}
+.form-horizontal .feedback-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.form-inline .form-group {
+  display: inline-block;
+  margin-bottom: 0;
+  position: relative;
+  vertical-align: middle;
+}
+.form-inline .form-control {
+  display: inline-block;
+  width: auto;
+}
+.form-inline .feedback-icon {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+}
 .has-error input {
   background: #f0f0f0;
 }
@@ -72,6 +109,12 @@ a[data-bs-toggle="popover"]:focus {
 }
 .feedback-icon-remove {
   color: #dc3545;
+}
+
+@media (min-width: 576px) {
+  .form-horizontal .control-label {
+    text-align: right;
+  }
 }
 
 .fixed {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -4,11 +4,90 @@
   margin-left: auto;
   max-width: 960px;
   margin-bottom: 5em;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 body {
 	font-size: 18px;
 	line-height: 30px;
+}
+h1 {
+  font-size: 36px;
+  line-height: 1.1;
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
+h2 {
+  font-size: 30px;
+  line-height: 1.1;
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
+
+/* Bootstrap 5 is used for security; these rules preserve the former site layout. */
+.navbar {
+  margin-bottom: 20px;
+  min-height: 52px;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.navbar > .container-fluid {
+  min-height: 52px;
+  padding-left: 0;
+  padding-right: 0;
+}
+.navbar-brand {
+  align-items: center;
+  display: flex;
+  height: 52px;
+  padding: 15px;
+}
+.navbar-nav .nav-link {
+  color: #9d9d9d;
+  line-height: 20px;
+  padding: 15px;
+}
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+  color: #fff;
+}
+.navbar-form-bs3 {
+  margin: 8px 0 8px 22px;
+}
+.navbar-form-bs3 + .navbar-form-bs3 {
+  margin-left: 30px;
+}
+.navbar-form-bs3 .form-control,
+.navbar-form-bs3 .form-select {
+  height: 34px;
+  line-height: 1.42857143;
+  padding: 6px 12px;
+}
+.navbar-form-bs3 .form-control {
+  width: 177px;
+}
+.navbar-form-bs3 .form-select {
+  width: 193px;
+}
+.row > * {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.btn-outline-secondary {
+  background-color: #fff;
+  border-color: #ccc;
+  border-radius: 4px;
+  color: #333;
+  font-size: 14px;
+  line-height: 1.42857143;
+  padding: 6px 12px;
+}
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus {
+  background-color: #e6e6e6;
+  border-color: #adadad;
+  color: #333;
 }
 
 /* popover */
@@ -73,10 +152,15 @@ body {
 	padding: 0.2em;
 }
 .jumbotron {
-  background: #f8f9fa;
-  border-radius: 0.5rem;
-  margin-top: 2rem;
-  padding: 2rem;
+  background: #eee;
+  border-radius: 6px;
+  margin-bottom: 30px;
+  padding: 48px 60px;
+}
+.jumbotron h1 {
+  font-size: 63px;
+  line-height: 1.1;
+  margin-top: 20px;
 }
 
 #eksporto {
@@ -94,10 +178,34 @@ img.leciona {
 ul.pager {
   clear: both;
 	padding-top: 1em;
-  display: flex;
-  justify-content: space-between;
   list-style: none;
+  margin: 20px 0;
   padding-left: 0;
+  text-align: center;
+}
+ul.pager:before,
+ul.pager:after {
+  content: " ";
+  display: table;
+}
+ul.pager:after {
+  clear: both;
+}
+ul.pager li {
+  display: inline;
+}
+ul.pager li > a {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 15px;
+  display: inline-block;
+  padding: 5px 14px;
+}
+ul.pager .next > a {
+  float: right;
+}
+ul.pager .previous > a {
+  float: left;
 }
 .well {
   background: #f8f9fa;
@@ -105,10 +213,30 @@ ul.pager {
   border-radius: 0.375rem;
   padding: 0.75rem;
 }
+.well-sm {
+  border-radius: 3px;
+  padding: 9px;
+}
 .ad {
   text-align: center;
 	font-size: smaller;
 	border-radius: 0.5em;
 	padding: 0.5em;
-	background: #eee;
+  background: #eee;
+}
+
+@media (max-width: 767px) {
+  .navbar-form-bs3 {
+    margin: 8px 15px;
+  }
+  .navbar-form-bs3 .form-control,
+  .navbar-form-bs3 .form-select {
+    width: 100%;
+  }
+  .jumbotron {
+    padding: 30px 15px;
+  }
+  .jumbotron h1 {
+    font-size: 36px;
+  }
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -1,7 +1,7 @@
 /* set a max-width for horizontal fluid layout and make it centered */
 :root {
-  --bs-link-color: #337ab7;
-  --bs-link-hover-color: #23527c;
+  --bs-link-color-rgb: 51, 122, 183;
+  --bs-link-hover-color-rgb: 35, 82, 124;
 }
 
 .container {
@@ -16,13 +16,6 @@
 body {
 	font-size: 18px;
 	line-height: 30px;
-}
-a {
-  color: #337ab7;
-}
-a:hover,
-a:focus {
-  color: #23527c;
 }
 h1 {
   margin-bottom: 10px;
@@ -49,35 +42,16 @@ h3 {
 }
 
 @media (max-width: 991.98px) {
-  .navbar-collapse {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
-  }
-  .navbar .nav-link {
-    padding: 10px 15px;
-  }
-  .navbar .nav-link.show {
-    background-color: #080808;
-    color: #fff;
-  }
   .navbar .dropdown-menu {
-    background-color: #222;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-    margin: 0;
-    padding: 5px 0 15px;
-    position: static;
-    width: 100%;
+    --bs-dropdown-bg: #222;
+    --bs-dropdown-border-width: 0;
+    --bs-dropdown-link-color: rgba(255, 255, 255, 0.6);
+    --bs-dropdown-link-hover-bg: #222;
+    --bs-dropdown-link-hover-color: #fff;
+    --bs-dropdown-min-width: 100%;
   }
   .navbar .dropdown-item {
-    color: rgba(255, 255, 255, 0.6);
-    padding: 6px 30px;
     white-space: normal;
-  }
-  .navbar .dropdown-item:hover,
-  .navbar .dropdown-item:focus {
-    background-color: #222;
-    color: #fff;
   }
 }
 
@@ -93,8 +67,6 @@ h3 {
 }
 
 /* popover */
-.popover-title,
-.popover-content,
 .popover-header,
 .popover-body {
 	font-size: 18px;
@@ -103,27 +75,20 @@ h3 {
   line-height: 1.42857143;
   margin: 0;
 }
-.popover-content table,
 .popover-body table {
     border-spacing: 0.5em;
     border-collapse: separate;    
 }
-.popover-content table tr,
 .popover-body table tr {
   vertical-align: top;
   text-align: left;
 }
-.popover-content table td:first-child,
 .popover-body table td:first-child {
   text-align: right;
 }
-a[data-bs-toggle="popover"] {
-  color: #337ab7;
-  text-decoration: none;
-}
+a[data-bs-toggle="popover"],
 a[data-bs-toggle="popover"]:hover,
 a[data-bs-toggle="popover"]:focus {
-  color: #23527c;
   text-decoration: none;
 }
 
@@ -216,28 +181,16 @@ ol.tasko {
 	padding: 0;
 }
 
-.jumbotron ul {
+.lingvolisto {
 	margin: 0;
 	margin-top: 2em;
   padding: 0;
   list-style-type: none;
 }
-.jumbotron li {
+.lingvolisto li {
 	display: inline-block;
 	padding: 0.2em;
 }
-.jumbotron {
-  background: #eee;
-  border-radius: 6px;
-  margin-bottom: 30px;
-  padding: 48px 60px;
-}
-.jumbotron h1 {
-  font-size: 63px;
-  line-height: 1.1;
-  margin-top: 20px;
-}
-
 #eksporto {
 	float: right;
   margin-top: 1em;
@@ -252,45 +205,8 @@ img.leciona {
 }
 ul.pager {
   clear: both;
-	padding-top: 1em;
-  list-style: none;
   margin: 20px 0;
-  padding-left: 0;
-  text-align: center;
-}
-ul.pager:before,
-ul.pager:after {
-  content: " ";
-  display: table;
-}
-ul.pager:after {
-  clear: both;
-}
-ul.pager li {
-  display: inline;
-}
-ul.pager li > a {
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 15px;
-  display: inline-block;
-  padding: 5px 14px;
-}
-ul.pager .next > a {
-  float: right;
-}
-ul.pager .previous > a {
-  float: left;
-}
-.well {
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
-  border-radius: 0.375rem;
-  padding: 0.75rem;
-}
-.well-sm {
-  border-radius: 3px;
-  padding: 9px;
+	padding-top: 1em;
 }
 .ad {
   text-align: center;
@@ -298,13 +214,4 @@ ul.pager .previous > a {
 	border-radius: 0.5em;
 	padding: 0.5em;
   background: #eee;
-}
-
-@media (max-width: 767px) {
-  .jumbotron {
-    padding: 30px 15px;
-  }
-  .jumbotron h1 {
-    font-size: 36px;
-  }
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -66,6 +66,10 @@ h3 {
 .popover-body {
 	font-size: 18px;
 }
+.popover-header {
+  line-height: 1.42857143;
+  margin: 0;
+}
 .popover-content table,
 .popover-body table {
     border-spacing: 0.5em;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -13,24 +13,44 @@ body {
 
 /* popover */
 .popover-title,
-.popover-content {
+.popover-content,
+.popover-header,
+.popover-body {
 	font-size: 18px;
 }
-.popover-content table {
+.popover-content table,
+.popover-body table {
     border-spacing: 0.5em;
     border-collapse: separate;    
 }
-.popover-content table tr {
+.popover-content table tr,
+.popover-body table tr {
   vertical-align: top;
   text-align: left;
 }
-.popover-content table td:first-child {
+.popover-content table td:first-child,
+.popover-body table td:first-child {
   text-align: right;
 }
 
 /* Ekzercoj */
 .has-error input {
   background: #f0f0f0;
+}
+.has-success input {
+  background: #eff8ef;
+}
+.feedback-icon {
+  display: inline-block;
+  font-weight: bold;
+  min-width: 1.5em;
+  text-align: center;
+}
+.feedback-icon-ok {
+  color: #198754;
+}
+.feedback-icon-remove {
+  color: #dc3545;
 }
 
 .fixed {
@@ -52,6 +72,12 @@ body {
 	display: inline-block;
 	padding: 0.2em;
 }
+.jumbotron {
+  background: #f8f9fa;
+  border-radius: 0.5rem;
+  margin-top: 2rem;
+  padding: 2rem;
+}
 
 #eksporto {
 	float: right;
@@ -68,6 +94,16 @@ img.leciona {
 ul.pager {
   clear: both;
 	padding-top: 1em;
+  display: flex;
+  justify-content: space-between;
+  list-style: none;
+  padding-left: 0;
+}
+.well {
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+  padding: 0.75rem;
 }
 .ad {
   text-align: center;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -48,6 +48,39 @@ h3 {
   padding-top: 0;
 }
 
+@media (max-width: 991.98px) {
+  .navbar-collapse {
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+  }
+  .navbar .nav-link {
+    padding: 10px 15px;
+  }
+  .navbar .nav-link.show {
+    background-color: #080808;
+    color: #fff;
+  }
+  .navbar .dropdown-menu {
+    background-color: #222;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+    padding: 5px 0 15px;
+    position: static;
+    width: 100%;
+  }
+  .navbar .dropdown-item {
+    color: rgba(255, 255, 255, 0.6);
+    padding: 6px 30px;
+    white-space: normal;
+  }
+  .navbar .dropdown-item:hover,
+  .navbar .dropdown-item:focus {
+    background-color: #222;
+    color: #fff;
+  }
+}
+
 .card-header {
   padding: 10px 15px;
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -59,7 +59,7 @@ h2 {
   text-align: right;
 }
 a[data-bs-toggle="popover"] {
-  color: inherit;
+  color: #337ab7;
   text-decoration: none;
 }
 a[data-bs-toggle="popover"]:hover,
@@ -69,9 +69,6 @@ a[data-bs-toggle="popover"]:focus {
 }
 
 /* Ekzercoj */
-ol.tasko > li {
-  margin-bottom: 1.25em;
-}
 .form-group {
   margin-bottom: 15px;
 }
@@ -83,10 +80,15 @@ ol.tasko > li {
 }
 .form-horizontal .control-label {
   font-weight: 700;
+  padding-right: 0.75rem;
   padding-top: 7px;
 }
 .form-horizontal .col-sm-10 {
+  padding-left: 0.75rem;
   position: relative;
+}
+.ekzerco3-tasko > li {
+  margin-bottom: 1.25em;
 }
 .form-horizontal .feedback-icon {
   position: absolute;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -29,12 +29,34 @@ h1 {
   margin-top: 20px;
 }
 h2 {
+  font-size: 30px;
+  line-height: 1.1;
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
+h3 {
+  font-size: 24px;
+  line-height: 1.1;
   margin-bottom: 10px;
   margin-top: 20px;
 }
 
 .navbar {
   margin-bottom: 20px;
+  min-height: 52px;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.card-header {
+  padding: 10px 15px;
+}
+.card-header a {
+  text-decoration: none;
+}
+.card-title {
+  font-size: 16px;
+  line-height: 1.1;
 }
 
 /* popover */
@@ -69,6 +91,9 @@ a[data-bs-toggle="popover"]:focus {
 }
 
 /* Ekzercoj */
+ol.tasko {
+  padding-left: 40px;
+}
 .form-group {
   margin-bottom: 15px;
 }
@@ -108,6 +133,10 @@ a[data-bs-toggle="popover"]:focus {
 }
 .form-inline .form-control {
   display: inline-block;
+  font-size: 14px;
+  height: 34px;
+  line-height: 1.42857143;
+  padding: 6px 42.5px 6px 12px;
   width: auto;
 }
 .form-inline .feedback-icon {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -1,4 +1,9 @@
 /* set a max-width for horizontal fluid layout and make it centered */
+:root {
+  --bs-link-color: #337ab7;
+  --bs-link-hover-color: #23527c;
+}
+
 .container {
   margin-right: auto;
   margin-left: auto;
@@ -55,6 +60,9 @@ a[data-bs-toggle="popover"]:focus {
 }
 
 /* Ekzercoj */
+ol.tasko > li {
+  margin-bottom: 0.5em;
+}
 .form-group {
   margin-bottom: 15px;
 }
@@ -78,7 +86,7 @@ a[data-bs-toggle="popover"]:focus {
 }
 .form-inline .form-group {
   display: inline-block;
-  margin-bottom: 0;
+  margin: 0 0.2em 0.2em;
   position: relative;
   vertical-align: middle;
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -67,6 +67,11 @@ h3 {
   font-size: 16px;
   line-height: 1.1;
 }
+.footer a,
+.footer a:hover,
+.footer a:focus {
+  text-decoration: none;
+}
 
 /* popover */
 .popover-header,
@@ -207,8 +212,14 @@ img.leciona {
 }
 ul.pager {
   clear: both;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  column-gap: 0.5rem;
   margin: 20px 0;
 	padding-top: 1em;
+}
+ul.pager .next {
+  text-align: right;
 }
 .ad {
   text-align: center;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -1,6 +1,8 @@
 /* set a max-width for horizontal fluid layout and make it centered */
 :root {
+  --bs-link-color: #337ab7;
   --bs-link-color-rgb: 51, 122, 183;
+  --bs-link-hover-color: #23527c;
   --bs-link-hover-color-rgb: 35, 82, 124;
 }
 

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -17,6 +17,13 @@ body {
 	font-size: 18px;
 	line-height: 30px;
 }
+a {
+  color: #337ab7;
+}
+a:hover,
+a:focus {
+  color: #23527c;
+}
 h1 {
   margin-bottom: 10px;
   margin-top: 20px;
@@ -52,16 +59,18 @@ h2 {
   text-align: right;
 }
 a[data-bs-toggle="popover"] {
+  color: inherit;
   text-decoration: none;
 }
 a[data-bs-toggle="popover"]:hover,
 a[data-bs-toggle="popover"]:focus {
+  color: #23527c;
   text-decoration: none;
 }
 
 /* Ekzercoj */
 ol.tasko > li {
-  margin-bottom: 0.5em;
+  margin-bottom: 1.25em;
 }
 .form-group {
   margin-bottom: 15px;
@@ -70,6 +79,7 @@ ol.tasko > li {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
+  margin-bottom: 18px;
 }
 .form-horizontal .control-label {
   font-weight: 700;
@@ -83,6 +93,10 @@ ol.tasko > li {
   right: 12px;
   top: 50%;
   transform: translateY(-50%);
+}
+.form-horizontal .solvu,
+.form-horizontal .forigu {
+  margin-top: 0.25em;
 }
 .form-inline .form-group {
   display: inline-block;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -13,81 +13,16 @@ body {
 	line-height: 30px;
 }
 h1 {
-  font-size: 36px;
-  line-height: 1.1;
   margin-bottom: 10px;
   margin-top: 20px;
 }
 h2 {
-  font-size: 30px;
-  line-height: 1.1;
   margin-bottom: 10px;
   margin-top: 20px;
 }
 
-/* Bootstrap 5 is used for security; these rules preserve the former site layout. */
 .navbar {
   margin-bottom: 20px;
-  min-height: 52px;
-  padding-bottom: 0;
-  padding-top: 0;
-}
-.navbar > .container-fluid {
-  min-height: 52px;
-  padding-left: 0;
-  padding-right: 0;
-}
-.navbar-brand {
-  align-items: center;
-  display: flex;
-  height: 52px;
-  padding: 15px;
-}
-.navbar-nav .nav-link {
-  color: #9d9d9d;
-  line-height: 20px;
-  padding: 15px;
-}
-.navbar-nav .nav-link:hover,
-.navbar-nav .nav-link:focus {
-  color: #fff;
-}
-.navbar-form-bs3 {
-  margin: 8px 0 8px 22px;
-}
-.navbar-form-bs3 + .navbar-form-bs3 {
-  margin-left: 30px;
-}
-.navbar-form-bs3 .form-control,
-.navbar-form-bs3 .form-select {
-  height: 34px;
-  line-height: 1.42857143;
-  padding: 6px 12px;
-}
-.navbar-form-bs3 .form-control {
-  width: 177px;
-}
-.navbar-form-bs3 .form-select {
-  width: 193px;
-}
-.row > * {
-  padding-left: 15px;
-  padding-right: 15px;
-}
-.btn-outline-secondary {
-  background-color: #fff;
-  border-color: #ccc;
-  border-radius: 4px;
-  color: #333;
-  font-size: 14px;
-  line-height: 1.42857143;
-  padding: 6px 12px;
-}
-.btn-outline-secondary:hover,
-.btn-outline-secondary:focus {
-  background-color: #e6e6e6;
-  border-color: #adadad;
-  color: #333;
 }
 
 /* popover */
@@ -110,6 +45,13 @@ h2 {
 .popover-content table td:first-child,
 .popover-body table td:first-child {
   text-align: right;
+}
+a[data-bs-toggle="popover"] {
+  text-decoration: none;
+}
+a[data-bs-toggle="popover"]:hover,
+a[data-bs-toggle="popover"]:focus {
+  text-decoration: none;
 }
 
 /* Ekzercoj */
@@ -226,13 +168,6 @@ ul.pager .previous > a {
 }
 
 @media (max-width: 767px) {
-  .navbar-form-bs3 {
-    margin: 8px 15px;
-  }
-  .navbar-form-bs3 .form-control,
-  .navbar-form-bs3 .form-select {
-    width: 100%;
-  }
   .jumbotron {
     padding: 30px 15px;
   }

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -19,19 +19,10 @@
   <body>
 
 
-    <nav class="navbar navbar-inverse">
+    <nav class="navbar navbar-dark bg-dark">
       <div class="container-fluid">
-        <!-- Brand and toggle get grouped for better mobile display -->
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/"><img id="logo" src="assets/img/stelo.png" alt="Verda stelo"></a>
-        </div>
-      </div><!-- /.container-fluid -->
+        <a class="navbar-brand" href="/"><img id="logo" src="assets/img/stelo.png" alt="Verda stelo"></a>
+      </div>
     </nav>   
 
     <div class="container">
@@ -42,38 +33,38 @@
  <div class="jumbotron">
   <h1>Learn Esperanto</h1>
 	<ul>
-		<li><a class="btn btn-default" href="ar/" title="araba">العربية</a></li>
-		<li><a class="btn btn-default" href="ca/" title="kataluna">Català</a></li>
-		<li><a class="btn btn-default" href="cs/" title="ĉeĥa">Čeština</a></li>
-		<li><a class="btn btn-default" href="de/" title="germana">Deutsch</a></li>
-		<li><a class="btn btn-default" href="da/" title="dana">Dansk</a></li>
-		<li><a class="btn btn-default" href="el/" title="greka">Ελληνικά</a></li>
-		<li><a class="btn btn-default" href="en/" title="angla">English</a></li>
-		<li><a class="btn btn-default" href="es/" title="hispana">Español</a></li>
-		<li><a class="btn btn-default" href="fa/" title="persa">فارسی</a></li>
-		<li><a class="btn btn-default" href="fr/" title="franca">Français</a></li>
-		<li><a class="btn btn-default" href="ga/" title="irlanda">Gaeilge</a></li>
-		<li><a class="btn btn-default" href="he/" title="hebrea">עברית</a></li>
-		<li><a class="btn btn-default" href="hr/" title="kroata">Hrvatski</a></li>
-		<li><a class="btn btn-default" href="hu/" title="hungara">Magyar</a></li>
-		<li><a class="btn btn-default" href="id/" title="indonezia">Bahasa Indonesia</a></li>
-		<li><a class="btn btn-default" href="it/" title="itala">Italiano</a></li>
-		<li><a class="btn btn-default" href="ja/" title="japana">日本語</a></li>
-		<li><a class="btn btn-default" href="ko/" title="korea">한국어</a></li>
-		<li><a class="btn btn-default" href="ms/" title="malaja">Bahasa Melayu</a></li>
-		<li><a class="btn btn-default" href="nl/" title="nederlanda">Nederlands</a></li>
-		<li><a class="btn btn-default" href="pl/" title="pola">Polski</a></li>
-		<li><a class="btn btn-default" href="pt/" title="portugala">Português</a></li>
-		<li><a class="btn btn-default" href="ru/" title="rusa">Русский</a></li>
-		<li><a class="btn btn-default" href="sk/" title="slovaka">Slovenčina</a></li>
-		<li><a class="btn btn-default" href="sl/" title="slovena">Slovenščina</a></li>
-		<li><a class="btn btn-default" href="sv/" title="sveda">Svenska</a></li>
-		<li><a class="btn btn-default" href="th/" title="taja">ภาษาไทย</a></li>
-		<li><a class="btn btn-default" href="tr/" title="turka">Türkçe</a></li>
-		<li><a class="btn btn-default" href="uk/" title="ukraina">Українська</a></li>
-		<li><a class="btn btn-default" href="vi/" title="vjetnama">Tiếng Việt</a></li>
-		<li><a class="btn btn-default" href="zh/" title="ĉina">中文</a></li>
-		<li><a class="btn btn-default" href="zh-tw/" title="tradicia ĉina">正體中文</a></li>
+		<li><a class="btn btn-outline-secondary" href="ar/" title="araba">العربية</a></li>
+		<li><a class="btn btn-outline-secondary" href="ca/" title="kataluna">Català</a></li>
+		<li><a class="btn btn-outline-secondary" href="cs/" title="ĉeĥa">Čeština</a></li>
+		<li><a class="btn btn-outline-secondary" href="de/" title="germana">Deutsch</a></li>
+		<li><a class="btn btn-outline-secondary" href="da/" title="dana">Dansk</a></li>
+		<li><a class="btn btn-outline-secondary" href="el/" title="greka">Ελληνικά</a></li>
+		<li><a class="btn btn-outline-secondary" href="en/" title="angla">English</a></li>
+		<li><a class="btn btn-outline-secondary" href="es/" title="hispana">Español</a></li>
+		<li><a class="btn btn-outline-secondary" href="fa/" title="persa">فارسی</a></li>
+		<li><a class="btn btn-outline-secondary" href="fr/" title="franca">Français</a></li>
+		<li><a class="btn btn-outline-secondary" href="ga/" title="irlanda">Gaeilge</a></li>
+		<li><a class="btn btn-outline-secondary" href="he/" title="hebrea">עברית</a></li>
+		<li><a class="btn btn-outline-secondary" href="hr/" title="kroata">Hrvatski</a></li>
+		<li><a class="btn btn-outline-secondary" href="hu/" title="hungara">Magyar</a></li>
+		<li><a class="btn btn-outline-secondary" href="id/" title="indonezia">Bahasa Indonesia</a></li>
+		<li><a class="btn btn-outline-secondary" href="it/" title="itala">Italiano</a></li>
+		<li><a class="btn btn-outline-secondary" href="ja/" title="japana">日本語</a></li>
+		<li><a class="btn btn-outline-secondary" href="ko/" title="korea">한국어</a></li>
+		<li><a class="btn btn-outline-secondary" href="ms/" title="malaja">Bahasa Melayu</a></li>
+		<li><a class="btn btn-outline-secondary" href="nl/" title="nederlanda">Nederlands</a></li>
+		<li><a class="btn btn-outline-secondary" href="pl/" title="pola">Polski</a></li>
+		<li><a class="btn btn-outline-secondary" href="pt/" title="portugala">Português</a></li>
+		<li><a class="btn btn-outline-secondary" href="ru/" title="rusa">Русский</a></li>
+		<li><a class="btn btn-outline-secondary" href="sk/" title="slovaka">Slovenčina</a></li>
+		<li><a class="btn btn-outline-secondary" href="sl/" title="slovena">Slovenščina</a></li>
+		<li><a class="btn btn-outline-secondary" href="sv/" title="sveda">Svenska</a></li>
+		<li><a class="btn btn-outline-secondary" href="th/" title="taja">ภาษาไทย</a></li>
+		<li><a class="btn btn-outline-secondary" href="tr/" title="turka">Türkçe</a></li>
+		<li><a class="btn btn-outline-secondary" href="uk/" title="ukraina">Українська</a></li>
+		<li><a class="btn btn-outline-secondary" href="vi/" title="vjetnama">Tiếng Việt</a></li>
+		<li><a class="btn btn-outline-secondary" href="zh/" title="ĉina">中文</a></li>
+		<li><a class="btn btn-outline-secondary" href="zh-tw/" title="tradicia ĉina">正體中文</a></li>
 	</ul>
   </div>         
 
@@ -106,7 +97,7 @@
 
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
-    <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
+    <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
 

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -33,9 +33,9 @@
 
         <div class="col-sm-12">
 
- <div class="jumbotron">
-  <h1>Learn Esperanto</h1>
-	<ul>
+ <div class="p-5 mb-4 bg-body-tertiary rounded-3">
+  <h1 class="display-3">Learn Esperanto</h1>
+	<ul class="lingvolisto">
 		<li><a class="btn btn-outline-secondary" href="ar/" title="araba">العربية</a></li>
 		<li><a class="btn btn-outline-secondary" href="ca/" title="kataluna">Català</a></li>
 		<li><a class="btn btn-outline-secondary" href="cs/" title="ĉeĥa">Čeština</a></li>
@@ -75,7 +75,7 @@
         </div>
       </div>
 
-			<div class="footer well well-sm">
+			<div class="footer p-2 bg-body-tertiary border rounded">
 				<div>
 					<a href="https://github.com/Esperanto/kurso-zagreba-metodo#permesiloj">
 				    <img id="cc" src="assets/img/cc.png" alt="Creative commons">

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -22,6 +22,9 @@
     <nav class="navbar navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand" href="/"><img id="logo" src="assets/img/stelo.png" alt="Verda stelo"></a>
+        <button type="button" class="navbar-toggler" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
       </div>
     </nav>   
 

--- a/fonto/html/ekz2-test.html
+++ b/fonto/html/ekz2-test.html
@@ -2,23 +2,23 @@
                <ol class="tasko">
       <li>
 <div class="input-group">
-  <input style="background-color:#eee;" type="button" class=" btn btn-default " value="Li">
+  <input style="background-color:#eee;" type="button" class=" btn btn-outline-secondary " value="Li">
 </div>
 <div class="input-group">
-  <input style="background-color:#eee;" type="button" class="btn btn-default" value="estas">
+  <input style="background-color:#eee;" type="button" class="btn btn-outline-secondary" value="estas">
 </div>
 <div class="input-group">
-  <span class="input-group-addon">lern</span>
+  <span class="input-group-text">lern</span>
   <input type="text" class="form-control">
-  <span class="input-group-addon">o</span>
+  <span class="input-group-text">o</span>
 </div>
 <div class="input-group">
-  <input type="button" class="btn btn-default" value="kaj">
+  <input type="button" class="btn btn-outline-secondary" value="kaj">
 </div>
 <div class="input-group">
-  <span class="input-group-addon">sport</span>
+  <span class="input-group-text">sport</span>
   <input type="text" class="form-control">
-       <span id="" class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
-  <span class="input-group-addon">o</span>
+       <span id="" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
+  <span class="input-group-text">o</span>
 
 </div>

--- a/fonto/html/ekzerco1.html
+++ b/fonto/html/ekzerco1.html
@@ -27,19 +27,17 @@
 
   <h3 dir="{{enhavo.tekstodirekto}}"> {{enhavo.fasado[tasko]}} / {{tasko}} </h3>
 
-	<div class="panel-group">
-		<div class="panel panel-default">
-			<div class="panel-heading">
-				<a data-toggle="collapse" href="#teksto">
-					<h4 class="panel-title" dir="{{enhavo.tekstodirekto}}">
+	<div class="card mb-3">
+		<div class="card-header">
+				<a data-bs-toggle="collapse" href="#teksto">
+					<h4 class="card-title mb-0" dir="{{enhavo.tekstodirekto}}">
 						{{enhavo.fasado['Teksto']}}
 					</h4>
 				</a>
-			</div>
-			<div id="teksto" class="panel-collapse collapse">
-				<div class="panel-body">
+		</div>
+		<div id="teksto" class="collapse">
+			<div class="card-body">
 					{% include 'paragrafoj.html' %}
-				</div>
 			</div>
 		</div>
 	</div>
@@ -52,14 +50,14 @@
       {% set id = 'vico-' ~ leciono_index ~ '-' ~ ekzerco_index ~ '-' ~ vico_loop.index %}
       <div id="form-group-{{id}}" class="form-group has-error has-feedback">
         {% for esperante,fontlingve in vico.items() %}
-          <label class="control-label col-sm-2" for="{{id}}" data-toggle="popover" data-placement="bottom" title="{{fontlingve if fontlingve is string else fontlingve|join(', ')}}" >{{esperante}}:</label>
+          <label class="control-label col-sm-2" for="{{id}}" data-bs-toggle="popover" data-bs-placement="bottom" title="{{fontlingve if fontlingve is string else fontlingve|join(', ')}}" >{{esperante}}:</label>
           <div class="col-sm-10">
             {%- if fontlingve is string -%}
               <input id="{{id}}" class="form-control" type="text" size="{{fontlingve|string|length}}" data-solvo="{{fontlingve}}"/>
             {%- elif fontlingve is iterable -%}
               <input id="{{id}}" class="form-control" type="text" size="{{fontlingve[0]|string|length}}" data-solvo="{{fontlingve|join(' | ')}}"/>
             {%- endif -%}
-            <span id="glyphicon-{{id}}" class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+            <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
           </div>
         {% endfor %}
       </div>

--- a/fonto/html/ekzerco2.html
+++ b/fonto/html/ekzerco2.html
@@ -27,18 +27,16 @@
 
   <h3 dir="{{enhavo.tekstodirekto}}"> {{enhavo.fasado[tasko]}} / {{tasko}} </h3>
 
-	<div class="panel-group">
-		<div class="panel panel-default">
-			<div class="panel-heading">
-<a data-toggle="collapse" href="#teksto">
-				<h4 class="panel-title" dir="{{enhavo.tekstodirekto}}">
+	<div class="card mb-3">
+		<div class="card-header">
+<a data-bs-toggle="collapse" href="#teksto">
+				<h4 class="card-title mb-0" dir="{{enhavo.tekstodirekto}}">
 					{{enhavo.fasado['Teksto']}}
 				</h4></a>
-			</div>
-			<div id="teksto" class="panel-collapse collapse">
-				<div class="panel-body">
+		</div>
+		<div id="teksto" class="collapse">
+			<div class="card-body">
 					{% include 'paragrafoj.html' %}
-				</div>
 			</div>
 		</div>
 	</div>
@@ -61,7 +59,7 @@
             {%- elif klavo == 'solvo' -%}
               <div id="form-group-{{id}}" class="form-group has-error has-feedback">
                 <input id="{{id}}" type="text" class="form-control" size="{{valoro|length}}" data-solvo="{{valoro}}" />
-                <span id="glyphicon-{{id}}" class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+                <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
               </div>
             {%- endif -%} 
          {%- endfor -%}

--- a/fonto/html/ekzerco2.html
+++ b/fonto/html/ekzerco2.html
@@ -58,7 +58,7 @@
               {%- else %} {% endif -%} 
             {%- elif klavo == 'solvo' -%}
               <div id="form-group-{{id}}" class="form-group has-error has-feedback">
-                <input id="{{id}}" type="text" class="form-control" size="{{valoro|length}}" data-solvo="{{valoro}}" />
+                <input id="{{id}}" type="text" class="form-control" size="{{(valoro|length) + 2}}" data-solvo="{{valoro}}" />
                 <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
               </div>
             {%- endif -%} 

--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -43,7 +43,7 @@
 	
   <p class="alert alert-info" role="alert" dir="{{enhavo.tekstodirekto}}">{{ enhavo.fasado['Por la Esperantaj literoj vi ankaŭ rajtas skribi cx, gx, hx, jx, sx kaj ux.'] }}</p>
 
-  <ol class="tasko">
+  <ol class="tasko ekzerco3-tasko">
     {% for vico in leciono.ekzercoj[tasko] %}
       {% set vico_loop = loop %}
       {% set form_id = leciono_index ~ '-' ~ ekzerco_index ~ '-' ~ vico_loop.index %}

--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -27,18 +27,16 @@
   
   <h3 dir="{{enhavo.tekstodirekto}}"> {{enhavo.fasado[tasko]}} / {{tasko}} </h3>
 
-	<div class="panel-group">
-		<div class="panel panel-default">
-			<div class="panel-heading">
-<a data-toggle="collapse" href="#teksto">
-				<h4 class="panel-title" dir="{{enhavo.tekstodirekto}}">
+	<div class="card mb-3">
+		<div class="card-header">
+<a data-bs-toggle="collapse" href="#teksto">
+				<h4 class="card-title mb-0" dir="{{enhavo.tekstodirekto}}">
 					{{enhavo.fasado['Teksto']}}
 				</h4></a>
-			</div>
-			<div id="teksto" class="panel-collapse collapse">
-				<div class="panel-body">
+		</div>
+		<div id="teksto" class="collapse">
+			<div class="card-body">
 					{% include 'paragrafoj.html' %}
-				</div>
 			</div>
 		</div>
 	</div>
@@ -62,10 +60,10 @@
             {% for esperante, fontlingve in duopo.items() %}
               <div id="form-group-{{id}}" class="form-group has-error has-feedback">
                 <label class="control-label col-sm-2" for="{{id}}" 
-                  data-toggle="popover" data-placement="bottom" title="{{esperante}}">{{fontlingve|join}}:</label>
+                  data-bs-toggle="popover" data-bs-placement="bottom" title="{{esperante}}">{{fontlingve|join}}:</label>
                 <div class="col-sm-10">
                   <input id="{{id}}" class="form-control" type="text" size="{{esperante|length}}" data-solvo="{{esperante}}"/>
-                  <span id="glyphicon-{{id}}" class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+                  <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
                 </div>
               </div>
               {% endfor %}

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -105,7 +105,7 @@
         </div>
       </div>
 
-			<div class="footer well well-sm">
+			<div class="footer p-2 bg-body-tertiary border rounded">
 				<div>
 					<a href="https://github.com/Esperanto/kurso-zagreba-metodo#permesiloj">
 				    <img id="cc" src="{{vojprefikso}}../assets/img/cc.png" alt="Creative commons">

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -27,7 +27,7 @@
         </button>
 
         <div class="collapse navbar-collapse" id="site-navigation">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <ul class="navbar-nav mb-2 mb-lg-0">
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                 {{enhavo.fasado['Lecionoj']}}

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -27,7 +27,7 @@
         </button>
 
         <div class="collapse navbar-collapse" id="site-navigation">
-          <ul class="navbar-nav me-auto">
+          <ul class="navbar-nav">
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                 {{enhavo.fasado['Lecionoj']}}
@@ -62,10 +62,10 @@
             </li>
           </ul>
 
-          <form class="d-flex ms-lg-3 my-2 my-lg-0">
+          <form class="navbar-form-bs3 d-flex">
             {% include 'vortaro.html' %}
           </form>
-          <form class="d-flex ms-lg-3 my-2 my-lg-0">
+          <form class="navbar-form-bs3 d-flex">
             <select id="lingvoelektilo" class="form-select">
               {% for kodo in enhavo.lingvoj|sort if enhavo.lingvoj[kodo].stato == 'preta' %}
                 <option value="{{kodo}}"

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -19,63 +19,54 @@
   <body>
 
 
-    <nav class="navbar navbar-inverse">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
-        <!-- Brand and toggle get grouped for better mobile display -->
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="{{vojprefikso}}"><img id="logo" src="{{vojprefikso}}../assets/img/stelo.png" alt="Verda stelo"></a>
-        </div>
+        <a class="navbar-brand" href="{{vojprefikso}}"><img id="logo" src="{{vojprefikso}}../assets/img/stelo.png" alt="Verda stelo"></a>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#site-navigation" aria-controls="site-navigation" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
 
-        <!-- Collect the nav links, forms, and other content for toggling -->
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-          <ul class="nav navbar-nav">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+        <div class="collapse navbar-collapse" id="site-navigation">
+          <ul class="navbar-nav me-auto">
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                 {{enhavo.fasado['Lecionoj']}}
-                <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
                 {% for leciono in enhavo.lecionoj %}
-                <li><a href="{{vojprefikso}}{{leciono.indekso.cxene}}">{{leciono.indekso.cifre}}. {{leciono.teksto.titolo_string}}</a></li>
+                <li><a class="dropdown-item" href="{{vojprefikso}}{{leciono.indekso.cxene}}">{{leciono.indekso.cifre}}. {{leciono.teksto.titolo_string}}</a></li>
                 {% endfor %}
               </ul>
             </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                 {{enhavo.fasado['Aldono']}}
-                <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
-                <li><a href="{{vojprefikso}}tabelvortoj">
+                <li><a class="dropdown-item" href="{{vojprefikso}}tabelvortoj">
                   {{enhavo.fasado['Tabelvortoj']}}
                 </a></li>
-                <li><a href="{{vojprefikso}}prepozicioj">
+                <li><a class="dropdown-item" href="{{vojprefikso}}prepozicioj">
                   {{enhavo.fasado['Prepozicioj']}}
                 </a></li>
-                <li><a href="{{vojprefikso}}konjunkcioj">
+                <li><a class="dropdown-item" href="{{vojprefikso}}konjunkcioj">
                   {{enhavo.fasado['Konjunkcioj']}}
                 </a></li>
-                <li><a href="{{vojprefikso}}afiksoj">
+                <li><a class="dropdown-item" href="{{vojprefikso}}afiksoj">
                   {{enhavo.fasado['Afiksoj']}}
                 </a></li>
-                <li><a href="{{vojprefikso}}diversajxoj">
+                <li><a class="dropdown-item" href="{{vojprefikso}}diversajxoj">
                   {{enhavo.fasado['Diversaĵoj']}}
                 </a></li>
               </ul>
             </li>
           </ul>
 
-          <form class="navbar-form navbar-left">
+          <form class="d-flex ms-lg-3 my-2 my-lg-0">
             {% include 'vortaro.html' %}
           </form>
-          <form class="navbar-form navbar-left">
-            <select id="lingvoelektilo" class="form-control">
+          <form class="d-flex ms-lg-3 my-2 my-lg-0">
+            <select id="lingvoelektilo" class="form-select">
               {% for kodo in enhavo.lingvoj|sort if enhavo.lingvoj[kodo].stato == 'preta' %}
                 <option value="{{kodo}}"
                 {% if kodo == enhavo.lingvo %}  
@@ -93,8 +84,8 @@
             </select>
           </form>
 
-        </div><!-- /.navbar-collapse -->
-      </div><!-- /.container-fluid -->
+        </div>
+      </div>
     </nav>   
 
     <div class="container">
@@ -139,7 +130,7 @@
 
     <script src="/vendor/jquery/jquery.min.js"></script>
     <script src="/vendor/jquery/jquery-ui.min.js"></script>
-    <script src="/vendor/bootstrap/js/bootstrap.min.js"></script>
+    <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -27,7 +27,7 @@
         </button>
 
         <div class="collapse navbar-collapse" id="site-navigation">
-          <ul class="navbar-nav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false">
                 {{enhavo.fasado['Lecionoj']}}
@@ -62,10 +62,10 @@
             </li>
           </ul>
 
-          <form class="navbar-form-bs3 d-flex">
+          <form class="d-flex ms-lg-3 my-2 my-lg-0">
             {% include 'vortaro.html' %}
           </form>
-          <form class="navbar-form-bs3 d-flex">
+          <form class="d-flex ms-lg-3 my-2 my-lg-0">
             <select id="lingvoelektilo" class="form-select">
               {% for kodo in enhavo.lingvoj|sort if enhavo.lingvoj[kodo].stato == 'preta' %}
                 <option value="{{kodo}}"

--- a/fonto/html/pager.html
+++ b/fonto/html/pager.html
@@ -1,8 +1,8 @@
-<ul class="pager">
+<ul class="pager list-unstyled d-flex align-items-center ps-0">
   {% if previous_path -%}
-  <li class="previous"><a href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+  <li class="previous me-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
   {%- endif %} 
   {% if next_path -%}
-  <li class="next"><a href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+  <li class="next ms-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
   {%- endif %} 
 </ul>

--- a/fonto/html/pager.html
+++ b/fonto/html/pager.html
@@ -1,8 +1,13 @@
-<ul class="pager list-unstyled d-flex align-items-center ps-0">
+<ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-  <li class="previous me-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+  <li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+  {%- else %}
+  <li></li>
   {%- endif %} 
+  <li></li>
   {% if next_path -%}
-  <li class="next ms-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+  <li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+  {%- else %}
+  <li></li>
   {%- endif %} 
 </ul>

--- a/fonto/html/pagxonumerado-komentejo.html
+++ b/fonto/html/pagxonumerado-komentejo.html
@@ -1,14 +1,20 @@
-<ul class="pager list-unstyled d-flex align-items-center ps-0">
+<ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-		<li class="previous me-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+		<li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+  {%- else %}
+		<li></li>
   {%- endif %} 
 
 	{% if enhavo.lingvoj[enhavo.lingvo].komentejo %} 
-		<li class="mx-auto"><a class="btn btn-outline-secondary rounded-pill" href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
+		<li class="comments"><a class="btn btn-outline-secondary rounded-pill" href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
+  {%- else %}
+		<li></li>
   {%- endif %} 
 
   {% if next_path -%}
-		<li class="next ms-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+		<li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+  {%- else %}
+		<li></li>
   {%- endif %} 
 </ul>
 

--- a/fonto/html/pagxonumerado-komentejo.html
+++ b/fonto/html/pagxonumerado-komentejo.html
@@ -1,14 +1,14 @@
-<ul class="pager">
+<ul class="pager list-unstyled d-flex align-items-center ps-0">
   {% if previous_path -%}
-		<li class="previous"><a href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+		<li class="previous me-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
   {%- endif %} 
 
 	{% if enhavo.lingvoj[enhavo.lingvo].komentejo %} 
-		<li><a href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
+		<li class="mx-auto"><a class="btn btn-outline-secondary rounded-pill" href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
   {%- endif %} 
 
   {% if next_path -%}
-		<li class="next"><a href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+		<li class="next ms-auto"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
   {%- endif %} 
 </ul>
 

--- a/fonto/html/tabs.html
+++ b/fonto/html/tabs.html
@@ -1,12 +1,7 @@
 <ul class="nav nav-tabs">
   {% for id, href, caption in tabs %}
-    <li 
-      {% if id == active_tab %} 
-        class="active"
-      {% endif %}
-      role="presentation"
-    >
-    <a href="{{tab_vojprefikso}}{{href}}">{{caption}}</a>
+    <li class="nav-item" role="presentation">
+    <a class="nav-link{% if id == active_tab %} active{% endif %}" href="{{tab_vojprefikso}}{{href}}">{{caption}}</a>
     </li>
   {% endfor %}
 </ul>

--- a/fonto/html/vorto.html
+++ b/fonto/html/vorto.html
@@ -1,7 +1,7 @@
 {%- if vorto is string -%}
   {{vorto}}
 {%- elif vorto is iterable -%}
-  <a href="javascript:" data-toggle="popover" title="
+  <a href="javascript:" data-bs-toggle="popover" title="
     {% set klavo = false %}
     {% if vorto|join|lower in enhavo.vortaro -%}
       {% set klavo = vorto|join|lower %}
@@ -9,7 +9,7 @@
       {% set klavo = vorto|join %}
     {% endif %} 
     {% include 'tradukajxo.html' %}
-  " data-content="
+  " data-bs-content="
     <table>
     {# Loop only if there are multiple roots. #}
     {% if vorto|length > 1 -%} 

--- a/fonto/html/vortoj.html
+++ b/fonto/html/vortoj.html
@@ -24,7 +24,7 @@
   <div dir="{{enhavo.tekstodirekto}}">
 	
 	<div id="eksporto">
-    <a class="btn btn-default" href="{{vojprefikso}}eksporto/{{enhavo.lingvo}}.apkg"> Anki APKG</a>
+    <a class="btn btn-outline-secondary" href="{{vojprefikso}}eksporto/{{enhavo.lingvo}}.apkg"> Anki APKG</a>
 	</div>
 
   <h3>
@@ -86,4 +86,3 @@
   {% include 'pagxonumerado-komentejo.html' %}
 
 {% endblock %}
-

--- a/fonto/js/main.js
+++ b/fonto/js/main.js
@@ -1,17 +1,22 @@
 $(document).ready(function(){
-  var popoverWhiteList = $.extend(
+  var popoverAllowList = $.extend(
+    true,
     {},
-    $.fn.tooltip.Constructor.DEFAULTS.whiteList,
+    bootstrap.Tooltip.Default.allowList,
     { table: [], tbody: [], tr: [], td: [] }
   );
 
-  $('[data-toggle="tooltip"]').tooltip(); 
-  $('[data-toggle="popover"]').popover({
-    placement: 'bottom',
-    trigger: 'hover',
-    html: true,
-    whiteList: popoverWhiteList
-  }); 
+  $('[data-bs-toggle="tooltip"]').each(function() {
+    new bootstrap.Tooltip(this);
+  });
+  $('[data-bs-toggle="popover"]').each(function() {
+    new bootstrap.Popover(this, {
+      placement: 'bottom',
+      trigger: 'hover',
+      html: true,
+      allowList: popoverAllowList
+    });
+  });
   $('.container table').addClass('table'); 
 });
 
@@ -59,7 +64,7 @@ function selectNextTabbableOrFocusable(selector){
 $('input[data-solvo]').on('input', function() {
   var id = $(this).attr('id');
   var form_group = $('#form-group-' + id);
-  var glyphicon = $('#glyphicon-' + id);
+  var feedback = $('#feedback-' + id);
 
   // Get input and normalize.
   var input = $(this).val();
@@ -77,7 +82,7 @@ $('input[data-solvo]').on('input', function() {
 
   if (correct) {
     form_group.removeClass('has-error').addClass('has-success');
-    glyphicon.removeClass('glyphicon-remove').addClass('glyphicon-ok');
+    feedback.removeClass('feedback-icon-remove').addClass('feedback-icon-ok').text('✓');
 		// Set focus on the current
 		// to not confuse it during the following step. 
 		$(this).focus();
@@ -87,7 +92,7 @@ $('input[data-solvo]').on('input', function() {
 		console.log(input);
 		console.log($(this).attr('data-solvo'));
     form_group.removeClass('has-success').addClass('has-error');
-    glyphicon.removeClass('glyphicon-ok').addClass('glyphicon-remove');
+    feedback.removeClass('feedback-icon-ok').addClass('feedback-icon-remove').text('✕');
   }
 });
 

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -164,21 +164,14 @@ def copy_static_files(versio):
         (FONTO_DIR / 'sonoj' / 'ogg', OUTPUT_DIR / 'assets' / 'ogg'),
         (FONTO_DIR / 'bildoj', OUTPUT_DIR / 'assets' / 'img'),
     ]
-    bootstrap_fonts = [
-        'glyphicons-halflings-regular.eot',
-        'glyphicons-halflings-regular.svg',
-        'glyphicons-halflings-regular.ttf',
-        'glyphicons-halflings-regular.woff',
-        'glyphicons-halflings-regular.woff2',
-    ]
     vendor_files = [
         (
             NODE_MODULES_DIR / 'bootstrap' / 'dist' / 'css' / 'bootstrap.min.css',
             OUTPUT_DIR / 'vendor' / 'bootstrap' / 'css' / 'bootstrap.min.css',
         ),
         (
-            NODE_MODULES_DIR / 'bootstrap' / 'dist' / 'js' / 'bootstrap.min.js',
-            OUTPUT_DIR / 'vendor' / 'bootstrap' / 'js' / 'bootstrap.min.js',
+            NODE_MODULES_DIR / 'bootstrap' / 'dist' / 'js' / 'bootstrap.bundle.min.js',
+            OUTPUT_DIR / 'vendor' / 'bootstrap' / 'js' / 'bootstrap.bundle.min.js',
         ),
         (
             NODE_MODULES_DIR / 'jquery' / 'dist' / 'jquery.min.js',
@@ -193,13 +186,6 @@ def copy_static_files(versio):
             OUTPUT_DIR / 'vendor' / 'typeahead' / 'typeahead.bundle.min.js',
         ),
     ]
-    vendor_files.extend(
-        (
-            NODE_MODULES_DIR / 'bootstrap' / 'dist' / 'fonts' / fonto,
-            OUTPUT_DIR / 'vendor' / 'bootstrap' / 'fonts' / fonto,
-        )
-        for fonto in bootstrap_fonts
-    )
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     write_file(str(OUTPUT_DIR / 'index.html'), render_cxefpagxo(versio))

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
 PWA_SERVICE_WORKER_PATTERN = re.compile(r'const PRECACHE_URLS = \[')
-BOOTSTRAP_PATTERN = re.compile(r'Bootstrap v3\.4\.1')
+BOOTSTRAP_PATTERN = re.compile(r'Bootstrap\s+v5\.3\.8')
 JQUERY_PATTERN = re.compile(r'jQuery v3\.7\.1')
 JQUERY_UI_PATTERN = re.compile(r'jQuery UI - v1\.13\.3')
 TYPEAHEAD_PATTERN = re.compile(r'typeahead\.js 0\.11\.1')
@@ -94,6 +94,7 @@ def main():
         output_dir / 'assets' / 'css' / 'main.css',
         output_dir / 'assets' / 'js' / 'main.js',
         output_dir / 'vendor' / 'bootstrap' / 'css' / 'bootstrap.min.css',
+        output_dir / 'vendor' / 'bootstrap' / 'js' / 'bootstrap.bundle.min.js',
         output_dir / 'manifest.webmanifest',
         output_dir / 'manifest.json',
         output_dir / 'pwa' / 'registru.js',
@@ -104,6 +105,7 @@ def main():
 
     require_pattern(output_dir / 'sw.js', PWA_SERVICE_WORKER_PATTERN)
     require_pattern(output_dir / 'vendor' / 'bootstrap' / 'css' / 'bootstrap.min.css', BOOTSTRAP_PATTERN)
+    require_pattern(output_dir / 'vendor' / 'bootstrap' / 'js' / 'bootstrap.bundle.min.js', BOOTSTRAP_PATTERN)
     require_pattern(output_dir / 'vendor' / 'jquery' / 'jquery.min.js', JQUERY_PATTERN)
     require_pattern(output_dir / 'vendor' / 'jquery' / 'jquery-ui.min.js', JQUERY_UI_PATTERN)
     require_pattern(output_dir / 'vendor' / 'typeahead' / 'typeahead.bundle.min.js', TYPEAHEAD_PATTERN)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "kurso-zagreba-metodo",
       "dependencies": {
-        "bootstrap": "3.4.1",
+        "bootstrap": "5.3.8",
         "jquery": "3.7.1",
         "jquery-ui-dist": "1.13.3",
         "typeahead.js": "0.11.1"
@@ -34,14 +34,34 @@
         "node": ">=18"
       }
     },
-    "node_modules/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "24.14.1"
   },
   "dependencies": {
-    "bootstrap": "3.4.1",
+    "bootstrap": "5.3.8",
     "jquery": "3.7.1",
     "jquery-ui-dist": "1.13.3",
     "typeahead.js": "0.11.1"

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -39,3 +39,17 @@ test('ŝvebi super tekstaj vortoj montras tradukajn ŝprucfenestrojn', async ({ 
 
   await expect(verbPopover).toBeVisible();
 });
+
+test('poŝtelefona aldona menuo restas malhela', async ({ page }) => {
+  await page.setViewportSize({ width: 580, height: 720 });
+  await page.goto('/en/01/');
+
+  await page.getByRole('button', { name: 'Toggle navigation' }).click();
+  await page.getByRole('button', { name: 'Appendix' }).click();
+
+  const menu = page.locator('.dropdown-menu.show').filter({
+    hasText: 'Correlatives',
+  });
+  await expect(menu).toBeVisible();
+  await expect(menu).toHaveCSS('background-color', 'rgb(34, 34, 34)');
+});


### PR DESCRIPTION
## Resumo
- ĝisdatigas Bootstrap de 3.4.1 al 5.3.8 por forigi la audit-trovon
- uzas la Bootstrap-5-bundle-on kaj ne plu kopias malnovajn Glyphicons-dosierojn
- adaptas ŝablonojn, popoverojn, dropdownojn, tabojn kaj ekzerco-feedback por Bootstrap 5
- lasas jQuery ĉe 3.7.1, ĉar npm audit ne raportas tie vundeblecon

## Kontroloj
- npm ci --ignore-scripts
- npm audit --json: 0 vundeblecoj
- make check
- make check-ui
- make html-all
- git diff --check
