### PR TITLE
Plibonigu germanajn gramatik-klarigojn laŭ pedagogiaj normoj

### DIFF
--- a/enhavo/tradukenda/de/gramatiko/01.md
+++ b/enhavo/tradukenda/de/gramatiko/01.md
@@ -1,145 +1,166 @@
 # Aussprache
 
-Esperanto hat eine buchstabengetreue Aussprache. Die Vokale (a, e, i, o, u) werden ausgesprochen wie in den Wörtern Tante, Test, Titel, Toto, Turnus. Die Vokale dürfen nicht gedehnt gesprochen werden. Der Halbvokal ŭ kommt nur in Verbindung mit a oder e vor (aŭto, aŭtoro, Eŭropo, neŭtrala). eŭ in diesen Wörtern wird nicht wie im Deutschen als "oj", sondern – wie geschrieben – als e mit nachklingendem schwachem u gesprochen. Das ŭ wird wie w in englisch water gesprochen. Bei den Konsonanten müssen stimmhafte und stimmlose Laute genau unterschieden werden. Das r soll, wenn möglich, als gerolltes Zungenspitzen-r gesprochen werden, wie in einigen deutschen Dialekten, im Polnischen, Russischen, Italienischen oder Spanischen. Folgende Lautzeichen weichen von unserem Alphabet ab:
+Esperanto wird gesprochen, wie es geschrieben wird: Jeder Buchstabe steht für genau einen Laut – ohne Ausnahmen. Wer die folgenden Regeln einmal kennt, kann jedes Wort sofort richtig aussprechen.
 
-- C – z (*citrono* – Zitrone)
-- Ĉ – tsch (*puĉo* – Putsch)
-- Ŝ – sch (*ŝafo* – Schaf)
-- Ĵ – stimmhaftes sch (*ĵurnalo* – Journal)
-- Z – stimmhaftes s (*rozo* – Rose)
-- V – w (*vagono* – Waggon)
-- Ĝ – dsch (*ĝangalo* – Dschungel)
-- Ĥ – ch (*eĥo* – Echo)
+## Vokale
 
-International verbreitete Fremdwörter werden ins Esperanto übernommen und erhalten nur die entsprechende Esperantoschreibung und Endung: 
-  
-- *telefono*
-- *naturo*
-- *internacia*
+Die fünf Vokale *a, e, i, o, u* werden kurz und klar gesprochen, wie in den Wörtern Tante, Test, Titel, Toto, Turnus. Sie werden nie gedehnt.
 
+## Der Halbvokal *ŭ*
+
+*ŭ* klingt wie das w in englisch *water* und kommt nur nach *a* oder *e* vor:
+
+- *aŭto*, *aŭtoro*, *Eŭropo*, *neŭtrala*
+
+**Achtung:** *eŭ* wird nicht wie das deutsche „eu" (oj) gesprochen, sondern – wie geschrieben – als *e* mit kurz nachklingendem *u*.
+
+## Abweichende Lautzeichen
+
+Bei den Konsonanten müssen stimmhafte und stimmlose Laute genau unterschieden werden. Folgende Lautzeichen weichen vom deutschen Alphabet ab:
+
+- *C* – z (*citrono* – Zitrone)
+- *Ĉ* – tsch (*puĉo* – Putsch)
+- *Ŝ* – sch (*ŝafo* – Schaf)
+- *Ĵ* – stimmhaftes sch (*ĵurnalo* – Journal)
+- *Z* – stimmhaftes s (*rozo* – Rose)
+- *V* – w (*vagono* – Waggon)
+- *Ĝ* – dsch (*ĝangalo* – Dschungel)
+- *Ĥ* – ch (*eĥo* – Echo)
+
+**Stolperfallen für Deutschsprachige:** *c* ist immer „z" (nie „k"!) – *citrono* klingt wie „Zitrono". *v* ist immer „w" – *vagono* klingt wie „Wagono". Und *z* ist das stimmhafte (summende) s wie in „Rose", nicht das scharfe ß.
+
+**Eselsbrücke:** Die vier „Hut-Buchstaben" *ĉ, ŝ, ĝ, ĵ* bekommen durch ihr Dächlein einen Zischlaut – ganz wie sch/tsch/dsch.
+
+Das *r* soll, wenn möglich, als gerolltes Zungenspitzen-*r* gesprochen werden – wie in einigen deutschen Dialekten, im Polnischen, Russischen, Italienischen oder Spanischen.
+
+International verbreitete Fremdwörter übernimmt Esperanto unverändert; nur Schreibung und Endung passen sich an:
+
+- *telefono*, *naturo*, *internacia*
 
 # Betonung
 
-Die Betonung liegt auf der vorletzten Silbe. Nebeneinander stehende Vokale verschmelzen nicht, sondern bilden gesonderte Silben: Daher 
-  
+Betont wird immer die **vorletzte Silbe** – ganz ohne Ausnahme (wie im Italienischen). Nebeneinanderstehende Vokale verschmelzen nicht, sondern bilden gesonderte Silben:
+
 - *instr__u__-i*
 - *m__i__-a*
 - *famil__i__-o*
 
-
 # Wortarten
 
-Die Wortart erkennt man sofort an der Wortendung:
+Das ist der Schlüssel zu Esperanto: **Die Endung verrät die Wortart.** Man sieht jedem Wort sofort an, was es ist.
 
-## Hauptwort: *-o*
+## Hauptwort: *__-o__*
 
-  - *amiko* – Freund
-  - *laboro* – Arbeit
-  - *libro* – Buch
-  - *skribo* – Schrift
+- *amiko* – Freund
+- *laboro* – Arbeit
+- *libro* – Buch
+- *skribo* – Schrift
 
-## Zeitwort in der Grundform (Infinitiv): *-i*
+## Zeitwort in der Grundform (Infinitiv): *__-i__*
 
-  - *labori* – arbeiten
-  - *sidi* – sitzen
+- *labori* – arbeiten
+- *sidi* – sitzen
 
-## Zeitwort in der Gegenwart: *-as*
+## Zeitwort in der Gegenwart: *__-as__*
 
-  - *li sidas* – er sitzt
-  - *ili laboras* – sie arbeiten
-  - *mi lernas* – ich lerne
+- *li sidas* – er sitzt
+- *ili laboras* – sie arbeiten
+- *mi lernas* – ich lerne
+
+**Merke:** Anders als im Deutschen bleibt die Endung *-as* für jede Person gleich: *mi lernas, vi lernas, li lernas* … Es gibt nichts auswendig zu lernen.
 
 # Mehrzahl
 
-Die Mehrzahl wird bei Hauptwort und Eigenschaftswort durch Anfügen des "j" gebildet: 
-  
+Die Mehrzahl bildet man bei Haupt- und Eigenschaftswörtern einfach durch angehängtes *__-j__*:
+
 - *amiko* – Freund / *amiko__j__* – Freunde
-  
+
+**Achtung:** Die Mehrzahl ist *-j* (gesprochen wie das „j" in „ja"), nicht *-s* wie im Englischen. *amikoj* klingt also wie „amiko-j".
 
 # Artikel
 
-Es gibt nur den bestimmten Artikel __la__, der für Ein- und Mehrzahl gleich ist:
+Es gibt nur den bestimmten Artikel *__la__* – gleich für Einzahl, Mehrzahl und jedes Geschlecht. Kein der/die/das zum Auswendiglernen:
 
-- *la amiko*  – der Freund
-- *la amikoj*  – die Freunde
-- *la ĉambro*  – das Zimmer
+- *la amiko* – der Freund
+- *la amikoj* – die Freunde
+- *la ĉambro* – das Zimmer
 
-Der unbestimmte Artikel im Deutschen wird nicht übersetzt: 
+Einen unbestimmten Artikel („ein/eine") kennt Esperanto nicht; er bleibt unübersetzt:
 
-- Es ist ein Schreibtisch – *Ĝi estas skribotablo.*
-
+- *Ĝi estas skribotablo.* – Es ist ein Schreibtisch.
 
 # Ja / Nein
 
-Die Antwort auf einfache Fragen lautet *__jes__* – ja oder *__ne__* – nein:
+Die Antwort auf einfache Fragen lautet *__jes__* (ja) oder *__ne__* (nein):
 
 - *__Jes__, la patro estas en la ĉambro.*
 - *__Ne__, la libro __ne__ estas sur la tablo.*
 
-Die Verneinung "ne" steht in der Regel vor dem Zeitwort.
-
+Die Verneinung *ne* steht in der Regel direkt vor dem Zeitwort.
 
 # Fürwörter
 
-Persönliche Fürwörter / Besitz anzeigende Fürwörter
+Die besitzanzeigenden Fürwörter entstehen ganz regelmäßig – aus dem persönlichen Fürwort plus Endung *__-a__*:
 
-- *mi*         – ich         / *mia*     – mein
-- *vi*         – du          / *via*     – dein
-- *li, ŝi, ĝi* – er, sie, es / *lia, ŝia, ĝia* – sein, ihr
-- *ni*         – wir         / *nia*     – unser
-- *vi*         – ihr         / *via*     – euer
-- *ili*        – sie         / *ilia*    – ihr
+- *mi* – ich / *mi__a__* – mein
+- *vi* – du / *vi__a__* – dein
+- *li, ŝi, ĝi* – er, sie, es / *li__a__, ŝi__a__, ĝi__a__* – sein, ihr
+- *ni* – wir / *ni__a__* – unser
+- *vi* – ihr / *vi__a__* – euer
+- *ili* – sie / *ili__a__* – ihr
 
-Sächliches Geschlecht haben nur Dinge und Tiere.
-
+**Hinweis:** *ĝi* (es) steht nur für Dinge und Tiere. Ein grammatisches Geschlecht wie im Deutschen (der/die/das) gibt es nicht.
 
 # sein – *esti*
 
-*Estas* ist die Gegenwartsform des Zeitwortes *esti* – sein.
+*Estas* ist die Gegenwartsform des Zeitwortes *esti* (sein) – und lautet für alle Personen gleich:
 
-- *mi estas*	 – ich bin
-- *vi estas*	 – du bist
-- *li/ŝi/ĝi estas*	 – er/sie/es ist
-- *ni estas*	 – wir sind
-- *vi estas*	 – ihr seid
-- *ili estas*	 – sie sind
+- *mi estas* – ich bin
+- *vi estas* – du bist
+- *li/ŝi/ĝi estas* – er/sie/es ist
+- *ni estas* – wir sind
+- *vi estas* – ihr seid
+- *ili estas* – sie sind
+
+**Merke:** Ein Verb, eine Form – *estas* gilt für alle. Das deutsche „bin/bist/ist/sind/seid" schrumpft auf ein einziges Wort.
 
 # Fragewörter
 
-Esperanto-Fragewörter beginnen mit ki-.
+Esperanto-Fragewörter beginnen alle mit *__ki-__*:
 
 - *kiu?* – wer? welcher?
 - *kio?* – was?
+
+Beispiele:
+
 - *Kiu vi estas?* – Wer bist du?
 - *Kio estas sur la tablo?* – Was ist auf dem Tisch?
 
-
 # *Ĉu?*
 
-Die Stellung der Satzteile ist im Esperanto frei – in der Regel wird die Reihenfolge Subjekt-Prädikat-Objekt bevorzugt. Eine andere Reihenfolge dient meist der Hervorhebung des ersten Satzteils. Während im Deutschen einfache Fragesätze durch Umstellung entstehen, wird im Esperanto *ĉu* vorangestellt und die ursprüngliche Wortreihenfolge erhalten.
+Im Deutschen bildet man einfache Fragen durch Umstellung („Sie arbeiten." → „Arbeiten sie?"). Im Esperanto bleibt die Wortstellung dagegen erhalten – man stellt einfach *__ĉu__* voran:
 
-- Sie arbeiten jetzt. – *Ili nun laboras.*
-- Arbeiten sie jetzt? – *__Ĉu__ ili nun laboras?*
-- Unterrichtet die Mutter? – *__Ĉu__ la patrino instruas?*
+- *Ili nun laboras.* – Sie arbeiten jetzt.
+- *__Ĉu__ ili nun laboras?* – Arbeiten sie jetzt?
+- *__Ĉu__ la patrino instruas?* – Unterrichtet die Mutter?
 
+**Eselsbrücke:** *ĉu* ist das Fragezeichen am Satzanfang – steht es vorn, wird der ganze Satz zur Ja/Nein-Frage.
 
-# Nachsilbe *-ist*
+Die Reihenfolge der Satzteile ist im Esperanto frei; in der Regel wird Subjekt – Prädikat – Objekt bevorzugt. Eine andere Reihenfolge dient meist der Hervorhebung des ersten Satzteils.
 
-zeigt den Beruf oder eine weltanschauliche Einstellung:
+# Nachsilbe *__-ist__*
+
+bezeichnet den Beruf oder eine weltanschauliche Einstellung – ganz wie das deutsche „-ist":
 
 - *hotel__ist__o* – Hotelier
 - *esperant__ist__o* – Esperantist
 - *polic__ist__o* – Polizist
 - *social__ist__o* – Sozialist
 
+# Nachsilbe *__-in__*
 
-# Nachsilbe *-in*
+bedeutet „weiblich". **Eselsbrücke:** Es ist dasselbe „-in" wie in der deutschen „Lehrerin" oder „Schülerin":
 
-hat die Bedeutung "weiblich":
-
-- *patro* – Vater
-    - *patr__in__o* – Mutter
-- *lernanto* – Schüler
-    - *lernant__in__o* – Schülerin
-- *instruisto* – Lehrer
-    - *instruist__in__o* – Lehrerin
+- *patro* – Vater / *patr__in__o* – Mutter
+- *lernanto* – Schüler / *lernant__in__o* – Schülerin
+- *instruisto* – Lehrer / *instruist__in__o* – Lehrerin

--- a/enhavo/tradukenda/de/gramatiko/02.md
+++ b/enhavo/tradukenda/de/gramatiko/02.md
@@ -1,167 +1,161 @@
 # Konjugation
 
-Die Konjugation, der schwierigste Teil beim Sprachstudium, ist in Esperanto in kurzer Zeit erlernbar. Man ersetzt die Grundform-Endung "i" durch die entsprechende Zeitform-Endung.
+Die Konjugation – beim Sprachenlernen sonst der schwierigste Teil – ist in Esperanto in wenigen Minuten erlernt. Man ersetzt einfach die Grundform-Endung *-i* durch die Endung der gewünschten Zeit. Mehr ist es nicht.
 
-## Grundform: *-i*
-  
-- *labor__i__*          – arbeiten
+## Grundform: *__-i__*
 
-## Gegenwart: *-as*
+- *labor__i__* – arbeiten
 
-- *mi labor__as__*      – ich arbeite
-- *vi labor__as__*      – du arbeitest
-- *li/ŝi labor__as__*   – er/sie arbeitet
-- *ni labor__as__*      – wir arbeiten
-- *vi labor__as__*      – ihr arbeitet
-- *ili labor__as__*     – sie arbeiten
+## Gegenwart: *__-as__*
 
-## Vergangenheit: *-is*
+- *mi labor__as__* – ich arbeite
+- *vi labor__as__* – du arbeitest
+- *li/ŝi labor__as__* – er/sie arbeitet
+- *ni labor__as__* – wir arbeiten
+- *vi labor__as__* – ihr arbeitet
+- *ili labor__as__* – sie arbeiten
 
-- *mi labor__is__*      – ich arbeitete oder ich habe gearbeitet
-- *vi labor__is__*      – du arbeitetest oder du hast gearbeitet
-- *li/ŝi labor__is__*   – er/sie arbeitete oder er/sie hat gearbeitet
-- *ni labor__is__*      – wir arbeiteten oder wir haben gearbeitet
-- *vi labor__is__*      – ihr arbeitetet oder ihr habt gearbeitet
-- *ili labor__is__*     – sie arbeiteten oder sie haben gearbeitet
+## Vergangenheit: *__-is__*
 
-## Zukunft: *-os*
+- *mi labor__is__* – ich arbeitete oder ich habe gearbeitet
+- *vi labor__is__* – du arbeitetest oder du hast gearbeitet
+- *li/ŝi labor__is__* – er/sie arbeitete oder er/sie hat gearbeitet
+- *ni labor__is__* – wir arbeiteten oder wir haben gearbeitet
+- *vi labor__is__* – ihr arbeitetet oder ihr habt gearbeitet
+- *ili labor__is__* – sie arbeiteten oder sie haben gearbeitet
 
-- *mi labor__os__*      – ich werde arbeiten
-- *vi labor__os__*      – du wirst arbeiten
-- *li/ŝi labor__os__*   – er/sie wird arbeiten
-- *ni labor__os__*      – wir werden arbeiten
-- *vi labor__os__*      – ihr werdet arbeiten
-- *ili labor__os__*     – sie werden arbeiten
+## Zukunft: *__-os__*
 
-Im Esperanto gibt es nur 3 Zeiten. Die Entsprechungen zu den deutschen zusammengesetzten Zeiten können mit vielfältigeren Möglichkeiten als im Deutschen gebildet werden. Sie kommen jedoch so selten zur Anwendung, dass hier auf ihre Darstellung verzichtet wird. Für alle Personen in der Einzahl und in der Mehrzahl wird die gleiche Endung benützt.
+- *mi labor__os__* – ich werde arbeiten
+- *vi labor__os__* – du wirst arbeiten
+- *li/ŝi labor__os__* – er/sie wird arbeiten
+- *ni labor__os__* – wir werden arbeiten
+- *vi labor__os__* – ihr werdet arbeiten
+- *ili labor__os__* – sie werden arbeiten
 
-- *Mi estas*        – ich bin
-- *vi estas*        – du bist
-- *la patroj estas* – die Väter sind 
+**Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o: *-is* (Vergangenheit), *-as* (Gegenwart), *-os* (Zukunft).
+
+**Merke:** Wie schon in Lektion 1 ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
+
+- *Mi estas* – ich bin
+- *vi estas* – du bist
+- *la patroj estas* – die Väter sind
 - … usw.
 
-Das unpersönliche "es" wird nicht übersetzt: 
-  
-- *Es regnet.*  – Pluvas. 
-- *Es ist so.*  – Estas tiel.
+Esperanto hat nur diese 3 Zeiten. Entsprechungen zu den zusammengesetzten deutschen Zeiten lassen sich zwar bilden, kommen aber so selten vor, dass hier auf sie verzichtet wird.
 
+Das unpersönliche „es" wird nicht übersetzt:
+
+- *Pluvas.* – Es regnet.
+- *Estas tiel.* – Es ist so.
 
 # Wortbildung
 
-Durch die Kenntnis von Fremdwörtern besitzt man bereits einen großen Esperanto-Wortschatz. An die Besonderheiten der Schreibung gewöhnt man sich rasch. Folgende Wörter zum Beispiel versteht jeder sofort: 
+Wer Fremdwörter kennt, besitzt bereits einen großen Esperanto-Wortschatz. An die Besonderheiten der Schreibung gewöhnt man sich rasch – folgende Wörter zum Beispiel versteht jeder sofort:
 
- - *kvanto*
- - *kvalito*
- - *bazo*
- - *centro*
- - *katastrofo*
- - *krizo*
- - *kontroli*
- - *konsumi*
- - *kalkuli*
- - *korekti*
- - *protesti*
+- *kvanto*, *kvalito*, *bazo*, *centro*, *katastrofo*, *krizo*, *kontroli*, *konsumi*, *kalkuli*, *korekti*, *protesti*
 
-Neue Wörter können gebildet werden durch:
+Neue Wörter entstehen auf drei Wegen:
 
-- Änderungen der Wortendung:
+- **Endung ändern:**
     - *skribo* – Schrift
     - *skriba* – schriftlich
     - *skribi* – schreiben
-- Wortverbindung
+- **Wörter verbinden:**
     - *skribmaŝino* – Schreibmaschine
     - *maŝinskribo* – Maschinenschrift
-- Wortbildungssilben (Vorsilbe - prefikso, Nachsilbe – sufikso) wie zum Beispiel
+- **Wortbildungssilben** (Vorsilbe – *prefikso*, Nachsilbe – *sufikso*), zum Beispiel:
     - *malbono* – schlecht
     - *patrino* – Mutter
- 
+
+**Tipp:** Diese Baukasten-Logik ist das Herz von Esperanto: Aus wenigen Wurzeln und Silben bildet man selbst unzählige Wörter.
 
 # Akkusativ
 
-Esperanto kennt nur 2 Fälle: Nominativ und Akkusativ. Den Akkusativ bildet man mit der Endung -n.
+Esperanto kennt nur 2 Fälle: Nominativ und Akkusativ. Den Akkusativ bildet man mit der Endung *__-n__*.
 
-Auf folgende Fragewörter folgt der Akkusativ: 
+Er steht dort, wo man fragt:
 
-- Wen oder was (sehe ich)? 
+- Wen oder was (sehe ich)?
 - Wohin (gehst du)?
 
 ## Nominativ
 
-- Einzahl:       	*libro*        – das Buch (ist)
-- Mehrzahl:      	*libroj*       – die Bücher (sind)
-- Fürwort:       	*mi*           – ich
+- Einzahl: *libro* – das Buch (ist)
+- Mehrzahl: *libroj* – die Bücher (sind)
+- Fürwort: *mi* – ich
 
 ## Akkusativ
 
-- Einzahl:       	*libro__n__*   – das Buch (sehe ich)
-- Mehrzahl:      	*libroj__n__*  – die Bücher (sehe ich)
-- Fürwort:       	*mi__n__*      – mich
+- Einzahl: *libro__n__* – das Buch (sehe ich)
+- Mehrzahl: *libroj__n__* – die Bücher (sehe ich)
+- Fürwort: *mi__n__* – mich
+
+**Merke:** Das *-n* steht immer ganz hinten – auch nach dem Mehrzahl-*j*: *libroj__n__*.
 
 ## Beispiele
 
 - *Ĉu vi havas novan amikon?* – Hast du einen neuen Freund?
-- *Kiun libron vi havas?*     – Welches Buch hast du?
+- *Kiun libron vi havas?* – Welches Buch hast du?
 
-Wo im Deutschen Genitiv oder Dativ gebraucht werden, steht im Esperanto der Nominativ in Verbindung mit einem Verhältniswort: 
-  
-- das Buch des Vaters          – *la libro de la patro*
-- Der Vater gibt ihr ein Buch. – *La patro donas al ŝi libron.*
+**Hinweis:** Wo das Deutsche Genitiv oder Dativ gebraucht, steht im Esperanto der Nominativ in Verbindung mit einem Verhältniswort:
 
+- *la libro de la patro* – das Buch des Vaters
+- *La patro donas al ŝi libron.* – Der Vater gibt ihr ein Buch.
 
-# Vorsilbe *mal-*
+# Vorsilbe *__mal-__*
 
-Bildet das Gegenteil:	
+bildet das genaue Gegenteil:
 
-- *amiko:*         – Freund
-- *__mal__amiko:*  – Feind
-- *granda:*        – groß
-- *__mal__granda:* – klein
- 
+- *amiko* – Freund / *__mal__amiko* – Feind
+- *granda* – groß / *__mal__granda* – klein
 
-# Vorsilbe *ge-*
+**Eselsbrücke:** Ein einziges *mal-* ersetzt ein ganzes Heer von Gegenwörtern – statt eigener Vokabeln für „klein, kurz, langsam, schlecht" genügen *malgranda, mallonga, malrapida, malbona*.
 
-Personen beiderlei Geschlechts (dabei muss immer die Pluralendung "j" zugefügt werden):
+# Vorsilbe *__ge-__*
 
-- *__ge__patroj*   – Eltern
-- *__ge__fratoj*   – Geschwister
+fasst Personen beiderlei Geschlechts zusammen (die Mehrzahl-Endung *-j* muss dabei immer hinzutreten):
+
+- *__ge__patroj* – Eltern
+- *__ge__fratoj* – Geschwister
 - *__ge__sinjoroj* – Damen und Herren
 
- 
 # *Ke*
 
-*ke* – dass
+*__ke__* – dass
 
 - *Mi ne komprenas, __ke__ vi ne havas tempon.* – Ich verstehe nicht, dass du keine Zeit hast.
 - *Ĉu vi povas kompreni, __ke__ li ne skribis?* – Kannst du verstehen, dass er nicht schrieb?
 
+**Achtung:** *ke* (dass) nicht mit *kio* (was) verwechseln – *ke* leitet nur einen Nebensatz ein und fragt nach nichts.
 
 # Fürwörter
 
-Hinweisende Fürwörter beginnen mit ti-. Zwischen ki- und ti-Wörtern besteht eine Wechselbeziehung:
+Hinweisende Fürwörter beginnen mit *ti-*. Zwischen den *ki-* und *ti-*-Wörtern besteht eine feste Wechselbeziehung – „Frage" und „Antwort" reimen sich:
 
-- *kiu / tiu*  – wer / der
-    - *__Kiu__ laboras, __tiu__ havas monon.*  – Wer arbeitet, der hat Geld.
-- *kio / tio*  – was / das
-    - *__Kio__ estas mia, __tio__ estas ankaŭ via.*  – Was mein ist, das ist auch dein.
-- *kia / tia*  – wie / so
-    - *__Kia__ la patro, __tia__ la filo.*  – Wie der Vater, so der Sohn.
-- *kie / tie*  – wo / dort
-    - *__Kie__ vi manĝas, __tie__ mi lernas.*  – Wo du isst, dort lerne ich.
-- *kion / tion*  – was / das
-    - *__Kion__ mi volas, __tion__ mi havas.*  – Was ich will, das habe ich.
+- *kiu / tiu* – wer / der
+    - *__Kiu__ laboras, __tiu__ havas monon.* – Wer arbeitet, der hat Geld.
+- *kio / tio* – was / das
+    - *__Kio__ estas mia, __tio__ estas ankaŭ via.* – Was mein ist, das ist auch dein.
+- *kia / tia* – wie / so
+    - *__Kia__ la patro, __tia__ la filo.* – Wie der Vater, so der Sohn.
+- *kie / tie* – wo / dort
+    - *__Kie__ vi manĝas, __tie__ mi lernas.* – Wo du isst, dort lerne ich.
+- *kion / tion* – was / das
+    - *__Kion__ mi volas, __tion__ mi havas.* – Was ich will, das habe ich.
 
+**Tipp:** Das vollständige System dieser Wörter folgt in Lektion 5 als „Tabellenwörter". Hier genügt es, das Paar-Prinzip *ki-* → *ti-* zu erkennen.
 
 # Eigenschaftswörter
 
-Eigenschaftswörter enden auf *-a*:
+Eigenschaftswörter enden auf *__-a__*:
 
-- *bel__a__*         – schön
-- *bon__a__*         – gut
+- *bel__a__* – schön
+- *bon__a__* – gut
 - *grand__a__ libro* – ein großes Buch
-
 
 # Einige Höflichkeitsformen
 
 - *saluton* – Guten Tag, Tschüss
 - *bonvolu* – bitte … (nehmen Sie, gehen Sie …)
-- *dankon*  – danke
+- *dankon* – danke

--- a/enhavo/tradukenda/de/gramatiko/02.md
+++ b/enhavo/tradukenda/de/gramatiko/02.md
@@ -35,7 +35,7 @@ Die Konjugation – beim Sprachenlernen sonst der schwierigste Teil – ist in E
 
 **Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o: *-is* (Vergangenheit), *-as* (Gegenwart), *-os* (Zukunft).
 
-**Merke:** Wie schon in Lektion 1 ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
+**Merke:** Wie schon in [Lektion 1](/de/01/gramatiko/) ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
 
 - *Mi estas* – ich bin
 - *vi estas* – du bist
@@ -144,7 +144,7 @@ Hinweisende Fürwörter beginnen mit *ti-*. Zwischen den *ki-* und *ti-*-Wörter
 - *kion / tion* – was / das
     - *__Kion__ mi volas, __tion__ mi havas.* – Was ich will, das habe ich.
 
-**Tipp:** Das vollständige System dieser Wörter folgt in Lektion 5 als „Tabellenwörter". Hier genügt es, das Paar-Prinzip *ki-* → *ti-* zu erkennen.
+**Tipp:** Das vollständige System dieser Wörter steht im Anhang als [Tabellwörter](/de/tabelvortoj/). Hier genügt es, das Paar-Prinzip *ki-* → *ti-* zu erkennen.
 
 # Eigenschaftswörter
 

--- a/enhavo/tradukenda/de/gramatiko/03.md
+++ b/enhavo/tradukenda/de/gramatiko/03.md
@@ -66,7 +66,7 @@ Ort, Raum, Stelle:
 - *labor__ej__o* – Arbeitsplatz
 - *halt__ej__o* – Haltestelle
 
-**Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: wo man lernt (*lerni*) → *lernejo*, wo man arbeitet (*labori*) → *laborejo*.
+**Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: *lerni* (lernen) → *lernejo* (Schule), *labori* (arbeiten) → *laborejo* (Arbeitsplatz).
 
 # Nachsilbe *__-ebl__*
 

--- a/enhavo/tradukenda/de/gramatiko/03.md
+++ b/enhavo/tradukenda/de/gramatiko/03.md
@@ -1,68 +1,64 @@
 # Umstandswörter
 
-Die abgeleiteten Umstandswörter haben die Wortendung *-e*.
+Abgeleitete Umstandswörter tragen die Endung *__-e__*. Damit wird das Vokal-System rund: *-o* fürs Hauptwort, *-a* fürs Eigenschaftswort, *-e* fürs Umstandswort.
 
-- *bel__e__*   – schön
-- *mult__e__*  – viel
-- *fort__e__*  – stark
+- *bel__e__* – schön
+- *mult__e__* – viel
+- *fort__e__* – stark
 - *skrib__e__* – schriftlich
-- *post__e__*  – nachher
-- *kun__e__*   – zusammen
- 
+- *post__e__* – nachher
+- *kun__e__* – zusammen
 
 # Per und Kun
+
+Beide heißen auf Deutsch „mit" – Esperanto unterscheidet aber sauber zwischen Begleitung und Werkzeug:
 
 ## *Kun* – mit (zusammen)
 
 - *Li venis __kun__ la amikino.* – Er kam mit der Freundin.
-- *Mi parolos __kun__ li.*       – Ich werde mit ihm sprechen. 
+- *Mi parolos __kun__ li.* – Ich werde mit ihm sprechen.
 
 ## *Per* – mit (mittels)
 
-- *Ĉu vi venis __per__ aŭto?*   – Kamst du mit dem Auto?
+- *Ĉu vi venis __per__ aŭto?* – Kamst du mit dem Auto?
 - *Li salutis __per__ la mano.* – Er grüßte mit der Hand.
 
+**Eselsbrücke:** *kun* = in Gesellschaft (ein Kumpan kommt *kun*), *per* = das Mittel zum Zweck (per Bahn, per Hand).
 
 # *Post*
 
-*post* – nach (zeitlich)
+*__post__* – nach (zeitlich)
 
 - *__Post__ tri horoj li revenis.* – Nach drei Stunden kam er zurück.
 - *Ni foriris __post__ li.* – Wir gingen nach ihm fort.
 
- 
-
 # *Malantaŭ*
 
-*malantaŭ* – hinter
+*__malantaŭ__* – hinter (örtlich)
 
-- Mi iras post vi. – Ich gehe nach dir. (zeitlich)
-- Mi iras __malantaŭ__ vi. – Ich gehe hinter dir. (örtlich)
-- Ŝi sidas __malantaŭ__ la tablo. – Sie sitzt hinter dem Tisch.
+- *Mi iras post vi.* – Ich gehe nach dir. (zeitlich)
+- *Mi iras __malantaŭ__ vi.* – Ich gehe hinter dir. (örtlich)
+- *Ŝi sidas __malantaŭ__ la tablo.* – Sie sitzt hinter dem Tisch.
 
- 
+**Merke:** *post* meint die Zeit (nachher), *malantaŭ* den Ort (dahinter). Folgerichtig ist *malantaŭ* das *mal-*-Gegenteil von *antaŭ* (vor).
 
 # Befehlsform
 
-Die Befehlsform des Zeitwortes hat die Wortendung *-u*.
+Die Befehlsform des Zeitwortes trägt die Endung *__-u__*:
 
-- *Ven__u__* baldaŭ! – Komm bald!
-- *Kant__u__!*       – Singe!
-- *Manĝ__u__ nun!*   – Iss jetzt!
+- *Ven__u__ baldaŭ!* – Komm bald!
+- *Kant__u__!* – Singe!
+- *Manĝ__u__ nun!* – Iss jetzt!
 
- 
+# Nachsilbe *__-ul__*
 
-# Nachsilbe *-ul*
+Person mit einer bestimmten Eigenschaft:
 
-Person mit bestimmter Eigenschaft:
-
-- *grand__ul__o*  – ein Großer
+- *grand__ul__o* – ein Großer
 - *malbon__ul__o* – ein Böser
-- *jun__ul__o*    – ein junger Mensch
+- *jun__ul__o* – ein junger Mensch
 
- 
-
-# Nachsilbe *-ej*
+# Nachsilbe *__-ej__*
 
 Ort, Raum, Stelle:
 
@@ -70,11 +66,11 @@ Ort, Raum, Stelle:
 - *labor__ej__o* – Arbeitsplatz
 - *halt__ej__o* – Haltestelle
 
- 
+**Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: wo man lernt (*lerni*) → *lernejo*, wo man arbeitet (*labori*) → *laborejo*.
 
-# Nachsilbe *-ebl*
+# Nachsilbe *__-ebl__*
 
-Möglichkeit, -bar, -lich:
+Möglichkeit (-bar, -lich):
 
 - *manĝ__ebl__a* – essbar
 - *vid__ebl__a* – sichtbar
@@ -82,5 +78,3 @@ Möglichkeit, -bar, -lich:
 - *leg__ebl__a* – lesbar
 - *__ebl__e* – möglicherweise, vielleicht
 - *mal__ebl__a* – unmöglich
-
- 

--- a/enhavo/tradukenda/de/gramatiko/04.md
+++ b/enhavo/tradukenda/de/gramatiko/04.md
@@ -1,62 +1,62 @@
 # Zahlwörter
 
-Die Zahlen befinden sich im Anhang des Kurses. Wenn Sie sie gelernt haben, können Sie sie nach Wunsch kombinieren.
+Die Zahlen befinden sich im Anhang des Kurses. Hat man sie einmal gelernt, kann man sie beliebig kombinieren:
 
-- 1 238                     – *mil du-cent tri-dek ok*
-- 153 837                   – *cent kvin-dek tri mil ok-cent tri-dek sep*
-- Addieren:      8 + 3 = 11 – *ok plus tri estas dek-unu*
-- Subtrahieren:  15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
- 
+- 1 238 – *mil du-cent tri-dek ok*
+- 153 837 – *cent kvin-dek tri mil ok-cent tri-dek sep*
+- Addieren: 8 + 3 = 11 – *ok plus tri estas dek-unu*
+- Subtrahieren: 15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
 
 # Akkusativ der Richtung
 
-Die Bewegung in eine bestimmte Richtung (wohin?) wird durch die Akkusativendung *-n* angezeigt. In diesem Falle kommt auch nach einem Verhältniswort der Akkusativ. Logische Ausnahme: *al*, *ĝis*, *tra* (zu, bis, durch). Diese Wörter geben bereits die Richtung an.
+Eine Bewegung auf ein Ziel zu (wohin?) zeigt Esperanto mit der Akkusativ-Endung *__-n__* an. In diesem Fall steht der Akkusativ sogar nach einem Verhältniswort. Logische Ausnahme: *al*, *ĝis*, *tra* (zu, bis, durch) – diese Wörter geben die Richtung bereits selbst an.
 
 - *Mia amikino iris en la ĉambro__n__.* – Meine Freundin ging in das Zimmer.
 - *Mi metis la libron sur la tablo__n__.* – Ich habe das Buch auf den Tisch gelegt.
 - *Li falis en la akvo__n__.* – Er fiel ins Wasser.
- 
+
+**Eselsbrücke:** Wie im Deutschen „in dem Zimmer" (wo?) ↔ „in das Zimmer" (wohin?): Steht Bewegung dahinter, kommt das *-n* ans Ziel. *en la ĉambro* = im Zimmer, *en la ĉambron* = ins Zimmer.
 
 # Das rückbezügliche Fürwort *si*
 
-Das rückbezügliche Fürwort *si* gebraucht man nur in der dritten Person Einzahl und Mehrzahl.
+Das rückbezügliche Fürwort *si* (sich) gebraucht man nur in der dritten Person – Einzahl wie Mehrzahl:
 
 - *Mi lavas min.* – Ich wasche mich.
 - *Vi lavas vin.* – Du wäschst dich.
 - *Li/ŝi/ĝi lavas __sin__.* – Er/sie/es wäscht sich.
-- *(Aber: Ŝi lavas ŝin.* – Sie wäscht sie/eine andere Frau.)
+    - (Aber: *Ŝi lavas ŝin.* – Sie wäscht sie / eine andere Frau.)
 - *Ni lavas nin.* – Wir waschen uns.
 - *Vi lavas vin.* – Ihr wascht euch.
 - *Ili lavas __sin__.* – Sie waschen sich.
-- *(Aber: Ili lavas ilin.* – Sie waschen sie/die anderen.)
- 
+    - (Aber: *Ili lavas ilin.* – Sie waschen sie / die anderen.)
+
+**Achtung:** *sin* und *ŝin/ilin* sind nicht dasselbe! *si* zeigt zurück auf das Subjekt (er wäscht sich selbst), *ŝin/ilin* meint eine andere Person.
 
 # *Sia*
 
-Sia - sein eigener, ihr eigener:
+*sia* – sein eigener, ihr eigener:
 
 - *Ŝi iris kun __sia__ amikino en la teatron.* – Sie ging mit ihrer Freundin ins Theater.
 - *Li iris kun __siaj__ amikoj en la parkon.* – Er ging mit seinen Freunden in den Park.
- 
+
+**Merke:** *sia* ist das besitzanzeigende Gegenstück zu *si* (*si* + *-a*) – und meint stets den Besitz des Satzsubjekts.
 
 # *Meti*
 
-Meti ist ein Wort mit vielen Bedeutungen: setzen, stellen, legen, hintun, hineintun, z.B.:
+*meti* hat viele Bedeutungen: setzen, stellen, legen, hintun, hineintun. Mit Vorsilben wird es genauer, zum Beispiel:
 
 - *sur__meti__* – auflegen
-- *al__meti__*  – dazulegen
+- *al__meti__* – dazulegen
 - *for__meti__* – weglegen
-- *en__meti__*  – hineingeben
+- *en__meti__* – hineingeben
 
- 
+# Vorsilbe *__re-__*
 
-# Vorsilbe *re-*
-
-wieder-, zurück-
+wieder-, zurück-:
 
 - *__re__vidi* – wiedersehen
 - *__re__doni* – zurückgeben
 - *__re__veni* – zurückkommen
 - *__re__meti* – zurücklegen
 
- 
+**Eselsbrücke:** *re-* ist das lateinische „re-" wie in Re-vision oder Re-tour – etwas geschieht erneut oder zurück.

--- a/enhavo/tradukenda/de/gramatiko/05.md
+++ b/enhavo/tradukenda/de/gramatiko/05.md
@@ -1,6 +1,6 @@
-# Tabellenwörter
+# Tabellwörter
 
-In Esperanto beginnen die Fragewörter mit *ki-*, und eine ganze Wortfamilie steht mit ihnen in Beziehung. Da man sie üblicherweise in einer Tabelle anordnet, heißen sie Tabellenwörter. Wer ihre Logik versteht, kennt auf einen Schlag 45 Wörter.
+In Esperanto beginnen die Fragewörter mit *ki-*, und eine ganze Wortfamilie steht mit ihnen in Beziehung. Da man sie üblicherweise in einer Tabelle anordnet, heißen sie Tabellwörter. Wer ihre Logik versteht, kennt auf einen Schlag 45 Wörter.
 
 Sie funktionieren wie ein Setzkasten: Ein Spalten-Anfang wird mit einer Zeilen-Endung kombiniert.
 
@@ -13,7 +13,7 @@ Zusammengesetzt ergibt das zum Beispiel:
 - *neni-* + *-o* = *nenio* (nichts)
 - *ĉi-* + *-u* = *ĉiu* (jeder)
 
-**Die vollständige Tabelle** mit allen 45 Wörtern und ihren Bedeutungen steht im Anhang: [Tabellenwörter](/de/tabelvortoj/).
+**Die vollständige Tabelle** mit allen 45 Wörtern und ihren Bedeutungen steht im Anhang: [Tabellwörter](/de/tabelvortoj/).
 
 # *Ĉi*
 

--- a/enhavo/tradukenda/de/gramatiko/05.md
+++ b/enhavo/tradukenda/de/gramatiko/05.md
@@ -1,52 +1,56 @@
 # Tabellenwörter
 
-In Esperanto beginnen die Fragewörter mit ki-, und andere Wörter stehen mit ihnen in Beziehung. Da sie üblicherweise in einer Tabelle dargestellt werden, heißen sie Tabellenwörter.
+In Esperanto beginnen die Fragewörter mit *ki-*, und eine ganze Wortfamilie steht mit ihnen in Beziehung. Da man sie üblicherweise in einer Tabelle anordnet, heißen sie Tabellenwörter. Wer ihre Logik versteht, kennt auf einen Schlag 45 Wörter.
 
-| Tabellenwörter    | fragend: *ki-*      | hinweisend: *ti-*  | unbestimmt: *i-*              | allumfassend: *ĉi-*      | verneinend: *neni-*         |
-| ---               | ---                 | ---                | ---                           | ---                      | ---                         | 
-| Sache *-o*        | *kio* – was         | *tio* – jenes, das | *io* – irgendwas              | *ĉio* – alles            | *nenio* – nichts            | 
-| Person *-u*       | *kiu* – wer         | *tiu* – jener      | *iu* – jemand                 | *ĉiu* – jeder            | *neniu* – keiner            | 
-| Zeit *-am*        | *kiam* – wann       | *tiam* – dann      | *iam* – irgendwann            | *ĉiam* – immer           | *neniam* – nie              | 
-| Eigenschaft *-a*  | *kia* – was für ein | *tia* – solch ein  | *ia* – irgendein              | *ĉia* – jederlei         | *nenia* – keinerlei         | 
-| Art & Weise *-el* | *kiel* – wie        | *tiel* – so        | *iel* – irgendwie             | *ĉiel* – auf jede Weise  | *neniel* – in keiner Weise  | 
-| Menge *-om*       | *kiom* – wie viel   | *tiom* – so viel   | *iom* – etwas, ein wenig      | *ĉiom* – alles           | *neniom* – nichts           |
-| Grund *-al*       | *kial* – warum      | *tial* – deshalb   | *ial* – aus irgendeinem Grund | *ĉial* – aus jedem Grund | *nenial* – aus keinem Grund | 
-| Besitz *-es*      | *kies* – wessen     | *ties* – dessen    | *ies* – irgendjemandes        | *ĉies* – jedermanns      | *nenies* – niemandes        |
+Sie funktionieren wie ein Setzkasten: Ein Spalten-Anfang wird mit einer Zeilen-Endung kombiniert.
+
+- Anfänge: *ki-* (fragend), *ti-* (hinweisend), *i-* (unbestimmt), *ĉi-* (allumfassend), *neni-* (verneinend)
+- Endungen: *-o* (Sache), *-u* (Person), *-am* (Zeit), *-a* (Eigenschaft), *-el* (Art & Weise), *-om* (Menge), *-al* (Grund), *-es* (Besitz)
+
+Zusammengesetzt ergibt das zum Beispiel:
+
+- *ki-* + *-am* = *kiam* (wann)
+- *neni-* + *-o* = *nenio* (nichts)
+- *ĉi-* + *-u* = *ĉiu* (jeder)
+
+**Die vollständige Tabelle** mit allen 45 Wörtern und ihren Bedeutungen steht im Anhang: [Tabellenwörter](/de/tabelvortoj/).
 
 # *Ĉi*
 
-Ĉi hat die Bedeutung "näher liegend".
+*ĉi* hat die Bedeutung „näher liegend" und rückt ein *ti-*-Wort an den Sprecher heran:
 
-- *tiu* – jener      / *__ĉi__ tiu* – dieser (hier)
-- *tie* – dort       / *__ĉi__ tie* – hier
+- *tiu* – jener / *__ĉi__ tiu* – dieser (hier)
+- *tie* – dort / *__ĉi__ tie* – hier
 - *tio* – das (dort) / *__ĉi__ tio* – das hier
-- *tien* – dorthin   / *__ĉi__ tien* – hierher
- 
+- *tien* – dorthin / *__ĉi__ tien* – hierher
+
+**Eselsbrücke:** *ĉi* holt alles in die Nähe – „*ĉi* tie" ist das Hier, das man fast anfassen kann.
 
 # Komparativ, Superlativ
 
-1. Steigerungsstufe:	
+Gesteigert wird mit zwei kleinen Wörtchen – ganz ohne unregelmäßige Formen wie „gut, besser, am besten":
+
+1. Steigerungsstufe: *__pli__*
 
   - *__pli__ bona* – besser
   - *__pli__ bone* – besser
 
-2. Steigerungsstufe:	
+2. Steigerungsstufe: *__plej__*
 
   - *la __plej__ bona* – der beste
   - *__plej__ bone* – bestens
-
 
 - *Karlo estas bona kiel vi.* – Karl ist gut wie du.
 - *Li estas __pli__ granda ol mia frato.* – Er ist größer als mein Bruder.
 - *Li estas la __plej__ granda el ĉiuj.* – Er ist der größte von allen.
 
+Die Vergleichswörter merkt man sich gleich mit: *kiel* (wie) beim Gleichstand, *ol* (als) beim Mehr, *el* (von) bei der Auswahl.
 
-1. Stufe:	*alta* – hoch
-2. Stufe:	*__pli__ alta (ol ŝi)* – höher (als sie)
-3. Stufe:	*la __plej__ alta (domo en la urbo)* – das höchste (Haus der Stadt)
- 
+1. Stufe: *alta* – hoch
+2. Stufe: *__pli__ alta (ol ŝi)* – höher (als sie)
+3. Stufe: *la __plej__ alta (domo en la urbo)* – das höchste (Haus der Stadt)
 
-# Nachsilbe *-ind*
+# Nachsilbe *__-ind__*
 
 -wert, -würdig:
 
@@ -56,18 +60,16 @@ In Esperanto beginnen die Fragewörter mit ki-, und andere Wörter stehen mit ih
 - *nedank__ind__e* – nichts zu danken
 - *bedaŭr__ind__e* – leider
 
+# *Dum*
 
-# *Dum* 
-
-*dum* – während:
+*__dum__* – während:
 
 - *Ne parolu __dum__ la manĝo.* – Sprich nicht während des Essens.
 - *Ne parolu, __dum__ via patro parolas.* – Sprich nicht, während dein Vater spricht.
 - *__Dum__ ŝi estis en la lernejo, li laboris en la ĉambro.* – Während sie in der Schule war, arbeitete er im Zimmer.
 
- 
 # *Kioma*
 
-- Wie spät ist es? – *__Kioma__ horo estas?*
+- *__Kioma__ horo estas?* – Wie spät ist es?
 
- 
+**Hinweis:** *kioma* fragt nach der Reihenfolge (die wievielte Stunde?) – daher lautet die Antwort „die dritte (Stunde)".

--- a/enhavo/tradukenda/de/gramatiko/06.md
+++ b/enhavo/tradukenda/de/gramatiko/06.md
@@ -55,7 +55,7 @@ werden, sich … machen (das Subjekt ändert von selbst seinen Zustand):
 - *proksim__iĝ__i* – sich nähern
 - *trankvil__iĝ__i* – sich beruhigen
 
-**Merke:** *-iĝ* heißt „von selbst werden". In Lektion 8 folgt das Gegenstück *-ig* („etwas machen, bewirken") – das Dächlein auf *ĝ* zeigt nach innen, auf das Subjekt selbst.
+**Merke:** *-iĝ* heißt „von selbst werden". In [Lektion 8](/de/08/gramatiko/) folgt das Gegenstück *-ig* („etwas machen, bewirken") – das Dächlein auf *ĝ* zeigt nach innen, auf das Subjekt selbst.
 
 # *Farti*
 

--- a/enhavo/tradukenda/de/gramatiko/06.md
+++ b/enhavo/tradukenda/de/gramatiko/06.md
@@ -1,10 +1,10 @@
 # Wunschsätze
 
-Drückt der Hauptsatz Wunsch oder Gebot aus (wünschen, befehlen, bitten, verlangen usw.), muss im abhängigen Teilsatz die Befehlsform eingeleitet mit ke (dass) stehen.
+Drückt der Hauptsatz einen Wunsch oder ein Gebot aus (wünschen, befehlen, bitten, verlangen usw.), so steht im abhängigen Nebensatz die Befehlsform *-u*, eingeleitet mit *ke* (dass):
 
 - *Mi deziras, __ke__ vi lern__u__.* – Ich wünsche, dass du lernst!
 
- 
+**Merke:** Nach einem Wunsch folgt *ke* + Verb auf *-u* (nicht auf *-as*). Der Wunsch im Hauptsatz „färbt" das Verb des Nebensatzes.
 
 # Mögen
 
@@ -12,54 +12,51 @@ Drückt der Hauptsatz Wunsch oder Gebot aus (wünschen, befehlen, bitten, verlan
 
 - *Mi ne __ŝatas__ lerni.* – Ich mag nicht lernen.
 - *Mi __ŝatas__ teon.* – Ich mag Tee.
-- *Mi __ŝatas__ kafon, sed mi preferas* (bevorzuge) *teon.* – Ich habe Kaffee gern, habe aber Tee lieber.
-
- 
+- *Mi __ŝatas__ kafon, sed mi preferas (bevorzuge) teon.* – Ich habe Kaffee gern, habe aber Tee lieber.
 
 # *Je*
 
-Je ist ein Verhältniswort ohne bestimmte Bedeutung. Es wird dort verwendet, wo man kein anderes geeignetes Verhältnis finden kann.
+*je* ist ein Allzweck-Verhältniswort ohne feste Bedeutung. Man verwendet es dort, wo sich kein anderes, genaueres Verhältniswort findet:
 
 - *Mi revenos __je__ la tria (horo).* – Ich komme um drei Uhr zurück.
 - *__Je__ kioma horo vi venos?* – Um wie viel Uhr wirst du kommen?
 - *__Je__ via sano!* – Auf deine Gesundheit!
 
- 
+**Tipp:** *je* ist der „Joker" unter den Verhältniswörtern – im Zweifel passt *je*.
 
-# Nachsilbe *-et*
+# Nachsilbe *__-et__*
 
 Verkleinerung, Abschwächung:
 
 - *libr__et__o* – Büchlein
-- *dom__et__o*  – Häuschen
-- *bel__et__a*  – hübsch
-- *__et__a*     – winzig, klein
- 
+- *dom__et__o* – Häuschen
+- *bel__et__a* – hübsch
+- *__et__a* – winzig, klein
 
-# Nachsilbe *-eg*
+# Nachsilbe *__-eg__*
 
 Vergrößerung, Verstärkung:
 
-- *bel__eg__a*   – herrlich
-- *hom__eg__o*   – Riese
-- *varm__eg__a*  – heiß
-- *bon__eg__a*   – ausgezeichnet
-- *__eg__e*      – in hohem Maß
+- *bel__eg__a* – herrlich
+- *hom__eg__o* – Riese
+- *varm__eg__a* – heiß
+- *bon__eg__a* – ausgezeichnet
+- *__eg__e* – in hohem Maß
 - *grand__eg__a* – riesig
- 
 
-# Nachsilbe *-iĝ*
+**Eselsbrücke:** Das Gegensatzpaar merkt man sich am besten zusammen: *-et* macht klein (*dom__et__o* = Häuschen), *-eg* macht riesig (*dom__eg__o* = Riesenhaus).
 
-werden, sich … machen (Das Subjekt ändert seinen Zustand):
+# Nachsilbe *__-iĝ__*
 
-- *interes__iĝ__i*  – sich interessieren
-- *san__iĝ__i*      – gesund werden
-- *proksim__iĝ__i*  – sich nähern
+werden, sich … machen (das Subjekt ändert von selbst seinen Zustand):
+
+- *interes__iĝ__i* – sich interessieren
+- *san__iĝ__i* – gesund werden
+- *proksim__iĝ__i* – sich nähern
 - *trankvil__iĝ__i* – sich beruhigen
- 
+
+**Merke:** *-iĝ* heißt „von selbst werden". In Lektion 8 folgt das Gegenstück *-ig* („etwas machen, bewirken") – das Dächlein auf *ĝ* zeigt nach innen, auf das Subjekt selbst.
 
 # *Farti*
 
-- Wie geht es Ihnen (dir)? – *Kiel vi __fartas__?*
-
- 
+- *Kiel vi __fartas__?* – Wie geht es Ihnen (dir)?

--- a/enhavo/tradukenda/de/gramatiko/07.md
+++ b/enhavo/tradukenda/de/gramatiko/07.md
@@ -1,51 +1,55 @@
 # Verneinung
 
-- *__Ne__ parolu, sed laboru!*               – Sprich nicht, sondern arbeite!
-- *__Nek__ li __nek__ ŝi respondis.*             – Weder er noch sie antworteten.
-- *Li __neniam__ ridas.*                     – Er lacht nie.
+- *__Ne__ parolu, sed laboru!* – Sprich nicht, sondern arbeite!
+- *__Nek__ li __nek__ ŝi respondis.* – Weder er noch sie antworteten.
+- *Li __neniam__ ridas.* – Er lacht nie.
 - *Ŝi __nenion__ diris, sed rapide foriris.* – Sie sagte nichts, sondern ging schnell fort.
 
+**Merke:** Anders als im Deutschen gibt es keine doppelte Verneinung. Ein einziges *neni-*-Wort verneint bereits den ganzen Satz: *Ŝi diris nenion* (wörtlich „Sie sagte nichts").
 
 # *Mem / Sola*
 
-- *Mi __mem__ faris tion.*  – Ich habe das selbst gemacht.
+- *Mi __mem__ faris tion.* – Ich habe das selbst gemacht.
 - *Mi __sola__ faris tion.* – Ich habe das allein gemacht.
 
+**Achtung:** *mem* (selbst, eigenhändig) ist nicht *sola* (allein, ohne andere) – „ich selbst" ist nicht „ich allein".
 
 # *Estas …-e*
 
-In solchen Sätzen folgt immer ein Umstandswort:
+In solchen Sätzen folgt immer ein Umstandswort auf *-e*:
 
-- *estas fru__e__*   – es ist früh
+- *estas fru__e__* – es ist früh
 - *estas facil__e__* – es ist leicht
-- *estas bon__e__*   – es ist gut
+- *estas bon__e__* – es ist gut
 - *estas neces__e__* – es ist notwendig
-  
-  (Alle Beispiele zeigen Sätze, in denen es nichts gibt, dessen Eigenschaft ein Eigenschaftswort zeigen könnte. Daher wird die Endung für Umstandswörter benutzt.)
 
-Das unpersönliche "es" bleibt unübersetzt. Manchmal kann man sogar *estas* weglassen:
+(In all diesen Sätzen gibt es nichts, dessen Eigenschaft ein Eigenschaftswort beschreiben könnte. Daher wird die Endung für Umstandswörter benutzt.)
 
-- *Bone, ke vi venis.*            – Gut, dass du gekommen bist.
+Das unpersönliche „es" bleibt unübersetzt. Manchmal kann man sogar *estas* weglassen:
+
+- *Bone, ke vi venis.* – Gut, dass du gekommen bist.
 - *Malbone, ke vi ne povas veni.* – Schlecht, dass du nicht kommen kannst.
 
- 
+**Merke:** Kein „Ding" im Satz → Endung *-e*, nicht *-a*. Vergleiche *estas bone* (es ist gut – allgemein) mit *la libro estas bona* (das Buch ist gut).
 
-# Vorsilbe *ek-*
+# Vorsilbe *__ek-__*
 
 beginnende Handlung:
 
-- *__ek__sidi*  – sich hinsetzen
+- *__ek__sidi* – sich hinsetzen
 - *__ek__stari* – aufstehen
-- *__ek__krii*  – aufschreien
+- *__ek__krii* – aufschreien
 - *__ek__manĝi* – beginnen zu essen
- 
 
-# Nachsilbe *-aĵ*
+**Eselsbrücke:** *ek-* ist der Startschuss – der Moment, in dem die Handlung losgeht (*ekkrii* = einen Schrei ausstoßen).
+
+# Nachsilbe *__-aĵ__*
 
 konkrete Sache:
 
-- *manĝ__aĵ__o*  – Speise
+- *manĝ__aĵ__o* – Speise
 - *trink__aĵ__o* – Getränk
-- *send__aĵ__o*  – Sendung
+- *send__aĵ__o* – Sendung
 - *skrib__aĵ__o* – Schriftstück
- 
+
+**Eselsbrücke:** *-aĵ* macht aus einer Tätigkeit ein greifbares Ding: *manĝi* (essen) → *manĝaĵo* (die Speise).

--- a/enhavo/tradukenda/de/gramatiko/08.md
+++ b/enhavo/tradukenda/de/gramatiko/08.md
@@ -1,26 +1,29 @@
 # *Da*
 
-Da ist ein Verhältniswort bei Mengenangaben (Ein Teil aus einer größeren Menge):
+*da* ist das Verhältniswort der Mengenangabe – es verbindet eine Menge mit dem, woraus sie besteht (ein Teil aus einer größeren Menge):
 
 - *glaso __da__ akvo* – ein Glas Wasser
 - *iom __da__ tempo* – etwas Zeit
 - *tiom __da__ mono* – so viel Geld
- 
 
-# Nachsilbe *-ig*
+**Merke:** Nach Mengenwörtern (Glas, etwas, so viel) steht *da*, nicht *de*. *glaso da akvo* = ein Glas (voll) Wasser.
+
+# Nachsilbe *__-ig__*
 
 machen, in einen Zustand bringen, veranlassen:
 
 - *bel__ig__i* – schön machen
 - *for__ig__i* – entfernen
 - *ebl__ig__i* – ermöglichen
- 
 
-# Nachsilbe *-aĉ*
+**Achtung:** *-ig* und *-iĝ* (Lektion 6) nicht verwechseln! *-ig* = etwas oder jemanden verändern (*beligi* – schön machen), *-iĝ* = selbst werden (*beliĝi* – schön werden). Das Dächlein auf *ĝ* zeigt die Veränderung am Subjekt selbst.
+
+# Nachsilbe *__-aĉ__*
 
 äußere Verschlechterung, Wertlosigkeit, Untauglichkeit:
 
 - *dom__aĉ__o* – Hütte, Kate
 - *parol__aĉ__o* – Kauderwelsch
 - *rid__aĉ__i* – grinsen
- 
+
+**Eselsbrücke:** *-aĉ* ist das abwertende Suffix – schon der kratzige Laut „atsch" klingt nach Pfusch (ein *domaĉo* ist eine schäbige Bruchbude).

--- a/enhavo/tradukenda/de/gramatiko/08.md
+++ b/enhavo/tradukenda/de/gramatiko/08.md
@@ -16,7 +16,7 @@ machen, in einen Zustand bringen, veranlassen:
 - *for__ig__i* – entfernen
 - *ebl__ig__i* – ermöglichen
 
-**Achtung:** *-ig* und *-iĝ* (Lektion 6) nicht verwechseln! *-ig* = etwas oder jemanden verändern (*beligi* – schön machen), *-iĝ* = selbst werden (*beliĝi* – schön werden). Das Dächlein auf *ĝ* zeigt die Veränderung am Subjekt selbst.
+**Achtung:** *-ig* und *-iĝ* ([Lektion 6](/de/06/gramatiko/)) nicht verwechseln! *-ig* = etwas oder jemanden verändern (*beligi* – schön machen), *-iĝ* = selbst werden (*beliĝi* – schön werden). Das Dächlein auf *ĝ* zeigt die Veränderung am Subjekt selbst.
 
 # Nachsilbe *__-aĉ__*
 

--- a/enhavo/tradukenda/de/gramatiko/09.md
+++ b/enhavo/tradukenda/de/gramatiko/09.md
@@ -1,11 +1,13 @@
-# *Bedingungsform*
+# Bedingungsform
 
-Die Bedingungsform (*kondicionalo*) des Zeitwortes hat die Endung *-us*:
+Die Bedingungsform (*kondicionalo*) des Zeitwortes trägt die Endung *__-us__*. Sie steht für alles, was nur unter einer Bedingung gilt – „würde, hätte, wäre":
 
 - *Li certe redon__us__ la monon, se li hav__us__ la eblon.* – Sicherlich würde er das Geld zurückgeben, wenn er die Möglichkeit hätte.
 - *Se mi hav__us__ tempon, mi rest__us__ pli longe.* – Wenn ich Zeit hätte, würde ich länger bleiben.
 
- 
+**Merke:** Im *se*-Satz (wenn) und im Folgesatz steht beide Male *-us* – anders als im Deutschen, das „hätte … würde" mischt.
+
+**Eselsbrücke:** Jetzt sind alle Verb-Endungen beisammen: *-i* (Grundform), *-as/-is/-os* (die drei Zeiten), *-u* (Befehl), *-us* (Bedingung). Sechs Endungen – ein vollständiges Verbsystem.
 
 # *Se / Kiam*
 
@@ -16,7 +18,7 @@ Die Bedingungsform (*kondicionalo*) des Zeitwortes hat die Endung *-us*:
 - *__Kiam__ mi malsanis, (tiam) mi malmulte manĝis.* – Als ich krank war, habe ich wenig gegessen.
 - *__Kiam__ la patro venos, (tiam) mi estos en la lito.* – Wenn der Vater kommt, werde ich im Bett sein.
 
- 
+**Achtung:** Das deutsche „wenn" ist doppeldeutig. Geht es um eine Bedingung → *se*; geht es um einen Zeitpunkt → *kiam*. Probe: Lässt sich „falls" einsetzen, ist es *se*.
 
 # *Kvazaŭ*
 
@@ -26,34 +28,33 @@ Die Bedingungsform (*kondicionalo*) des Zeitwortes hat die Endung *-us*:
 - *Vi sidas tie __kvazaŭ__ vi estus riĉulo.* – Du sitzt dort, als ob du ein Reicher wärst.
 - *Vi sidas __kvazaŭ__ riĉulo.* – Du sitzt wie ein Reicher.
 
- 
+# Nachsilbe *__-ad__*
 
-# Nachsilbe *-ad*
-
-Dauer einer Handlung, hauptwörtlich gebrauchte Nennform:
+Dauer einer Handlung; auch die hauptwörtlich gebrauchte Nennform:
 
 - *parol__ad__o* – Rede
 - *vetur__ad__o* – Fahrt
 - *la dorm__ad__o* – das Schlafen
 - *la ir__ad__o* – das Gehen
- 
 
-# Nachsilbe *-ar*
+# Nachsilbe *__-ar__*
 
-Sammelbegriff, Menge:
+Sammelbegriff, Menge gleichartiger Dinge:
 
 - *arb__ar__o* – Wald
 - *vort__ar__o* – Wörterbuch
 - *vagon__ar__o* – Zug
 - *hom__ar__o* – Menschheit
- 
 
-# Nachsilbe *-um*
+**Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: viele Bäume (*arbo*) → ein Wald (*arbaro*), viele Wörter (*vorto*) → ein Wörterbuch (*vortaro*).
 
-verwandter Begriff (Joker-Suffix):
+# Nachsilbe *__-um__*
+
+verwandter Begriff – das „Joker-Suffix" ohne feste Bedeutung:
 
 - *plena* – voll / *plen__um__i* – erfüllen
 - *proksima* – nahe / *proksim__um__e* – ungefähr
-- *sun__um__i* – sich sonnen 
+- *sun__um__i* – sich sonnen
 - *malvarm__um__i* – sich erkälten
- 
+
+**Tipp:** *-um* ist der Nachsilben-Joker, *je* der Verhältniswort-Joker (Lektion 6) – beide springen ein, wo nichts Genaueres passt. Ihre Bedeutung lernt man Wort für Wort.

--- a/enhavo/tradukenda/de/gramatiko/09.md
+++ b/enhavo/tradukenda/de/gramatiko/09.md
@@ -46,7 +46,7 @@ Sammelbegriff, Menge gleichartiger Dinge:
 - *vagon__ar__o* – Zug
 - *hom__ar__o* – Menschheit
 
-**Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: viele Bäume (*arbo*) → ein Wald (*arbaro*), viele Wörter (*vorto*) → ein Wörterbuch (*vortaro*).
+**Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: *arbo* (Baum) → *arbaro* (Wald), *vorto* (Wort) → *vortaro* (Wörterbuch).
 
 # Nachsilbe *__-um__*
 
@@ -57,4 +57,4 @@ verwandter Begriff – das „Joker-Suffix" ohne feste Bedeutung:
 - *sun__um__i* – sich sonnen
 - *malvarm__um__i* – sich erkälten
 
-**Tipp:** *-um* ist der Nachsilben-Joker, *je* der Verhältniswort-Joker (Lektion 6) – beide springen ein, wo nichts Genaueres passt. Ihre Bedeutung lernt man Wort für Wort.
+**Tipp:** *-um* ist der Nachsilben-Joker, *je* der Verhältniswort-Joker ([Lektion 6](/de/06/gramatiko/)) – beide springen ein, wo nichts Genaueres passt. Ihre Bedeutung lernt man Wort für Wort.

--- a/enhavo/tradukenda/de/gramatiko/10.md
+++ b/enhavo/tradukenda/de/gramatiko/10.md
@@ -1,25 +1,25 @@
-# Nachsilbe *-an*
+# Nachsilbe *__-an__*
 
 Mitglied, Bewohner, Anhänger:
 
-- *klub__an__o*    – Klubmitglied
-- *parti__an__o*   – Parteianhänger
-- *amerik__an__o*  – Amerikaner
+- *klub__an__o* – Klubmitglied
+- *parti__an__o* – Parteianhänger
+- *amerik__an__o* – Amerikaner
 - *samland__an__o* – Landsmann
- 
 
-# Nachsilbe *-ec*
+# Nachsilbe *__-ec__*
 
-abstrakter Begriff, -heit, -keit, -schaft:
+abstrakter Begriff (-heit, -keit, -schaft):
 
 - *bel__ec__o* – Schönheit
 - *jun__ec__o* – Jugend
 - *varm__ec__o* – Wärme
 - *hom__ec__o* – Menschlichkeit
 - *amik__ec__o* – Freundschaft
- 
 
-# Nachsilbe *-uj*
+**Eselsbrücke:** *-ec* macht aus einer Eigenschaft einen Begriff – wie das deutsche „-heit/-keit": *bela* (schön) → *beleco* (Schönheit).
+
+# Nachsilbe *__-uj__*
 
 Behälter, Land, Baum:
 
@@ -28,11 +28,12 @@ Behälter, Land, Baum:
 - *Franc__uj__o* – Frankreich
 - *Angl__uj__o* – England
 - *pom__uj__o* – Apfelbaum
- 
+
+**Eselsbrücke:** *-uj* ist das, was etwas „enthält": Geld → Geldbörse, Äpfel (am Baum) → Apfelbaum, ein Volk → sein Land.
 
 # Umstandsbeziehungen
 
-In Esperanto können Umstandsbeziehungen weitgehend umstandswörtlich ausgedrückt werden:
+Vieles, wofür das Deutsche eine ganze Wortgruppe braucht, drückt Esperanto knapp mit einem Umstandswort auf *-e* aus:
 
 - *survoje* – unterwegs
 - *enlande* – im Inland
@@ -40,10 +41,14 @@ In Esperanto können Umstandsbeziehungen weitgehend umstandswörtlich ausgedrüc
 - *subakve* – unter Wasser
 - *fervoje* – mit der Bahn
 - *poŝtkarte* – mit einer Postkarte
- 
 
 # Stellung der Satzteile im Satz
 
-Da die Funktion der Wörter im Satz leicht erkannt werden kann, ist eine strenge grammatische Regelung der Reihenfolge der Satzteile nicht notwendig. Allerdings beziehen sich die Satzteile inhaltlich auf ihre Nachbarn. So gilt z.B.: *ne* muss vor dem Wort stehen, das verneint wird. Ne mi manĝas. = Nicht ich esse (sondern eine andere Person). <=> Mi ne manĝas. = Ich esse nicht (sondern mache etwas anderes). Den internationalen Stil der Sätze lernen Sie am besten bei der Lektüre.
+Da die Funktion jedes Wortes an seiner Endung leicht erkennbar ist, braucht Esperanto keine strenge Reihenfolge der Satzteile. Allerdings beziehen sich die Satzteile inhaltlich auf ihre Nachbarn. So gehört *ne* unmittelbar vor das Wort, das verneint wird:
 
- 
+- *__Ne__ mi manĝas.* – Nicht ich esse (sondern eine andere Person).
+- *Mi __ne__ manĝas.* – Ich esse nicht (sondern mache etwas anderes).
+
+Den internationalen Stil der Sätze lernt man am besten bei der Lektüre.
+
+**Merke:** *ne* wirkt wie ein Scheinwerfer – es verneint genau das Wort, vor dem es steht. Verschiebt man *ne*, verschiebt sich die Bedeutung.

--- a/enhavo/tradukenda/de/gramatiko/11.md
+++ b/enhavo/tradukenda/de/gramatiko/11.md
@@ -8,6 +8,6 @@ Werkzeug, Gerät, Mittel:
 - *vojmontr__il__o* – Wegweiser
 - *sanig__il__o* – Heilmittel, Medizin
 
-**Eselsbrücke:** *-il* ist das Mittel zum Zweck: womit man schreibt (*skribi*) → *skribilo*, womit man spielt (*ludi*) → *ludilo*.
+**Eselsbrücke:** *-il* ist das Mittel zum Zweck: *skribi* (schreiben) → *skribilo* (Schreibgerät), *ludi* (spielen) → *ludilo* (Spielzeug).
 
 **Tipp:** *manĝ__il__aro* verbindet zwei Silben aus früheren Lektionen: *-il* (Werkzeug) + *-ar* (Sammlung) = die ganze Garnitur Essgeräte, das Besteck.

--- a/enhavo/tradukenda/de/gramatiko/11.md
+++ b/enhavo/tradukenda/de/gramatiko/11.md
@@ -1,4 +1,4 @@
-# Nachsilbe *-il*
+# Nachsilbe *__-il__*
 
 Werkzeug, Gerät, Mittel:
 
@@ -7,4 +7,7 @@ Werkzeug, Gerät, Mittel:
 - *manĝ__il__aro* – Essbesteck
 - *vojmontr__il__o* – Wegweiser
 - *sanig__il__o* – Heilmittel, Medizin
- 
+
+**Eselsbrücke:** *-il* ist das Mittel zum Zweck: womit man schreibt (*skribi*) → *skribilo*, womit man spielt (*ludi*) → *ludilo*.
+
+**Tipp:** *manĝ__il__aro* verbindet zwei Silben aus früheren Lektionen: *-il* (Werkzeug) + *-ar* (Sammlung) = die ganze Garnitur Essgeräte, das Besteck.

--- a/enhavo/tradukenda/de/gramatiko/12.md
+++ b/enhavo/tradukenda/de/gramatiko/12.md
@@ -3,7 +3,8 @@
 *ju pli … des pli* – je mehr … desto mehr:
 
 - *Ju pli longe, des pli bone.* – Je länger, desto besser.
- 
+
+**Merke:** *ju* gehört zum ersten, *des* zum zweiten Satzteil – fest verbunden wie das deutsche „je … desto".
 
 # *Ajn*
 
@@ -11,21 +12,24 @@
 
 - *kiu __ajn__* – wer auch immer
 - *iu __ajn__* – ein x-beliebiger
- 
 
-# Vorsilbe *dis-*
+**Eselsbrücke:** *ajn* macht ein Tabellenwort (Lektion 5) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
 
-Trennung, Teilung, ent-, zer-, auseinander-:
+# Vorsilbe *__dis-__*
+
+Trennung, Teilung (ent-, zer-, auseinander-):
 
 - *__dis__ĵeti* – zerstreuen
 - *__dis__sendi* – versenden
- 
 
-# Nachsilbe *-on*
+**Eselsbrücke:** *dis-* ist das lateinische „dis-" wie in dis-tribuieren – etwas wird in alle Richtungen verteilt.
+
+# Nachsilbe *__-on__*
 
 Bruchzahl:
 
 - *du__on__o* – Hälfte
 - *tri__on__o* – Drittel
 - *kvar__on__o* – Viertel
- 
+
+**Eselsbrücke:** *-on* macht aus einer Grundzahl den Bruch: *du* (zwei) → *duono* (Hälfte), *kvar* (vier) → *kvarono* (Viertel).

--- a/enhavo/tradukenda/de/gramatiko/12.md
+++ b/enhavo/tradukenda/de/gramatiko/12.md
@@ -13,7 +13,7 @@
 - *kiu __ajn__* – wer auch immer
 - *iu __ajn__* – ein x-beliebiger
 
-**Eselsbrücke:** *ajn* macht ein Tabellenwort (Lektion 5) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
+**Eselsbrücke:** *ajn* macht ein [Tabellwort](/de/tabelvortoj/) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
 
 # Vorsilbe *__dis-__*
 


### PR DESCRIPTION
## Resumo

Reverkas ĉiujn 12 germanajn gramatik-lecionojn (*enhavo/tradukenda/de/gramatiko/*) laŭ pedagogiaj normoj. **La temoj kaj ĉiuj Esperanto-ekzemploj restas senŝanĝaj** – plibonigita estas nur la prezento:

- Densaj tekstblokoj dividitaj en skaneblan strukturon
- Novaj morfemoj aldone **grasaj** ĉe enkonduko (ekz. *-as*, *mal-*, *-iĝ*)
- Ĉiu Esperanto-vorto kursiva, ankaŭ la morfemoj en la posedaj pronomoj k.s.
- Kontrastoj al la germana, memorhelpiloj kaj „Eselsbrücken"
- Ruĝa fadeno per krucreferencoj: *-iĝ* (lec. 6) ↔ *-ig* (lec. 8); resumo de la ses verb-finaĵoj en lec. 9; *je*/*-um* kiel „ĵokeroj"

## Leciono 5

La tabelvorta tabelo rendiĝis kiel kruda Markdown (mistune sen `table`-kromaĵo). Por la germana ĝi nun cedas lokon al klariga „Setzkasten"-teksto plus ligilo al `/de/tabelvortoj/`.

> Noto: la sama kruda tabelo ankoraŭ ekzistas en lec. 5 de ĉiuj aliaj ~40 lingvoj — aparta tasko.

## Testplano

- [x] `make check` sukcesas
- [x] `make html LINGVO=de` – kontrolitaj: morfema reliefigo, kursivo, ligilo al /de/tabelvortoj/, neniuj krudaj „|"
- [ ] Vida kontrolo en la retejo (de/01–12/gramatiko)

🤖 Generated with [Claude Code](https://claude.com/claude-code)