### PR TITLE
Fiksu navigilon supre

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -49,6 +49,9 @@ h3 {
   min-height: 52px;
   padding-bottom: 0;
   padding-top: 0;
+  position: sticky;
+  top: 0;
+  z-index: 1030;
 }
 .cxefpagxo {
   margin-bottom: 1.5rem;

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -82,6 +82,16 @@ test('poŝtelefona aldona menuo restas malhela', async ({ page }) => {
   await expect(menu).toHaveCSS('background-color', 'rgb(34, 34, 34)');
 });
 
+test('navigilo restas supre dum rulumado', async ({ page }) => {
+  await page.goto('/en/01/');
+
+  await page.evaluate(() => window.scrollTo(0, 700));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+  const navbarBox = await page.locator('.navbar').boundingBox();
+  expect(navbarBox.y).toBe(0);
+});
+
 test('lecionaj langetoj montras ikonojn kun etikedoj sur labortablo', async ({ page }) => {
   await page.goto('/en/01/');
 


### PR DESCRIPTION
## Resumo
- Faras la ĉefan navigilon sticky ĉe la supra rando de la fenestro.
- Uzas la ekzistantan Bootstrap-z-indeksan nivelon por ke menuoj kaj ŝprucfenestroj restu super enhavo.
- Aldonas UI-teston, kiu rulas la paĝon kaj kontrolas ke la navigilo restas ĉe top 0.

## Kontroloj
- make check
- make check-ui
- make html-all
- make check-pwa
- git diff --check