### PR TITLE
Densigu labortablajn lecionajn langetojn

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -47,7 +47,10 @@ h3 {
 .nav-tabs .nav-link {
   align-items: center;
   display: inline-flex;
-  gap: 0.35rem;
+  gap: 0.3rem;
+  padding-left: 0.65rem;
+  padding-right: 0.65rem;
+  white-space: nowrap;
 }
 .nav-tabs .nav-link.active {
   background-color: var(--exercise-field-bg);


### PR DESCRIPTION
## Resumo
- Iom malgrandigas la horizontalan spacon inter ikonoj kaj etikedoj en lecionaj langetoj.
- Iom malgrandigas la horizontalan langet-paddingon ankaŭ sur labortablo.
- Malhelpas internan tekstan liniorompon en unuopaj langetoj, tiel ke /ru/01/ekzerco3/ restas en unu vico.

## Kontroloj
- make html LINGVO=ru
- loka Playwright-mezuro por /ru/01/ekzerco3/: 1 vico, 908 px el 930 px
- make check-ui
- make check
- git diff --check