### PR TITLE
Tenu supran navigilon unulinia

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -134,15 +134,17 @@ h3 {
   top: 0;
   z-index: 1030;
 }
-.navbar-enhavo {
+.navbar > .navbar-enhavo {
   align-items: center;
   display: flex;
   gap: 0.75rem;
   min-width: 0;
+  flex-wrap: nowrap;
 }
 .navbar-brand {
   align-items: center;
   display: inline-flex;
+  flex: 0 0 auto;
   gap: 0.5rem;
   margin-right: 0;
   min-width: 0;
@@ -153,21 +155,24 @@ h3 {
 .navbar-iloj {
   align-items: center;
   display: flex;
+  flex: 1 1 auto;
   gap: 0.4rem;
   margin-left: auto;
   min-width: 0;
 }
 .vortaro-form {
-  flex: 0 1 18rem;
-  min-width: 8rem;
+  flex: 1 1 18rem;
+  min-width: 4.5rem;
 }
 .vortaro-form .twitter-typeahead,
 .vortaro-form .typeahead {
+  min-width: 0;
   width: 100%;
 }
 .navbar-ikona-butono {
   align-items: center;
   display: inline-flex;
+  flex: 0 0 auto;
   height: 2.375rem;
   justify-content: center;
   padding-left: 0.55rem;
@@ -274,11 +279,16 @@ h3 {
 }
 
 @media (max-width: 575.98px) {
-  .navbar-enhavo {
+  .navbar > .navbar-enhavo {
     gap: 0.45rem;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
   }
   .navbar-iloj {
     gap: 0.25rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    margin-left: 0;
   }
   .vortaro-form {
     flex-basis: auto;

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -42,29 +42,32 @@ test('vortaro montras tradukon dum tajpado', async ({ page }) => {
   await expect(suggestion).toBeVisible();
 });
 
-test('poŝtelefone vortaro restas inter logo kaj cxiamaj butonoj', async ({ page }) => {
-  await page.setViewportSize({ width: 360, height: 720 });
-  await page.goto('/en/01/');
+test('poŝtelefone vortaro restas inter logo kaj cxiamaj butonoj en unu linio', async ({ page }) => {
+  for (const width of [320, 360, 390]) {
+    await page.setViewportSize({ width, height: 720 });
+    await page.goto('/en/01/');
 
-  const dictionary = page.locator('#vortaro');
-  await expect(dictionary).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Toggle navigation' })).toHaveCount(0);
+    const dictionary = page.locator('#vortaro');
+    await expect(dictionary).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Toggle navigation' })).toHaveCount(0);
 
-  const logoBox = await page.locator('.navbar-brand').boundingBox();
-  const dictionaryBox = await dictionary.boundingBox();
-  const appendixBox = await page.getByRole('button', { name: 'Appendix' }).boundingBox();
-  const languageBox = await page.getByRole('button', { name: 'Elekti alian lingvon' }).boundingBox();
-  const navbarBox = await page.locator('.navbar').boundingBox();
+    const logoBox = await page.locator('.navbar-brand').boundingBox();
+    const dictionaryBox = await dictionary.boundingBox();
+    const appendixBox = await page.getByRole('button', { name: 'Appendix' }).boundingBox();
+    const languageBox = await page.getByRole('button', { name: 'Elekti alian lingvon' }).boundingBox();
+    const navbarBox = await page.locator('.navbar').boundingBox();
 
-  expect(dictionaryBox.x).toBeGreaterThan(logoBox.x + logoBox.width - 1);
-  expect(dictionaryBox.x + dictionaryBox.width).toBeLessThan(appendixBox.x + 1);
-  expect(appendixBox.x + appendixBox.width).toBeLessThan(languageBox.x + languageBox.width + 1);
-  expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (logoBox.y + logoBox.height / 2))).toBeLessThan(3);
-  expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (appendixBox.y + appendixBox.height / 2))).toBeLessThan(3);
-  expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (languageBox.y + languageBox.height / 2))).toBeLessThan(3);
-  expect(navbarBox.height).toBeLessThan(70);
+    expect(dictionaryBox.x).toBeGreaterThan(logoBox.x + logoBox.width - 1);
+    expect(dictionaryBox.x + dictionaryBox.width).toBeLessThan(appendixBox.x + 1);
+    expect(appendixBox.x + appendixBox.width).toBeLessThan(languageBox.x + languageBox.width + 1);
+    expect(languageBox.x + languageBox.width).toBeLessThanOrEqual(width);
+    expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (logoBox.y + logoBox.height / 2))).toBeLessThan(3);
+    expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (appendixBox.y + appendixBox.height / 2))).toBeLessThan(3);
+    expect(Math.abs((dictionaryBox.y + dictionaryBox.height / 2) - (languageBox.y + languageBox.height / 2))).toBeLessThan(3);
+    expect(navbarBox.height).toBeLessThan(60);
+  }
 
-  await dictionary.fill('est');
+  await page.locator('#vortaro').fill('est');
 
   const suggestion = page.locator('.tt-menu .tt-suggestion').filter({
     hasText: 'esti',


### PR DESCRIPTION
## Resumo
- Malvastigas la vortaran kampon poŝtelefone kiam necesas.
- Uzas pli specifan regulon por superi la Bootstrap-enhavujan flex-aranĝon.
- Fiksas poŝtelefonan navbar-enhavon al unu grid-linio: logo, vortaro, 📎, 🌐.
- Plifortigas UI-teston por 320, 360 kaj 390 px larĝoj.

## Kontroloj
- `make check`
- `make check-ui`
- `git diff --check`