### PR TITLE
Riparu gramatikan emfazon en HTML

### DIFF
--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -3,7 +3,6 @@
 
 import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 
@@ -19,14 +18,24 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 FONTO_DIR = ROOT_DIR / 'fonto'
 NODE_MODULES_DIR = ROOT_DIR / 'node_modules'
 OUTPUT_DIR = ROOT_DIR / 'eligo' / 'retejo'
-GRAMATIKA_EMFAZO_PATTERN = re.compile(r'__([^_\n]+?)__')
 
 
-def render_markdown(text, md):
-    html = md(text)
-    # Mistune ne traktas __...__ kiel emfazon ene de vortoj, ekz. labor__i__.
-    html = GRAMATIKA_EMFAZO_PATTERN.sub(r'<strong>\1</strong>', html)
-    return Markup(html)
+def morfema_emfazo(md):
+    def parse_morfema_emfazo(inline, match, state):
+        child_state = state.copy()
+        child_state.src = match.group('morfemo')
+        state.append_token({
+            'type': 'strong',
+            'children': inline.render(child_state),
+        })
+        return match.end()
+
+    md.inline.register(
+        'morfema_emfazo',
+        r'__(?P<morfemo>[^_\n]+?)__',
+        parse_morfema_emfazo,
+        before='emphasis',
+    )
 
 
 def render_page(name, enhavo, vojprefikso, env):
@@ -216,14 +225,14 @@ def generate_pwa():
 
 def generate_html(lingvo, enhavo, args, kopiu_statikan=True):
     eligo = {}
-    md = mistune.create_markdown()
+    md = mistune.create_markdown(plugins=[morfema_emfazo])
     versio = get_version_hash()
     enhavo['versio'] = versio
     if kopiu_statikan:
         copy_static_files(versio)
 
     env = jinja2.Environment(auto_reload=False)
-    env.filters['markdown'] = lambda text: render_markdown(text, md)
+    env.filters['markdown'] = lambda text: Markup(md(text))
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -3,6 +3,7 @@
 
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 
@@ -18,6 +19,14 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 FONTO_DIR = ROOT_DIR / 'fonto'
 NODE_MODULES_DIR = ROOT_DIR / 'node_modules'
 OUTPUT_DIR = ROOT_DIR / 'eligo' / 'retejo'
+GRAMATIKA_EMFAZO_PATTERN = re.compile(r'__([^_\n]+?)__')
+
+
+def render_markdown(text, md):
+    html = md(text)
+    # Mistune ne traktas __...__ kiel emfazon ene de vortoj, ekz. labor__i__.
+    html = GRAMATIKA_EMFAZO_PATTERN.sub(r'<strong>\1</strong>', html)
+    return Markup(html)
 
 
 def render_page(name, enhavo, vojprefikso, env):
@@ -214,7 +223,7 @@ def generate_html(lingvo, enhavo, args, kopiu_statikan=True):
         copy_static_files(versio)
 
     env = jinja2.Environment(auto_reload=False)
-    env.filters['markdown'] = lambda text: Markup(md(text))
+    env.filters['markdown'] = lambda text: render_markdown(text, md)
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
+GRAMATIKO_EMFAZO_PATTERN = re.compile(r'<em>labor<strong>i</strong></em>\s+–\s+to work')
 PWA_SERVICE_WORKER_PATTERN = re.compile(r'const PRECACHE_URLS = \[')
 BOOTSTRAP_PATTERN = re.compile(r'Bootstrap\s+v5\.3\.8')
 JQUERY_PATTERN = re.compile(r'jQuery v3\.7\.1')
@@ -109,7 +110,9 @@ def main():
     require_pattern(output_dir / 'vendor' / 'jquery' / 'jquery.min.js', JQUERY_PATTERN)
     require_pattern(output_dir / 'vendor' / 'jquery' / 'jquery-ui.min.js', JQUERY_UI_PATTERN)
     require_pattern(output_dir / 'vendor' / 'typeahead' / 'typeahead.bundle.min.js', TYPEAHEAD_PATTERN)
-    require_pattern(lingvo_dir / '01' / 'gramatiko' / 'index.html', GRAMATIKO_PATTERN)
+    gramatiko_path = lingvo_dir / '01' / 'gramatiko' / 'index.html'
+    require_pattern(gramatiko_path, GRAMATIKO_PATTERN)
+    require_pattern(gramatiko_path, GRAMATIKO_EMFAZO_PATTERN)
     require_apkg(lingvo_dir / 'eksporto' / (lingvo + '.apkg'))
 
     print('Sukcesis: kontrolis Markdown-, HTML- kaj Anki-eligon por ' + lingvo)


### PR DESCRIPTION
## Resumo
- Aldonas propran Mistune-inline-kromprogramon por la projektspecifa `__...__` morfema emfazo.
- Riparas kazojn kiel `*labor__i__*`, kiuj nun fariĝas `labor<strong>i</strong>` ene de kursiva vorto.
- Aldonas eligan kontrolon por la angla gramatika paĝo.

## Kontroloj
- rekta Python-testo por `*tablo__j__*`, `*labor__i__*` kaj `*__Ĉu__ vi sidas?*`
- make check
- make html LINGVO=de
- rg por konfirmi `labor<strong>i</strong> – arbeiten`
- make html-all
- make check-pwa
- git diff --check