### PR TITLE
Aldonu kaŝmemor-busting al propraj JS- kaj CSS-dosieroj

### DIFF
--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -25,7 +25,7 @@
       href="/assets/img/logo/favicon-16x16.png"
     />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link href="assets/css/main.css" rel="stylesheet" />
+    <link href="assets/css/main.css?versio={{versio}}" rel="stylesheet" />
   </head>
   <body class="cxefpagxo-korpo">
     <nav class="navbar navbar-dark bg-dark">
@@ -148,7 +148,7 @@
     <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
-    <script src="assets/js/cxefpagxo.js"></script>
+    <script src="assets/js/cxefpagxo.js?versio={{versio}}"></script>
 
     <!-- 100% privacy-first analytics -->
     <script

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -22,8 +22,8 @@
       href="/assets/img/logo/favicon-16x16.png"
     />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link href="{{vojprefikso}}../assets/css/main.css?v=2" rel="stylesheet" />
-    <link href="{{vojprefikso}}../assets/css/vortaro.css" rel="stylesheet" />
+    <link href="{{vojprefikso}}../assets/css/main.css?versio={{enhavo.versio}}" rel="stylesheet" />
+    <link href="{{vojprefikso}}../assets/css/vortaro.css?versio={{enhavo.versio}}" rel="stylesheet" />
   </head>
   <body>
     <nav class="navbar navbar-dark bg-dark">
@@ -175,9 +175,9 @@
 
     <script src="/vendor/typeahead/typeahead.bundle.min.js"></script>
 
-    <script src="{{vojprefikso}}../assets/js/main.js"></script>
-    <script src="{{vojprefikso}}js/vortlisto.js"></script>
-    <script src="{{vojprefikso}}../assets/js/vortaro.js"></script>
+    <script src="{{vojprefikso}}../assets/js/main.js?versio={{enhavo.versio}}"></script>
+    <script src="{{vojprefikso}}js/vortlisto.js?versio={{enhavo.versio}}"></script>
+    <script src="{{vojprefikso}}../assets/js/vortaro.js?versio={{enhavo.versio}}"></script>
 
     <!-- 100% privacy-first analytics -->
     <script


### PR DESCRIPTION
## Resumo

- Aldonas `?versio=<commit-hash>` al ĉiuj propraj JS- kaj CSS-dosieroj en `layout.html` kaj `cxefpagxo.html`
- Uzas jam ekzistantan `enhavo.versio` (resp. `versio` en cxefpagxo) kiu enhavas la mallongigitan git-haŝon
- Vendoraj kaj eksteraj skriptoj (Bootstrap, jQuery, SimpleAnalytics k.a.) restas senŝanĝaj

## Testplano

- [x] `make check` sukcesas
- [ ] Kontrolu ke la kaŝmemor-parametro aperas en la generitaj HTML-dosieroj

🤖 Generated with [Claude Code](https://claude.com/claude-code)