### PR TITLE
Tenu mobila vortaro en unu vico

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -131,6 +131,26 @@ h3 {
 }
 
 @media (max-width: 991.98px) {
+  .navbar .container-fluid {
+    align-items: center;
+    column-gap: 0.5rem;
+    display: grid;
+    grid-template-columns: auto minmax(7rem, 1fr) auto;
+  }
+  .navbar-brand {
+    margin-right: 0;
+  }
+  .vortaro-form-mobile {
+    grid-column: 2;
+    margin: 0;
+  }
+  .navbar-toggler {
+    grid-column: 3;
+    justify-self: end;
+  }
+  .navbar-collapse {
+    grid-column: 1 / -1;
+  }
   .navbar .dropdown-menu {
     --bs-dropdown-bg: #222;
     --bs-dropdown-border-width: 0;

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -43,7 +43,7 @@ test('vortaro montras tradukon dum tajpado', async ({ page }) => {
 });
 
 test('poŝtelefone vortaro restas inter logo kaj menuo', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 720 });
+  await page.setViewportSize({ width: 360, height: 720 });
   await page.goto('/en/01/');
 
   const mobileDictionary = page.locator('#vortaro-mobile');
@@ -53,9 +53,13 @@ test('poŝtelefone vortaro restas inter logo kaj menuo', async ({ page }) => {
   const logoBox = await page.locator('.navbar-brand').boundingBox();
   const dictionaryBox = await mobileDictionary.boundingBox();
   const menuBox = await page.getByRole('button', { name: 'Toggle navigation' }).boundingBox();
+  const navbarBox = await page.locator('.navbar').boundingBox();
 
   expect(dictionaryBox.x).toBeGreaterThan(logoBox.x + logoBox.width - 1);
   expect(dictionaryBox.x + dictionaryBox.width).toBeLessThan(menuBox.x + 1);
+  expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (logoBox.y + logoBox.height / 2))).toBeLessThan(3);
+  expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (menuBox.y + menuBox.height / 2))).toBeLessThan(3);
+  expect(navbarBox.height).toBeLessThan(70);
 
   await mobileDictionary.fill('est');
 


### PR DESCRIPTION
## Resumo
- Aranĝas la mobile-navbar per tri-kolumna reto: logo, fleksebla vortaro, hamburger-menuo.
- Malhelpas ke la vortara kampo prenu propran linion aŭ puŝu la hamburgeron malsupren.
- Streĉas la UI-teston al 360px kaj kontrolas ke logo, vortaro kaj menuo havas la saman vertikalan centron.

## Kontroloj
- make check
- make check-ui
- make html-all
- make check-pwa
- git diff --check