### PR TITLE
Plibonigu lecionajn titolojn kaj tiparon

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -18,6 +18,7 @@
 body {
   display: flex;
   flex-direction: column;
+  font-family: 'Fira Sans', sans-serif;
   font-size: 18px;
   line-height: 30px;
   min-height: 100vh;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -106,6 +106,7 @@ h3 {
 }
 .leciona-titolo-teksto {
   min-width: 0;
+  text-wrap: balance;
 }
 .leciona-sago {
   align-items: center;

--- a/fonto/html/cxefpagxo.html
+++ b/fonto/html/cxefpagxo.html
@@ -10,6 +10,8 @@
       bazoj']}}
     </title>
 
+    <link href="/vendor/fira-sans/400.css" rel="stylesheet" />
+    <link href="/vendor/fira-sans/700.css" rel="stylesheet" />
     <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -7,6 +7,8 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{% block title %} {% endblock %}</title>
 
+    <link href="/vendor/fira-sans/400.css" rel="stylesheet" />
+    <link href="/vendor/fira-sans/700.css" rel="stylesheet" />
     <link href="/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -232,6 +232,17 @@ def copy_static_files(versio, cxefpagxa_fasado, cxefpagxaj_lingvoj):
     for fonto, celo in vendor_files:
         copy_vendor_file(fonto, celo)
 
+    fira_fonto = NODE_MODULES_DIR / '@fontsource' / 'fira-sans'
+    fira_celo = OUTPUT_DIR / 'vendor' / 'fira-sans'
+    if not fira_fonto.is_dir():
+        raise SystemExit('Mankas @fontsource/fira-sans. Rulu `make install`.')
+    fira_celo.mkdir(parents=True, exist_ok=True)
+    for pezo in ('400', '700'):
+        shutil.copy2(fira_fonto / f'{pezo}.css', fira_celo / f'{pezo}.css')
+    (fira_celo / 'files').mkdir(parents=True, exist_ok=True)
+    for f in (fira_fonto / 'files').glob('fira-sans-*-[47]00-normal.*'):
+        shutil.copy2(f, fira_celo / 'files' / f.name)
+
 
 def generate_pwa():
     pwa.write_service_worker(OUTPUT_DIR, get_version_hash())

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "kurso-zagreba-metodo",
       "dependencies": {
+        "@fontsource/fira-sans": "^5.2.7",
         "bootstrap": "5.3.8",
         "jquery": "3.7.1",
         "jquery-ui-dist": "1.13.3",
@@ -16,6 +17,15 @@
       },
       "engines": {
         "node": "24.14.1"
+      }
+    },
+    "node_modules/@fontsource/fira-sans": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/fira-sans/-/fira-sans-5.2.7.tgz",
+      "integrity": "sha512-5DE4AealD/VnbwdzMgnpWfCttMQBbteNiK9DCJE7cVwZEbDTPLUoFDMMvxNQ498nZc5in7Mta9c/s+3Ehh0BAg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@playwright/test": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": "24.14.1"
   },
   "dependencies": {
+    "@fontsource/fira-sans": "^5.2.7",
     "bootstrap": "5.3.8",
     "jquery": "3.7.1",
     "jquery-ui-dist": "1.13.3",


### PR DESCRIPTION
## Resumo

- `text-wrap: balance` sur leciona titolteksto — linirompoj estas ekvilibrigitaj (ekz. „La amikino / de Marko" anstataŭ „La amikino de / Marko")
- Aldonu Fira Sans kiel memstaran vendordosieron (`@fontsource/fira-sans`, pezoj 400 kaj 700)
- La tiparo estas kopiata al `vendor/fira-sans/` dum la konstruo, sen ekstera retpeto

## Testplano

- [x] `make check` sukcesas
- [ ] Kontrolu linirompojn en leciona titolo sur mallarĝa ekrano
- [ ] Kontrolu ke Fira Sans aperas en la retejo

🤖 Generated with [Claude Code](https://claude.com/claude-code)