### PR TITLE
Movu lecionajn sagojn al titolo

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -43,11 +43,22 @@ h3 {
   margin-bottom: 10px;
   margin-top: 20px;
 }
+.leciona-kapo {
+  align-items: center;
+  column-gap: 0.75rem;
+  display: grid;
+  grid-template-columns: minmax(2.75rem, 1fr) auto minmax(2.75rem, 1fr);
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
 .leciona-titolo {
   align-items: center;
   column-gap: 0.5rem;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
+  justify-self: center;
+  margin: 0;
+  max-width: 100%;
 }
 .leciona-menuo {
   display: inline-flex;
@@ -92,6 +103,26 @@ h3 {
 }
 .leciona-titolo-teksto {
   min-width: 0;
+}
+.leciona-sago {
+  align-items: center;
+  display: flex;
+}
+.leciona-sago .btn {
+  align-items: center;
+  display: inline-flex;
+  font-size: 1rem;
+  height: 2.25rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  width: 2.25rem;
+}
+.leciona-sago-antauxa {
+  justify-content: end;
+}
+.leciona-sago-sekva {
+  justify-content: start;
 }
 
 .navbar {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -119,10 +119,10 @@ h3 {
   width: 2.25rem;
 }
 .leciona-sago-antauxa {
-  justify-content: end;
+  justify-content: start;
 }
 .leciona-sago-sekva {
-  justify-content: start;
+  justify-content: end;
 }
 
 .navbar {

--- a/fonto/html/ekzerco1.html
+++ b/fonto/html/ekzerco1.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/fonto/html/ekzerco2.html
+++ b/fonto/html/ekzerco2.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/fonto/html/leciona-titolo.html
+++ b/fonto/html/leciona-titolo.html
@@ -1,21 +1,35 @@
-<h2 id="leciono{{leciono_index}}" class="leciona-titolo" aria-label="{{leciono_index}}. {{leciono.teksto.titolo_string}}">
-  <span class="dropdown leciona-menuo">
-    <button class="btn btn-light dropdown-toggle leciona-menuo-butono" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-      {{leciono_index}}.
-    </button>
-    <ul class="dropdown-menu leciona-menuo-listo">
-      {% for menu_leciono in enhavo.lecionoj %}
-        <li>
-          <a class="dropdown-item" href="{{vojprefikso}}{{menu_leciono.indekso.cxene}}">
-            {{menu_leciono.indekso.cifre}}. {{menu_leciono.teksto.titolo_string}}
-          </a>
-        </li>
+<div class="leciona-kapo">
+  <span class="leciona-sago leciona-sago-antauxa">
+    {% if previous_path -%}
+      <a class="btn btn-outline-secondary" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}">◀︎</a>
+    {%- endif %}
+  </span>
+
+  <h2 id="leciono{{leciono_index}}" class="leciona-titolo" aria-label="{{leciono_index}}. {{leciono.teksto.titolo_string}}">
+    <span class="dropdown leciona-menuo">
+      <button class="btn btn-light dropdown-toggle leciona-menuo-butono" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        {{leciono_index}}.
+      </button>
+      <ul class="dropdown-menu leciona-menuo-listo">
+        {% for menu_leciono in enhavo.lecionoj %}
+          <li>
+            <a class="dropdown-item" href="{{vojprefikso}}{{menu_leciono.indekso.cxene}}">
+              {{menu_leciono.indekso.cifre}}. {{menu_leciono.teksto.titolo_string}}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </span>
+    <span class="leciona-titolo-teksto">
+      {% for vorto in leciono.teksto.titolo %}
+        {% include 'vorto.html' %}
       {% endfor %}
-    </ul>
+    </span>
+  </h2>
+
+  <span class="leciona-sago leciona-sago-sekva">
+    {% if next_path -%}
+      <a class="btn btn-outline-secondary" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}">▶︎</a>
+    {%- endif %}
   </span>
-  <span class="leciona-titolo-teksto">
-    {% for vorto in leciono.teksto.titolo %}
-      {% include 'vorto.html' %}
-    {% endfor %}
-  </span>
-</h2>
+</div>

--- a/fonto/html/leciona-titolo.html
+++ b/fonto/html/leciona-titolo.html
@@ -1,7 +1,7 @@
 <div class="leciona-kapo">
   <span class="leciona-sago leciona-sago-antauxa">
     {% if previous_path -%}
-      <a class="btn btn-outline-secondary" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}">◀︎</a>
+      <a class="btn btn-outline-secondary" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a>
     {%- endif %}
   </span>
 
@@ -29,7 +29,7 @@
 
   <span class="leciona-sago leciona-sago-sekva">
     {% if next_path -%}
-      <a class="btn btn-outline-secondary" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}">▶︎</a>
+      <a class="btn btn-outline-secondary" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a>
     {%- endif %}
   </span>
 </div>

--- a/fonto/html/pager.html
+++ b/fonto/html/pager.html
@@ -1,12 +1,12 @@
 <ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-  <li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
+  <li class="previous"><a class="btn btn-outline-secondary" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
   {%- else %}
   <li></li>
   {%- endif %} 
   <li></li>
   {% if next_path -%}
-  <li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
+  <li class="next"><a class="btn btn-outline-secondary" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
   {%- else %}
   <li></li>
   {%- endif %} 

--- a/fonto/html/pager.html
+++ b/fonto/html/pager.html
@@ -1,12 +1,12 @@
 <ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-  <li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+  <li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
   {%- else %}
   <li></li>
   {%- endif %} 
   <li></li>
   {% if next_path -%}
-  <li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+  <li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
   {%- else %}
   <li></li>
   {%- endif %} 

--- a/fonto/html/pagxonumerado-komentejo.html
+++ b/fonto/html/pagxonumerado-komentejo.html
@@ -1,18 +1,18 @@
 <ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-		<li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
+		<li class="previous"><a class="btn btn-outline-secondary" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
   {%- else %}
 		<li></li>
   {%- endif %} 
 
 	{% if enhavo.lingvoj[enhavo.lingvo].komentejo %} 
-		<li class="comments"><a class="btn btn-outline-secondary rounded-pill" href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
+		<li class="comments"><a class="btn btn-outline-secondary" href="javascript:show_disqus();">{{enhavo.fasado['Komentejo']}}</a></li>
   {%- else %}
 		<li></li>
   {%- endif %} 
 
   {% if next_path -%}
-		<li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
+		<li class="next"><a class="btn btn-outline-secondary" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
   {%- else %}
 		<li></li>
   {%- endif %} 

--- a/fonto/html/pagxonumerado-komentejo.html
+++ b/fonto/html/pagxonumerado-komentejo.html
@@ -1,6 +1,6 @@
 <ul class="pager list-unstyled align-items-center ps-0">
   {% if previous_path -%}
-		<li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}">{{enhavo.fasado['malantaŭen']}}</a></li>
+		<li class="previous"><a class="btn btn-outline-secondary rounded-pill" href="{{previous_path}}" aria-label="{{enhavo.fasado['malantaŭen']}}" title="{{enhavo.fasado['malantaŭen']}}">◀︎</a></li>
   {%- else %}
 		<li></li>
   {%- endif %} 
@@ -12,7 +12,7 @@
   {%- endif %} 
 
   {% if next_path -%}
-		<li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}">{{enhavo.fasado['antaŭen']}}</a></li>
+		<li class="next"><a class="btn btn-outline-secondary rounded-pill" href="{{next_path}}" aria-label="{{enhavo.fasado['antaŭen']}}" title="{{enhavo.fasado['antaŭen']}}">▶︎</a></li>
   {%- else %}
 		<li></li>
   {%- endif %} 

--- a/fonto/html/teksto.html
+++ b/fonto/html/teksto.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/fonto/html/vortoj.html
+++ b/fonto/html/vortoj.html
@@ -10,8 +10,6 @@
 
 {% block content %}
 
-  {% include 'pager.html' %}
-
   {% include 'leciona-titolo.html' %}
 
   {% include 'tabs.html' %}

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -173,6 +173,7 @@ test('lecionaj sagoj estas apud centrita titolo', async ({ page }) => {
 
   const header = page.locator('.leciona-kapo');
   await expect(header.getByRole('link', { name: 'Forward' })).toHaveText('▶︎');
+  await expect(header.getByRole('link', { name: 'Forward' })).toHaveAttribute('title', 'forward');
   await expect(header.getByRole('link', { name: 'Back' })).toHaveCount(0);
 
   const metrics = await header.evaluate((row) => {
@@ -182,17 +183,45 @@ test('lecionaj sagoj estas apud centrita titolo', async ({ page }) => {
 
     return {
       nextCenterSpread: Math.abs((next.top + next.height / 2) - (title.top + title.height / 2)),
+      nextRightSpread: Math.abs(rowBox.right - next.right),
       titleCenterSpread: Math.abs((title.left + title.width / 2) - (rowBox.left + rowBox.width / 2)),
     };
   });
 
   expect(metrics.nextCenterSpread).toBeLessThanOrEqual(2);
+  expect(metrics.nextRightSpread).toBeLessThanOrEqual(2);
   expect(metrics.titleCenterSpread).toBeLessThanOrEqual(2);
 
   await page.goto('/en/02/');
   const secondHeader = page.locator('.leciona-kapo');
   await expect(secondHeader.getByRole('link', { name: 'Back' })).toHaveText('◀︎');
+  await expect(secondHeader.getByRole('link', { name: 'Back' })).toHaveAttribute('title', 'back');
   await expect(secondHeader.getByRole('link', { name: 'Forward' })).toHaveText('▶︎');
+  await expect(secondHeader.getByRole('link', { name: 'Forward' })).toHaveAttribute('title', 'forward');
+
+  const edgeMetrics = await secondHeader.evaluate((row) => {
+    const previous = row.querySelector('.leciona-sago-antauxa .btn').getBoundingClientRect();
+    const next = row.querySelector('.leciona-sago-sekva .btn').getBoundingClientRect();
+    const rowBox = row.getBoundingClientRect();
+
+    return {
+      previousLeftSpread: Math.abs(previous.left - rowBox.left),
+      nextRightSpread: Math.abs(rowBox.right - next.right),
+    };
+  });
+
+  expect(edgeMetrics.previousLeftSpread).toBeLessThanOrEqual(2);
+  expect(edgeMetrics.nextRightSpread).toBeLessThanOrEqual(2);
+});
+
+test('malsupra pagxilo uzas sagojn kun tradukitaj konsiletoj', async ({ page }) => {
+  await page.goto('/en/02/');
+
+  const pager = page.locator('ul.pager');
+  await expect(pager.getByRole('link', { name: 'Back' })).toHaveText('◀︎');
+  await expect(pager.getByRole('link', { name: 'Back' })).toHaveAttribute('title', 'back');
+  await expect(pager.getByRole('link', { name: 'Forward' })).toHaveText('▶︎');
+  await expect(pager.getByRole('link', { name: 'Forward' })).toHaveAttribute('title', 'forward');
 });
 
 test('leciona titolo ne falas sub la butonon dum linisalto', async ({ page }) => {

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -168,6 +168,33 @@ test('leciona titolo malfermas lecionliston', async ({ page }) => {
   await expect(lessonMenu.getByRole('link', { name: /^12\./ })).toHaveAttribute('href', '/en/12');
 });
 
+test('lecionaj sagoj estas apud centrita titolo', async ({ page }) => {
+  await page.goto('/en/01/');
+
+  const header = page.locator('.leciona-kapo');
+  await expect(header.getByRole('link', { name: 'Forward' })).toHaveText('▶︎');
+  await expect(header.getByRole('link', { name: 'Back' })).toHaveCount(0);
+
+  const metrics = await header.evaluate((row) => {
+    const title = row.querySelector('.leciona-titolo').getBoundingClientRect();
+    const next = row.querySelector('.leciona-sago-sekva .btn').getBoundingClientRect();
+    const rowBox = row.getBoundingClientRect();
+
+    return {
+      nextCenterSpread: Math.abs((next.top + next.height / 2) - (title.top + title.height / 2)),
+      titleCenterSpread: Math.abs((title.left + title.width / 2) - (rowBox.left + rowBox.width / 2)),
+    };
+  });
+
+  expect(metrics.nextCenterSpread).toBeLessThanOrEqual(2);
+  expect(metrics.titleCenterSpread).toBeLessThanOrEqual(2);
+
+  await page.goto('/en/02/');
+  const secondHeader = page.locator('.leciona-kapo');
+  await expect(secondHeader.getByRole('link', { name: 'Back' })).toHaveText('◀︎');
+  await expect(secondHeader.getByRole('link', { name: 'Forward' })).toHaveText('▶︎');
+});
+
 test('leciona titolo ne falas sub la butonon dum linisalto', async ({ page }) => {
   await page.setViewportSize({ width: 260, height: 720 });
   await page.goto('/en/09/');


### PR DESCRIPTION
## Resumo
- Forigas la supran tekstan pagxilon el lecionaj pagxoj.
- Enmetas la antauxan/sekvan navigadon en la lecionan titollinion.
- Montras la sagojn kiel `◀︎` kaj `▶︎`, vicigitajn meze apud la titolo.
- Centrigas la titolgrupon kun lecionnumero kaj titolo.
- Aldonas UI-kontrolojn por sagoj, centrigo kaj titola linisalto.

## Kontroloj
- `make check`
- `make check-ui`
- `make html-all`
- `make check-pwa`
- `git diff --check`