### PR TITLE
Aldonu ikonojn al lecionaj langetoj

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -169,10 +169,12 @@ ol.tasko {
   width: auto;
 }
 .form-horizontal .col-sm-10 {
+  justify-self: start;
+  max-width: none;
   min-width: 0;
   padding-left: 0;
   position: relative;
-  width: auto;
+  width: max-content;
 }
 .form-horizontal .form-control {
   display: inline-block;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -67,9 +67,16 @@ h3 {
 }
 
 @media (max-width: 767.98px) {
+  .nav-tabs {
+    flex-wrap: nowrap;
+  }
   .nav-tabs .nav-link {
+    gap: 0.2rem;
     justify-content: center;
-    min-width: 2.75rem;
+    min-width: 2rem;
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+    white-space: nowrap;
   }
   .nav-tabs .nav-link:not(.active) .tab-label {
     display: none;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -43,6 +43,15 @@ h3 {
   padding-top: 0;
 }
 
+.nav-tabs .nav-link {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+.nav-tabs .tab-icon {
+  line-height: 1;
+}
+
 @media (max-width: 991.98px) {
   .navbar .dropdown-menu {
     --bs-dropdown-bg: #222;
@@ -54,6 +63,16 @@ h3 {
   }
   .navbar .dropdown-item {
     white-space: normal;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .nav-tabs .nav-link {
+    justify-content: center;
+    min-width: 2.75rem;
+  }
+  .nav-tabs .nav-link:not(.active) .tab-label {
+    display: none;
   }
 }
 

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -49,6 +49,8 @@ h3 {
   gap: 0.35rem;
 }
 .nav-tabs .tab-icon {
+  align-items: center;
+  display: inline-flex;
   line-height: 1;
 }
 
@@ -70,9 +72,13 @@ h3 {
   .nav-tabs {
     flex-wrap: nowrap;
   }
+  .nav-tabs .nav-item {
+    display: flex;
+  }
   .nav-tabs .nav-link {
     gap: 0.2rem;
     justify-content: center;
+    min-height: 2.4rem;
     min-width: 2rem;
     padding-left: 0.4rem;
     padding-right: 0.4rem;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -4,6 +4,7 @@
   --bs-link-color-rgb: 51, 122, 183;
   --bs-link-hover-color: #23527c;
   --bs-link-hover-color-rgb: 35, 82, 124;
+  --exercise-field-bg: #f0f0f0;
 }
 
 .container {
@@ -47,6 +48,9 @@ h3 {
   align-items: center;
   display: inline-flex;
   gap: 0.35rem;
+}
+.nav-tabs .nav-link.active {
+  background-color: var(--exercise-field-bg);
 }
 .nav-tabs .tab-icon {
   align-items: center;
@@ -138,20 +142,30 @@ ol.tasko {
 .form-group {
   margin-bottom: 15px;
 }
+.form-horizontal {
+  --exercise-label-column: clamp(9rem, 38vw, 12rem);
+}
 .form-horizontal .form-group {
   align-items: center;
-  display: flex;
-  flex-wrap: wrap;
+  column-gap: 0.75rem;
+  display: grid;
+  grid-template-columns: var(--exercise-label-column) max-content;
   margin-bottom: 18px;
 }
 .form-horizontal .control-label {
   font-weight: 700;
-  padding-right: 0.75rem;
-  padding-top: 7px;
+  justify-self: end;
+  max-width: var(--exercise-label-column);
+  padding-right: 0;
+  padding-top: 0;
+  text-align: right;
+  width: auto;
 }
 .form-horizontal .col-sm-10 {
-  padding-left: 0.75rem;
+  min-width: 0;
+  padding-left: 0;
   position: relative;
+  width: auto;
 }
 .ekzerco3-tasko > li {
   margin-bottom: 1.25em;
@@ -187,7 +201,7 @@ ol.tasko {
   transform: translateY(-50%);
 }
 .has-error input {
-  background: #f0f0f0;
+  background: var(--exercise-field-bg);
 }
 .has-success input {
   background: #eff8ef;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -143,28 +143,40 @@ ol.tasko {
   margin-bottom: 15px;
 }
 .form-horizontal {
-  --exercise-label-column: clamp(9rem, 38vw, 12rem);
-}
-.form-horizontal .form-group {
+  --exercise-label-column: clamp(9rem, 30vw, 10.5rem);
   align-items: center;
   column-gap: 0.75rem;
   display: grid;
   grid-template-columns: var(--exercise-label-column) max-content;
-  margin-bottom: 18px;
+  row-gap: 18px;
+}
+.form-horizontal .form-group {
+  margin-bottom: 0;
+}
+.form-horizontal .form-group.has-feedback {
+  display: contents;
+}
+.form-horizontal .form-group:not(.has-feedback) {
+  grid-column: 1 / -1;
 }
 .form-horizontal .control-label {
   font-weight: 700;
   justify-self: end;
-  max-width: var(--exercise-label-column);
   padding-right: 0;
   padding-top: 0;
   text-align: right;
+  white-space: nowrap;
   width: auto;
 }
 .form-horizontal .col-sm-10 {
   min-width: 0;
   padding-left: 0;
   position: relative;
+  width: auto;
+}
+.form-horizontal .form-control {
+  display: inline-block;
+  padding-right: 42.5px;
   width: auto;
 }
 .ekzerco3-tasko > li {

--- a/fonto/html/ekzerco1.html
+++ b/fonto/html/ekzerco1.html
@@ -53,9 +53,9 @@
           <label class="control-label col-sm-2" for="{{id}}" data-bs-toggle="popover" data-bs-placement="bottom" title="{{fontlingve if fontlingve is string else fontlingve|join(', ')}}" >{{esperante}}:</label>
           <div class="col-sm-10">
             {%- if fontlingve is string -%}
-              <input id="{{id}}" class="form-control" type="text" size="{{fontlingve|string|length}}" data-solvo="{{fontlingve}}"/>
+              <input id="{{id}}" class="form-control" type="text" size="{{(fontlingve|string|length) + 2}}" data-solvo="{{fontlingve}}"/>
             {%- elif fontlingve is iterable -%}
-              <input id="{{id}}" class="form-control" type="text" size="{{fontlingve[0]|string|length}}" data-solvo="{{fontlingve|join(' | ')}}"/>
+              <input id="{{id}}" class="form-control" type="text" size="{{(fontlingve[0]|string|length) + 2}}" data-solvo="{{fontlingve|join(' | ')}}"/>
             {%- endif -%}
             <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
           </div>

--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -62,7 +62,7 @@
                 <label class="control-label col-sm-2" for="{{id}}" 
                   data-bs-toggle="popover" data-bs-placement="bottom" title="{{esperante}}">{{fontlingve|join}}:</label>
                 <div class="col-sm-10">
-                  <input id="{{id}}" class="form-control" type="text" size="{{esperante|length}}" data-solvo="{{esperante}}"/>
+                  <input id="{{id}}" class="form-control" type="text" size="{{(esperante|length) + 2}}" data-solvo="{{esperante}}"/>
                   <span id="feedback-{{id}}" class="feedback-icon feedback-icon-remove" aria-hidden="true">✕</span>
                 </div>
               </div>

--- a/fonto/html/tabs.html
+++ b/fonto/html/tabs.html
@@ -1,7 +1,18 @@
+{% set tab_icons = {
+  'teksto': '📖',
+  'vortoj': '🗂️',
+  'gramatiko': '🧩',
+  'ekzerco1': '1️⃣',
+  'ekzerco2': '2️⃣',
+  'ekzerco3': '3️⃣'
+} %}
 <ul class="nav nav-tabs">
   {% for id, href, caption in tabs %}
     <li class="nav-item" role="presentation">
-    <a class="nav-link{% if id == active_tab %} active{% endif %}" href="{{tab_vojprefikso}}{{href}}">{{caption}}</a>
+    <a class="nav-link{% if id == active_tab %} active{% endif %}" href="{{tab_vojprefikso}}{{href}}" aria-label="{{caption}}">
+      <span class="tab-icon" aria-hidden="true">{{tab_icons[id]}}</span>
+      <span class="tab-label">{{caption}}</span>
+    </a>
     </li>
   {% endfor %}
 </ul>

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -138,3 +138,17 @@ test('ekzercaj dupunktoj vicigxas dekstre', async ({ page }) => {
     await expect(labelEdgeSpread).toBeLessThanOrEqual(1);
   }
 });
+
+test('ekzercaj tekstkampoj sekvas la size-valoron', async ({ page }) => {
+  for (const path of ['/en/06/ekzerco1/', '/en/06/ekzerco3/']) {
+    await page.goto(path);
+
+    const sizeOffsets = await page.locator('.form-horizontal input[type="text"]')
+      .evaluateAll((inputs) => inputs.map((input) => {
+        const firstAnswer = input.dataset.solvo.split(' | ')[0];
+        return Number(input.getAttribute('size')) - firstAnswer.length;
+      }));
+
+    await expect(sizeOffsets.every((offset) => offset === 2)).toBe(true);
+  }
+});

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -82,6 +82,15 @@ test('poŝtelefone nur aktiva leciona langeto montras etikedon', async ({ page }
   await expect(grammarTab).toContainText('Grammar');
 });
 
+test('aktiva leciona langeto havas kampecan fonon', async ({ page }) => {
+  await page.goto('/en/01/ekzerco3/');
+
+  await expect(page.getByRole('link', { name: 'Exercise 3' })).toHaveCSS(
+    'background-color',
+    'rgb(240, 240, 240)',
+  );
+});
+
 test('poŝtelefonaj lecionaj langetoj restas en unu vico kaj alteco', async ({ page }) => {
   await page.setViewportSize({ width: 360, height: 720 });
 
@@ -111,5 +120,21 @@ test('poŝtelefonaj lecionaj langetoj restas en unu vico kaj alteco', async ({ p
     });
 
     await expect(centerSpread).toBeLessThanOrEqual(1);
+  }
+});
+
+test('ekzercaj dupunktoj vicigxas dekstre', async ({ page }) => {
+  await page.setViewportSize({ width: 580, height: 720 });
+
+  for (const path of ['/en/06/ekzerco1/', '/en/06/ekzerco3/']) {
+    await page.goto(path);
+
+    const labelEdgeSpread = await page.locator('.form-horizontal .form-group.has-feedback .control-label')
+      .evaluateAll((labels) => {
+        const rights = labels.map((label) => Math.round(label.getBoundingClientRect().right));
+        return Math.max(...rights) - Math.min(...rights);
+      });
+
+    await expect(labelEdgeSpread).toBeLessThanOrEqual(1);
   }
 });

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -82,7 +82,7 @@ test('poŝtelefone nur aktiva leciona langeto montras etikedon', async ({ page }
   await expect(grammarTab).toContainText('Grammar');
 });
 
-test('poŝtelefonaj lecionaj langetoj restas en unu vico', async ({ page }) => {
+test('poŝtelefonaj lecionaj langetoj restas en unu vico kaj alteco', async ({ page }) => {
   await page.setViewportSize({ width: 360, height: 720 });
 
   const activeTabs = [
@@ -101,5 +101,15 @@ test('poŝtelefonaj lecionaj langetoj restas en unu vico', async ({ page }) => {
     });
 
     await expect(rowCount).toBe(1);
+
+    const centerSpread = await page.locator('.nav-tabs .nav-link').evaluateAll((links) => {
+      const centers = links.map((link) => {
+        const box = link.getBoundingClientRect();
+        return Math.round(box.top + box.height / 2);
+      });
+      return Math.max(...centers) - Math.min(...centers);
+    });
+
+    await expect(centerSpread).toBeLessThanOrEqual(1);
   }
 });

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -152,3 +152,25 @@ test('ekzercaj tekstkampoj sekvas la size-valoron', async ({ page }) => {
     await expect(sizeOffsets.every((offset) => offset === 2)).toBe(true);
   }
 });
+
+test('ekzercaj respondaj ikonoj restas en la kampoj', async ({ page }) => {
+  for (const path of ['/en/06/ekzerco1/', '/en/06/ekzerco3/']) {
+    await page.goto(path);
+
+    const iconPositions = await page.locator('.form-horizontal .col-sm-10')
+      .evaluateAll((cells) => cells.map((cell) => {
+        const input = cell.querySelector('input[type="text"]');
+        const icon = cell.querySelector('.feedback-icon');
+        const inputBox = input.getBoundingClientRect();
+        const iconBox = icon.getBoundingClientRect();
+
+        return {
+          insideInput: iconBox.left >= inputBox.left && iconBox.right <= inputBox.right,
+          rightGap: Math.round(inputBox.right - iconBox.right),
+        };
+      }));
+
+    await expect(iconPositions.every(({ insideInput }) => insideInput)).toBe(true);
+    await expect(iconPositions.every(({ rightGap }) => rightGap >= 5 && rightGap <= 25)).toBe(true);
+  }
+});

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -81,3 +81,25 @@ test('poŝtelefone nur aktiva leciona langeto montras etikedon', async ({ page }
   await expect(grammarTab).toContainText('🧩');
   await expect(grammarTab).toContainText('Grammar');
 });
+
+test('poŝtelefonaj lecionaj langetoj restas en unu vico', async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 720 });
+
+  const activeTabs = [
+    '/en/01/vortoj/',
+    '/en/01/ekzerco1/',
+    '/en/01/ekzerco2/',
+    '/en/01/ekzerco3/',
+  ];
+
+  for (const path of activeTabs) {
+    await page.goto(path);
+
+    const rowCount = await page.locator('.nav-tabs .nav-item').evaluateAll((items) => {
+      const tops = items.map((item) => Math.round(item.getBoundingClientRect().top));
+      return new Set(tops).size;
+    });
+
+    await expect(rowCount).toBe(1);
+  }
+});

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -53,3 +53,31 @@ test('poŝtelefona aldona menuo restas malhela', async ({ page }) => {
   await expect(menu).toBeVisible();
   await expect(menu).toHaveCSS('background-color', 'rgb(34, 34, 34)');
 });
+
+test('lecionaj langetoj montras ikonojn kun etikedoj sur labortablo', async ({ page }) => {
+  await page.goto('/en/01/');
+
+  const tabs = page.locator('.nav-tabs');
+
+  await expect(tabs.getByRole('link', { name: 'Text' })).toContainText('📖');
+  await expect(tabs.getByRole('link', { name: 'New words' })).toContainText('🗂️');
+  await expect(tabs.getByRole('link', { name: 'Grammar' })).toContainText('🧩');
+  await expect(tabs.getByRole('link', { name: 'Exercise 1' })).toContainText('1️⃣');
+  await expect(tabs.getByRole('link', { name: 'Exercise 2' })).toContainText('2️⃣');
+  await expect(tabs.getByRole('link', { name: 'Exercise 3' })).toContainText('3️⃣');
+});
+
+test('poŝtelefone nur aktiva leciona langeto montras etikedon', async ({ page }) => {
+  await page.setViewportSize({ width: 580, height: 720 });
+  await page.goto('/en/01/gramatiko/');
+
+  const textTab = page.getByRole('link', { name: 'Text' });
+  const grammarTab = page.getByRole('link', { name: 'Grammar' });
+
+  await expect(textTab.locator('.tab-icon')).toBeVisible();
+  await expect(textTab.locator('.tab-label')).toBeHidden();
+  await expect(grammarTab.locator('.tab-icon')).toBeVisible();
+  await expect(grammarTab.locator('.tab-label')).toBeVisible();
+  await expect(grammarTab).toContainText('🧩');
+  await expect(grammarTab).toContainText('Grammar');
+});


### PR DESCRIPTION
## Resumo
- Aldonas UTF-8-ikonojn al la lecionaj langetoj.
- En poŝtelefona larĝo neaktivaj langetoj montras nur ikonon; la aktiva montras ikonon kaj etikedon.
- Konservas alireblajn langetnomojn per aria-label.

## Kontroloj
- make check
- make check-ui
- make html-all
- make check-pwa
- git diff --check