### PR TITLE
Montru vortaron en mobila kapo

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -50,6 +50,15 @@ h3 {
   padding-bottom: 0;
   padding-top: 0;
 }
+.vortaro-form-mobile {
+  flex: 1 1 auto;
+  margin: 0 0.5rem;
+  min-width: 0;
+}
+.vortaro-form-mobile .twitter-typeahead,
+.vortaro-form-mobile .typeahead {
+  width: 100%;
+}
 .cxefpagxo {
   margin-bottom: 1.5rem;
   padding: 1.5rem 0;

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -26,6 +26,11 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand" href="/"><img id="logo" src="/assets/img/logo/logo-64.png" width="32" height="32" alt="Esperanto"></a>
+        <form class="vortaro-form-mobile d-flex d-lg-none">
+          {% set vortaro_id = 'vortaro-mobile' %}
+          {% include 'vortaro.html' %}
+          {% set vortaro_id = 'vortaro' %}
+        </form>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#site-navigation" aria-controls="site-navigation" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -66,7 +71,7 @@
             </li>
           </ul>
 
-          <form class="d-flex ms-lg-3 my-2 my-lg-0">
+          <form class="vortaro-form-desktop d-none d-lg-flex ms-lg-3 my-2 my-lg-0">
             {% include 'vortaro.html' %}
           </form>
           <form class="d-flex ms-lg-3 my-2 my-lg-0">

--- a/fonto/html/vortaro.html
+++ b/fonto/html/vortaro.html
@@ -1,1 +1,1 @@
-  <input id="vortaro" class="typeahead form-control" type="text" placeholder="{{enhavo.fasado['Vortaro']}}">
+  <input id="{{vortaro_id|default('vortaro')}}" class="typeahead form-control" type="text" placeholder="{{enhavo.fasado['Vortaro']}}">

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -42,6 +42,32 @@ test('vortaro montras tradukon dum tajpado', async ({ page }) => {
   await expect(suggestion).toBeVisible();
 });
 
+test('poŝtelefone vortaro restas inter logo kaj menuo', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 720 });
+  await page.goto('/en/01/');
+
+  const mobileDictionary = page.locator('#vortaro-mobile');
+  await expect(mobileDictionary).toBeVisible();
+  await expect(page.locator('#vortaro')).toBeHidden();
+
+  const logoBox = await page.locator('.navbar-brand').boundingBox();
+  const dictionaryBox = await mobileDictionary.boundingBox();
+  const menuBox = await page.getByRole('button', { name: 'Toggle navigation' }).boundingBox();
+
+  expect(dictionaryBox.x).toBeGreaterThan(logoBox.x + logoBox.width - 1);
+  expect(dictionaryBox.x + dictionaryBox.width).toBeLessThan(menuBox.x + 1);
+
+  await mobileDictionary.fill('est');
+
+  const suggestion = page.locator('.tt-menu .tt-suggestion').filter({
+    hasText: 'esti',
+  }).filter({
+    hasText: 'to be',
+  }).first();
+
+  await expect(suggestion).toBeVisible();
+});
+
 test('ŝvebi super tekstaj vortoj montras tradukajn ŝprucfenestrojn', async ({ page }) => {
   await page.goto('/en/01/');
 


### PR DESCRIPTION
## Resumo
- Aldonas apartan mobile-vortaran kampon inter la logo kaj la hamburger-menuo.
- Kaŝas la desktop-vortaron sur malgrandaj ekranoj, sed konservas ĝin en la ordinara desktop-menua loko.
- Faras la vortaran partialon id-agordebla por eviti du samajn HTML-id-ojn.
- Aldonas UI-teston por kontroli la mobile-pozicion kaj Typeahead-sugeston.

## Kontroloj
- `make check`
- `make check-ui`
- `make html-all`
- `make check-pwa`
- `git diff --check`