### PR TITLE
Anstataŭigu tabelon de tabelvortoj en nederlanda leciono 5 per ligilo al aldono

### DIFF
--- a/enhavo/tradukenda/nl/gramatiko/05.md
+++ b/enhavo/tradukenda/nl/gramatiko/05.md
@@ -1,17 +1,19 @@
 # Tabelwoorden
 
-In Esperanto beginnen de vraagwoorden met ki-, en andere woorden staan er mee in een verhouding. Omdat ze gewoonlijk allemaal samen overzichtelijk in een tabel voorgesteld worden, noemt men ze tabelwoorden.
+In Esperanto beginnen de vraagwoorden met *ki-*, en een hele woordfamilie staat ermee in verhouding. Omdat ze gewoonlijk overzichtelijk in een tabel worden geordend, noemt men ze tabelwoorden. Wie hun logica begrijpt, kent in één klap 45 woorden.
 
-| Tabelwoorden       | vragend: *ki-*       | aanwijzend: *ti-* | onbepaald: *i*                  | allesomvattend: *ĉi-*              | ontkennend: *neni-*                       | 
-| ---                | ---                  | ---               | ---                             | ---                                | ---                                       | 
-| Zaak *-o*          | *kio* – wat          | *tio* – dit, dat  | *io* – iets                     | *ĉio* – alles                      | *nenio* – niets                           | 
-| Persoon *-u*       | *kiu* – wie          | *tiu* – deze      | *iu* – iemand                   | *ĉiu* – iedereen                   | *neniu* – niemand                         | 
-| Tijdstip *-am*     | *kiam* – wanneer     | *tiam* – dan      | *iam* – ooit                    | *ĉiam* – altijd                    | *neniam* – nooit                          | 
-| Eigenschap *-a*    | *kia* – wat voor een | *tia* – zulke     | *ia* – eender welke soort       | *ĉia* – allerlei, van alle soorten | *nenia* – generlei, van geen enkele soort | 
-| Aard & Wijze *-el* | *kiel* – hoe         | *tiel* – zo       | *iel* – op een of andere manier | *ĉiel* – op alle manieren          | *neniel* – op geen enkele manier          | 
-| Hoeveelheid *-om*  | *kiom* – hoeveel     | *tiom* – zoveel   | *iom* – enkele, iets            | *ĉiom* – alles                     | *neniom* – geen enkele hoeveelheid        | 
-| Reden *-al*        | *kial* – waarom      | *tial* – daarom   | *ial* – om een of andere reden  | *ĉial* – om alle redenen           | *nenial* – om  geen enkele reden          | 
-| Bezit *-es*        | *kies* – wiens       | *ties* – diens    | *ies* – iemands                 | *ĉies* – ieders                    | *nenies* – niemands                       | 
+Ze werken als een combinatiesysteem: een eerste deel (kolom) wordt gecombineerd met een tweede deel (uitgang).
+
+- Eerste deel: *ki-* (vragend), *ti-* (aanwijzend), *i-* (onbepaald), *ĉi-* (allesomvattend), *neni-* (ontkennend)
+- Tweede deel: *-o* (zaak), *-u* (persoon), *-am* (tijdstip), *-a* (eigenschap), *-el* (aard & wijze), *-om* (hoeveelheid), *-al* (reden), *-es* (bezit)
+
+Samengevoegd geeft dat bijvoorbeeld:
+
+- *ki-* + *-am* = *kiam* (wanneer)
+- *neni-* + *-o* = *nenio* (niets)
+- *ĉi-* + *-u* = *ĉiu* (iedereen)
+
+**De volledige tabel** met alle 45 woorden en hun betekenissen staat in de bijlage: [Tabelwoorden](/nl/tabelvortoj/).
 
 # *Ĉi*
 


### PR DESCRIPTION
## Problemo

En `enhavo/tradukenda/nl/gramatiko/05.md` la Markdown-tabelo de tabelvortoj
aperis kiel kruda teksto kun videblaj `|`, ĉar mistune estas agordita sen la
`table`-kromaĵo (`fonto/py/html.py`).

## Solvo

`nl` estis la **sola** dosiero en la tuta `enhavo/`-arbo kun enlinia
Markdown-tabelo. La germana kaj angla versioj jam ligas al la aldona paĝo
`/xx/tabelvortoj/`, kiu estas generita el Jinja-ŝablono
(`fonto/html/tabelvortoj.html`) kiel ĝuste stilita `<table class="table">`.

Tial mi forigis la enlinian tabelon kaj anstataŭigis ĝin per:

- klariga listo de la komencoj (`ki-`, `ti-`, `i-`, `ĉi-`, `neni-`) kaj finaĵoj
  kun ekzemploj, same kiel en la germana versio;
- ligilo al `/nl/tabelvortoj/`.

Tiel `nl` fariĝas konsekvenca kun la aliaj lingvoj kaj ne plu duobligas la
aldonan tabelon.

## Testado

- `make check` sukcesis.
- `make html LINGVO=nl` generis `eligo/retejo/nl/05/gramatiko/index.html` sen
  krudaj `|`; la ligilo aperas kiel `<a href="/nl/tabelvortoj/">Tabelwoorden</a>`,
  kaj `/nl/tabelvortoj/` enhavas la stilitan tabelon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
