### PR TITLE
Plibonigu anglajn gramatik-klarigojn laŭ pedagogiaj normoj

### DIFF
--- a/enhavo/tradukenda/en/gramatiko/01.md
+++ b/enhavo/tradukenda/en/gramatiko/01.md
@@ -28,9 +28,9 @@ Note the following differences from English:
 	- *aŭ* = ou in "mouth"
 	- *eŭ* = "eh-oo"
 
-**Watch out:** three familiar-looking letters sound different — *c* is "ts" (not "k" or "s"), *j* is "y" (not the "j" of "jam"), and *g* is always hard. So *ĝi* is "jee", whereas *gi* would be "ghee".
+**⚠️ Watch out:** three familiar-looking letters sound different — *c* is "ts" (not "k" or "s"), *j* is "y" (not the "j" of "jam"), and *g* is always hard. So *ĝi* is "jee", whereas *gi* would be "ghee".
 
-**Keep vowels pure:** Esperanto vowels are short and clean. Say *o* as a crisp "oh", not "oh-w"; *e* as "eh", not "ay".
+**⚠️ Keep vowels pure:** Esperanto vowels are short and clean. Say *o* as a crisp "oh", not "oh-w"; *e* as "eh", not "ay".
 
 # Pronunciation
 
@@ -51,7 +51,7 @@ Words of more than one syllable are stressed on the penultimate (second-to-last)
 - *ES-tas* (ESS-tahss)
 - note *AN-kaŭ* (because *kaŭ* is a single syllable)
 
-**Watch out:** count syllables the Esperanto way. Adjacent vowels form separate syllables, so *historio* is hi-sto-RI-o (hee-stoh-REE-oh), not "his-TO-ryo".
+**⚠️ Watch out:** count syllables the Esperanto way. Adjacent vowels form separate syllables, so *historio* is hi-sto-RI-o (hee-stoh-REE-oh), not "his-TO-ryo".
 
 # Article
 
@@ -62,7 +62,7 @@ The definite article is *la* ("the"). It never changes — no variation for gend
 - *la laboro* – the work
 	- *laboro* – work
 
-**Watch out:** don't translate "a / an" — Esperanto simply leaves it out. *Ĝi estas amiko* = "It is a friend."
+**⚠️ Watch out:** don't translate "a / an" — Esperanto simply leaves it out. *Ĝi estas amiko* = "It is a friend."
 
 # Personal Pronouns
 
@@ -104,7 +104,7 @@ The plural ending is *__-j__*. Both nouns and adjectives take it:
 - *lernanto__j__* – learners
 - *via__j__ lernanto__j__* – your learners
 
-**Watch out:** the plural is *-j* (pronounced like "y"), not *-s* as in English. "Tables" is *tabloj* (TAH-bloy), never *tablos*.
+**⚠️ Watch out:** the plural is *-j* (pronounced like "y"), not *-s* as in English. "Tables" is *tabloj* (TAH-bloy), never *tablos*.
 
 # Verbs
 
@@ -120,7 +120,7 @@ The verb endings are the same for every person and number — there is no extra 
 	- *ni sid__as__* – we sit
 	- *ili sid__as__* – they sit
 
-**Watch out:** English adds *-s* in the third person ("he sits"); Esperanto never does — *mi sidas, li sidas, ili sidas* are all identical.
+**⚠️ Watch out:** English adds *-s* in the third person ("he sits"); Esperanto never does — *mi sidas, li sidas, ili sidas* are all identical.
 
 # *Ĉu?*
 
@@ -152,7 +152,7 @@ forms the feminine of a noun:
 - *lernanto* – pupil / *lernant__in__o* – pupil (female)
 - *instruisto* – teacher / *instruist__in__o* – (woman) teacher
 
-**Memory aid:** think of the English "-ine" in *hero → heroine* — the *-in-* signals "female".
+**💡 Memory aid:** think of the English "-ine" in *hero → heroine* — the *-in-* signals "female".
 
 # Affirmative Particle
 

--- a/enhavo/tradukenda/en/gramatiko/01.md
+++ b/enhavo/tradukenda/en/gramatiko/01.md
@@ -1,63 +1,68 @@
 # Alphabet
 
-The Esperanto alphabet consists of 28 letters: a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z.
+The Esperanto alphabet has 28 letters: *a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z*. Each letter always stands for exactly one sound, so once you know the alphabet you can read any word aloud — there are no silent letters and no exceptions.
 
 Note the following differences from English:
 
-- __a__ as in "father"
-- __c__ = ts as in "Betsy"
-- __ĉ__ = ch as in "church"
-- __e__ as in "there"
-- __g__ as in "give"
-- __ĝ__ as in "judge"
-- __h__ as in "hammer"
-- __ĥ__ = Scottish ch as in "Loch"
-- __i__ as in "machine"
-- __j__ = y as in "yes". __aj__, __ej__, __oj__, __uj__ are diphthongs consisting respectively of a, e, o, u plus a short i-sound. Thus
-	- __aj__ = i in "die"
-	- __ej__ = a in "face"
-	- __oj__ = oy in "boy"
-	- __uj__ = ui in "ruin", pronounced quickly.
-- __ĵ__ = zh  as in "measure"
-- __o__  as in "north"
-- __r__ is always pronounced – ideally, rolled
-- __s__ as in "sense"
-- __ŝ__ = sh in "sharp"
-- __u__ as in "fool"
-- __ŭ__ = w as in "tower". __aŭ__, __eŭ__ are diphthongs consisting respectively of "a" or "e" plus a short oo-sound. Thus
-	- aŭ = ou in "mouth"
-	- eŭ = "eh-oo".
+- *a* as in "father"
+- *c* = ts as in "Betsy"
+- *ĉ* = ch as in "church"
+- *e* as in "there"
+- *g* as in "give" (always hard, never as in "gem")
+- *ĝ* = j as in "judge"
+- *h* as in "hammer"
+- *ĥ* = Scottish ch as in "loch"
+- *i* as in "machine"
+- *j* = y as in "yes". The combinations *aj, ej, oj, uj* are diphthongs, made of a, e, o, u plus a short i-sound:
+	- *aj* = i in "die"
+	- *ej* = a in "face"
+	- *oj* = oy in "boy"
+	- *uj* = ui in "ruin", said quickly
+- *ĵ* = zh as in "measure"
+- *o* as in "north"
+- *r* is always pronounced — ideally rolled
+- *s* as in "sense" (always hissed, never z as in "rose")
+- *ŝ* = sh as in "sharp"
+- *u* as in "fool"
+- *ŭ* = w as in "tower". The combinations *aŭ, eŭ* are diphthongs, made of a or e plus a short oo-sound:
+	- *aŭ* = ou in "mouth"
+	- *eŭ* = "eh-oo"
 
+**Watch out:** three familiar-looking letters sound different — *c* is "ts" (not "k" or "s"), *j* is "y" (not the "j" of "jam"), and *g* is always hard. So *ĝi* is "jee", whereas *gi* would be "ghee".
+
+**Keep vowels pure:** Esperanto vowels are short and clean. Say *o* as a crisp "oh", not "oh-w"; *e* as "eh", not "ay".
 
 # Pronunciation
 
-Words are pronounced exactly as spelled, applying the equivalents mentioned above, e.g.
+Words are pronounced exactly as spelled, applying the values above, e.g.
 
 - *amiko* = ah-MEE-koh
 - *ĉambro* = CHAHM-broh
-- *ĝi* = jee.
+- *ĝi* = jee
 
 # Stress
 
-Words of more than one syllable are stressed on the penultimate syllable, e.g.
+Words of more than one syllable are stressed on the penultimate (second-to-last) syllable — always, with no exceptions:
 
 - *te-le-FO-no* (teh-leh-FOH-noh)
 - *ra-DI-o* (rah-DEE-oh)
 - *kaj* (kigh)
-- a-MI-ko (ah-MEE-koh)
-- ES-tas (ESS-tahss).
-- NB: AN-kaŭ (because kaŭ is a single syllable).
+- *a-MI-ko* (ah-MEE-koh)
+- *ES-tas* (ESS-tahss)
+- note *AN-kaŭ* (because *kaŭ* is a single syllable)
 
-Be careful with words like historio (hi-sto-RI-o, hee-stoh-REE-oh).
+**Watch out:** count syllables the Esperanto way. Adjacent vowels form separate syllables, so *historio* is hi-sto-RI-o (hee-stoh-REE-oh), not "his-TO-ryo".
 
 # Article
 
-The definite article is *la* (*the*). It is invariable (no change for gender, case or number). There is no indefinite article:
+The definite article is *la* ("the"). It never changes — no variation for gender, case or number. There is no indefinite article:
 
 - *la amiko* – the friend
-  - *amiko* – a friend
+	- *amiko* – a friend
 - *la laboro* – the work
-  - *laboro* – work
+	- *laboro* – work
+
+**Watch out:** don't translate "a / an" — Esperanto simply leaves it out. *Ĝi estas amiko* = "It is a friend."
 
 # Personal Pronouns
 
@@ -69,23 +74,23 @@ The definite article is *la* (*the*). It is invariable (no change for gender, ca
 - *ni* – we
 - *ili* – they
 
-The pronouns *li, ŝi, ĝi* are used in just the same way as English "he, she, it".
+The pronouns *li, ŝi, ĝi* work just like English "he, she, it".
 
 # Possessive Pronouns
 
-These are formed by adding the ending __a__ to the simple pronouns:
+These are formed quite regularly, by adding the ending *__-a__* to the simple pronouns:
 
-- *mia* – my
-- *via* – your
-- *lia* – his
-- *ŝia* – her
-- *ĝia* – its
-- *nia* – our
-- *ilia* – their
+- *mi__a__* – my
+- *vi__a__* – your
+- *li__a__* – his
+- *ŝi__a__* – her
+- *ĝi__a__* – its
+- *ni__a__* – our
+- *ili__a__* – their
 
 # Nouns
 
-All nouns end in -O. There is no grammatical gender: where appropriate, feminine sex is indicated by a suffix.
+All nouns end in *__-o__*. There is no grammatical gender; where appropriate, the female sex is shown by a suffix:
 
 - *tabl__o__* – table
 - *lernant__o__* – learner
@@ -93,69 +98,71 @@ All nouns end in -O. There is no grammatical gender: where appropriate, feminine
 
 # Plural
 
-The plural ending is __j__. Both nouns and adjectives take this ending, e.g.:
+The plural ending is *__-j__*. Both nouns and adjectives take it:
 
 - *tablo__j__* – tables
 - *lernanto__j__* – learners
 - *via__j__ lernanto__j__* – your learners
 
+**Watch out:** the plural is *-j* (pronounced like "y"), not *-s* as in English. "Tables" is *tabloj* (TAH-bloy), never *tablos*.
+
 # Verbs
 
-1. The infinitive ending is __-i__, e.g.
-   - *lern__i__* – to learn
-   - *labor__i__* – to work
-   - *est__i__* – to be.
-2. The present tense ending is __-as__. It is the same for all persons and numbers:
-   - *mi sid__as__* – I sit
-   - *vi sid__as__* – you sit
-   - *ni sid__as__* – we sit
-   - *ili sid__as__* – they sit.
+The verb endings are the same for every person and number — there is no extra *-s* for "he/she/it" as in English.
+
+1. The infinitive ends in *__-i__*:
+	- *lern__i__* – to learn
+	- *labor__i__* – to work
+	- *est__i__* – to be
+2. The present tense ends in *__-as__*, the same for all persons:
+	- *mi sid__as__* – I sit
+	- *vi sid__as__* – you sit
+	- *ni sid__as__* – we sit
+	- *ili sid__as__* – they sit
+
+**Watch out:** English adds *-s* in the third person ("he sits"); Esperanto never does — *mi sidas, li sidas, ili sidas* are all identical.
 
 # *Ĉu?*
 
-This is an interrogative particle, used to turn a statement into a yes/no question:
+*ĉu* is a question word that turns a statement into a yes/no question. English does this by inverting the verb or adding "do"; Esperanto just puts *ĉu* in front and keeps the word order:
 
 - *__Ĉu__ vi sidas?* – Are you sitting?
 - *__Ĉu__ vi skribas?* – Are you writing? Do you write?
 
 # *Kiu?*
 
-This interrogative functions both as a pronoun ("who?") and as an adjective ("which?"), e.g.
+This question word works both as a pronoun ("who?") and as an adjective ("which?"):
 
 - *__Kiu__ vi estas?* – Who are you?
 - *__Kiu__ instruisto sidas?* – Which teacher is sitting?
 
+# The Suffix *__-ist__*
 
-# The Suffix *-ist*
-
-is used to form the name of a person regularly engaged in some activity, e.g.
-
+forms the name of a person regularly engaged in some activity — just like English "-ist":
 
 - *instru__ist__o* – teacher
 - *hotel__ist__o* – hotelier, hotel-keeper
-- *esperant__ist__o* – Esperantist, adherent of Esperanto
+- *esperant__ist__o* – Esperantist, supporter of Esperanto
 
+# The Suffix *__-in__*
 
-# The Suffix *-in*
+forms the feminine of a noun:
 
-is used to form the feminine of a noun:
+- *patro* – father / *patr__in__o* – mother
+- *lernanto* – pupil / *lernant__in__o* – pupil (female)
+- *instruisto* – teacher / *instruist__in__o* – (woman) teacher
 
-- *patro* – father
-    - *patr__in__o* – mother
-- *lernanto* – pupil
-    - *lernant__in__o* – pupil (female)
-- *instruisto* – teacher
-    - *instruist__in__o* – (woman) teacher
+**Memory aid:** think of the English "-ine" in *hero → heroine* — the *-in-* signals "female".
 
 # Affirmative Particle
 
-*__jes__* has the same sound and meaning as the English "yes".
+*__jes__* has the same sound and meaning as English "yes":
 
-- *Ĉu vi estas en la ĉambro?* 
-  - *__Jes__, mi estas en la ĉambro.* 
+- *Ĉu vi estas en la ĉambro?*
+	- *__Jes__, mi estas en la ĉambro.*
 
 # Negative Particle
 
-*__ne__* corresponds to "no" (opposite of "yes") and to "not":
+*__ne__* corresponds both to "no" (the opposite of "yes") and to "not":
 
-- *__Ne__, mi __ne__ estas en la ĉambro.* 
+- *__Ne__, mi __ne__ estas en la ĉambro.*

--- a/enhavo/tradukenda/en/gramatiko/02.md
+++ b/enhavo/tradukenda/en/gramatiko/02.md
@@ -1,85 +1,92 @@
 # Adjectives
 
-The adjectival ending is *__-a__*, e.g.
+The adjective ending is *__-a__*:
 
 - *bel__a__* – beautiful
 - *grand__a__ frato* – big brother
 - *malgrand__a__ fratino* – little sister
 
+**Memory aid:** the final vowel signals the part of speech — *-o* for nouns, *-a* for adjectives, *-e* for adverbs ([lesson 3](/en/03/gramatiko/)).
+
 # Cases
 
-Esperanto nouns have two cases, nominative and accusative. The accusative is used to show the object of a transitive verb (the person or thing affected by the action of the verb).
+Esperanto nouns have two cases, nominative and accusative. The accusative, marked by *__-n__*, shows the object of a transitive verb (the person or thing affected by the action):
 
 - *Kiu__n__ mi vidas?* – Who__m__ do I see?
-- *Mi vidas amiko__n__* – I see a friend.
+- *Mi vidas amiko__n__.* – I see a friend.
+
+**Memory aid:** English keeps a special object form in only a few pronouns — *me, him, whom*. Esperanto is consistent and marks *every* object with *-n*.
 
 Do not use the accusative after the verb "to be" or its equivalents.
 
-Adjectives agree with the nouns they qualify: they take the same *__-j__* and *__-n__* endings.
+Adjectives agree with the nouns they qualify, taking the same *__-j__* and *__-n__* endings:
 
-- *Vi estas bon__a__ amik__o__* – You're a good friend.
-- *Vi estas bon__aj__ amik__oj__* – You're good friends.
-- *Vi havas bon__an__ amik__on__* – You have a good friend.
-- *Vi havas bon__ajn__ amik__ojn__* – You have good friends.
+- *Vi estas bon__a__ amik__o__.* – You're a good friend.
+- *Vi estas bon__aj__ amik__oj__.* – You're good friends.
+- *Vi havas bon__an__ amik__on__.* – You have a good friend.
+- *Vi havas bon__ajn__ amik__ojn__.* – You have good friends.
 
-Esperanto expresses other case relationships through the use of prepositions. The English possessive is rendered by *__de__*:
+Esperanto expresses other case relationships with prepositions. The English possessive ('s) is rendered by *__de__* ("of"):
 
 - *La libroj __de__ mia frato.* – My brother's books.
 
-# Conjugation 
+# Conjugation
 
-## Base form: *-i*
-  
-- *labor__i__*          – to work
+To conjugate, simply replace the infinitive *-i* with the tense ending. The ending is the same for every person, and there are no irregular verbs.
 
-## Present tense: *-as*
+## Base form: *__-i__*
 
-- *mi labor__as__*      – I work
-- *vi labor__as__*      – You work
-- *li/ŝi labor__as__*   – He/she works
-- *ni labor__as__*      – We work 
-- *ili labor__as__*     – They work
+- *labor__i__* – to work
 
-## Past tense: *-is*
+## Present tense: *__-as__*
 
-- *mi labor__is__*      – I worked.
-- *vi labor__is__*      – You worked.
-- *li/ŝi labor__is__*   – He/she worked.
-- *ni labor__is__*      – We worked.
-- *ili labor__is__*     – They worked.
+- *mi labor__as__* – I work
+- *vi labor__as__* – you work
+- *li/ŝi labor__as__* – he/she works
+- *ni labor__as__* – we work
+- *ili labor__as__* – they work
 
-## Future tense: *-os*
+## Past tense: *__-is__*
 
-- *mi labor__os__*      – I will work.
-- *vi labor__os__*      – You will work.
-- *li/ŝi labor__os__*   – He/she will work.
-- *ni labor__os__*      – We will work.
-- *ili labor__os__*     – They will work.
+- *mi labor__is__* – I worked
+- *vi labor__is__* – you worked
+- *li/ŝi labor__is__* – he/she worked
+- *ni labor__is__* – we worked
+- *ili labor__is__* – they worked
+
+## Future tense: *__-os__*
+
+- *mi labor__os__* – I will work
+- *vi labor__os__* – you will work
+- *li/ŝi labor__os__* – he/she will work
+- *ni labor__os__* – we will work
+- *ili labor__os__* – they will work
+
+**Memory aid:** the tense vowels run i–a–o: *-is* (past), *-as* (present), *-os* (future).
 
 # The conjunction *ke*
 
-is used to introduce a noun clause. Unlike its English equivalent "that":
+introduces a noun clause. Unlike its English equivalent "that":
 
-1. it cannot be omitted, and
+1. it can never be omitted, and
 2. it is usually preceded by a comma.
 
-Examples:
+- *Vi vidas, __ke__ mi manĝas.* – You see that I'm eating.
+- *Li diras, __ke__ li iros.* – He says he'll go.
 
-- *Vi vidas __ke__ mi manĝas.* – You see that I'm eating.
-- *Li diras __ke__ li iros.* – He says he'll go.
+**Watch out:** don't confuse *ke* ("that", a conjunction) with *kio* ("what", a question word). *ke* only links clauses and asks nothing.
 
-# The prefix *mal-*
+# The prefix *__mal-__*
 
-changes the meaning of a word to its opposite.
+changes a word to its exact opposite:
 
-- *bona* – good
-  - *__mal__bona* – bad
-- *granda* – big, great
-  - *__mal__granda* – little, small
-- *bela* – beautiful
-  - *__mal__bela* – ugly
+- *bona* – good / *__mal__bona* – bad
+- *granda* – big, great / *__mal__granda* – little, small
+- *bela* – beautiful / *__mal__bela* – ugly
 
-# The prefix *ge-*
+**Memory aid:** you already know *mal-* from English words like *malfunction* and *malformed*. One prefix saves learning a separate word for every opposite.
+
+# The prefix *__ge-__*
 
 denotes both sexes together:
 
@@ -94,19 +101,19 @@ denotes both sexes together:
 
 # Word order
 
-The usual order of words in the sentence is subject-verb-object, as in English. However, since the accusative ending *-n* of the object makes it clear which is the subject and which the object, word order can be varied for stylistic or pragmatic purposes, very much more readily in Esperanto than in English.
+The usual order is subject–verb–object, as in English. But because the accusative *-n* shows which word is the object, word order can be varied far more freely than in English — for emphasis or style:
 
 - *Mi legas libron.* – I'm reading a book.
 - *Libron mi legas.* – (A book is what I'm reading.)
 
 # *Kio, Kion*
 
-*Kio* means "what", as subject of the sentence:
+*kio* means "what" as the subject of the sentence:
 
 - *__Kio__ estas tio?* – What's that?
 - *__Kio__ estas sur la tablo?* – What is on the table?
 
-Where "what" is the object of the verb, the Esperanto equivalent is *Kion*:
+When "what" is the object of the verb, the Esperanto equivalent takes the accusative, *kion*:
 
 - *__Kion__ vi faras?* – What are you doing?
 - *__Kion__ ŝi diris?* – What did she say?

--- a/enhavo/tradukenda/en/gramatiko/02.md
+++ b/enhavo/tradukenda/en/gramatiko/02.md
@@ -6,7 +6,7 @@ The adjective ending is *__-a__*:
 - *grand__a__ frato* – big brother
 - *malgrand__a__ fratino* – little sister
 
-**Memory aid:** the final vowel signals the part of speech — *-o* for nouns, *-a* for adjectives, *-e* for adverbs ([lesson 3](/en/03/gramatiko/)).
+**💡 Memory aid:** the final vowel signals the part of speech — *-o* for nouns, *-a* for adjectives, *-e* for adverbs ([lesson 3](/en/03/gramatiko/)).
 
 # Cases
 
@@ -15,7 +15,7 @@ Esperanto nouns have two cases, nominative and accusative. The accusative, marke
 - *Kiu__n__ mi vidas?* – Who__m__ do I see?
 - *Mi vidas amiko__n__.* – I see a friend.
 
-**Memory aid:** English keeps a special object form in only a few pronouns — *me, him, whom*. Esperanto is consistent and marks *every* object with *-n*.
+**💡 Memory aid:** English keeps a special object form in only a few pronouns — *me, him, whom*. Esperanto is consistent and marks *every* object with *-n*.
 
 Do not use the accusative after the verb "to be" or its equivalents.
 
@@ -62,7 +62,7 @@ To conjugate, simply replace the infinitive *-i* with the tense ending. The endi
 - *ni labor__os__* – we will work
 - *ili labor__os__* – they will work
 
-**Memory aid:** the tense vowels run i–a–o: *-is* (past), *-as* (present), *-os* (future).
+**💡 Memory aid:** the tense vowels run i–a–o: *-is* (past), *-as* (present), *-os* (future).
 
 # The conjunction *ke*
 
@@ -74,7 +74,7 @@ introduces a noun clause. Unlike its English equivalent "that":
 - *Vi vidas, __ke__ mi manĝas.* – You see that I'm eating.
 - *Li diras, __ke__ li iros.* – He says he'll go.
 
-**Watch out:** don't confuse *ke* ("that", a conjunction) with *kio* ("what", a question word). *ke* only links clauses and asks nothing.
+**⚠️ Watch out:** don't confuse *ke* ("that", a conjunction) with *kio* ("what", a question word). *ke* only links clauses and asks nothing.
 
 # The prefix *__mal-__*
 
@@ -84,7 +84,7 @@ changes a word to its exact opposite:
 - *granda* – big, great / *__mal__granda* – little, small
 - *bela* – beautiful / *__mal__bela* – ugly
 
-**Memory aid:** you already know *mal-* from English words like *malfunction* and *malformed*. One prefix saves learning a separate word for every opposite.
+**💡 Memory aid:** you already know *mal-* from English words like *malfunction* and *malformed*. One prefix saves learning a separate word for every opposite.
 
 # The prefix *__ge-__*
 

--- a/enhavo/tradukenda/en/gramatiko/03.md
+++ b/enhavo/tradukenda/en/gramatiko/03.md
@@ -1,65 +1,64 @@
 # Adverbs
 
-Adverbs may be formed by adding the ending *-e*.
+Derived adverbs are formed with the ending *__-e__*. This completes the vowel system: *-o* for nouns, *-a* for adjectives, *-e* for adverbs.
 
-- *bel__e__*   – beautifully
-- *fort__e__*  – strongly
-- *rapid__a__ aŭto*   – a fast car
-	- *veturi rapid__e__*   – to travel fast
-
+- *bel__e__* – beautifully
+- *fort__e__* – strongly
+- *rapid__a__ aŭto* – a fast car
+	- *veturi rapid__e__* – to travel fast
 
 # The prepositions *per* and *kun*
 
-## *Per* - with (by means of, making use of)
+Both can translate as "with", but they cover different meanings.
 
-- *Manĝi __per__ kulero* – To eat with a spoon
+## *Per* – with (by means of, using)
+
+- *Manĝi __per__ kulero* – to eat with a spoon
 - *Ŝi kantis __per__ tre bela voĉo.* – She sang with (in) a very beautiful voice.
- 
-## *Kun* - with (together with)        
 
-- *Mi iris __kun__ la amiko.*    – I went with the friend.
-- *Mi parolos __kun__ li.*       – I will talk to him.
+## *Kun* – with (together with)
 
+- *Mi iris __kun__ la amiko.* – I went with the friend.
+- *Mi parolos __kun__ li.* – I will talk to him.
 
+**Memory aid:** *kun* is company (you do something *with* someone), *per* is the means (you do something *by means of* a thing).
 
 # The Preposition *post*
 
 *post* – after (referring to time)
 
-- *Li venis __post__ mi.*   – He came after me (after I did).
+- *Li venis __post__ mi.* – He came after me (after I did).
 - *__post__ du horoj* – in two hours' time
 - *Li venos __post__ tri horoj.* – He will come in three hours.
 - *poste* – afterwards, later on
 
+# The Preposition *malantaŭ*
 
-# The Preposition *Malantaŭ*
+*malantaŭ* – behind (referring to place)
 
-*malantaŭ* - behind
+- *Li venis __malantaŭ__ mi.* – He came behind me (walking or driving along behind).
 
-- *Li venis __malantaŭ__ mi.* – He came behind me (walking / driving along behind).
+**Watch out:** stress this word correctly — *mal__an__taŭ*. Note that it is just *mal-* + *antaŭ* (in front of), so "behind" is literally the opposite of "in front of".
 
-Be careful to stress this word correctly: *mal__an__taŭ*.
- 
-# The suffix *-ul*
+# The suffix *__-ul__*
 
-A person characterized by some quality:
+a person characterized by some quality:
 
-- *grand__ul__o*  – a large person
+- *grand__ul__o* – a large person
 - *malbon__ul__o* – a bad person
-- *bel__ul__ino*  – a beautiful woman, a beauty
+- *bel__ul__ino* – a beautiful woman, a beauty
 
- 
-
-# The suffix *-ej*
+# The suffix *__-ej__*
 
 forms the word for a place where something regularly happens:
 
-- *lern__ej__o*  – school (place for learning)
-- *kuir__ej__o*  – kitchen (place for cooking: *kuiri* – to cook)
+- *lern__ej__o* – school (place for learning)
+- *kuir__ej__o* – kitchen (*kuiri* – to cook)
 - *labor__ej__o* – workplace
- 
 
-# The suffix *-ebl*
+**Memory aid:** *-ej* turns an activity into its place: *lerni* (to learn) → *lernejo* (school), *kuiri* (to cook) → *kuirejo* (kitchen).
+
+# The suffix *__-ebl__*
 
 denotes possibility, and corresponds to English "-able", "-ible":
 
@@ -69,16 +68,14 @@ denotes possibility, and corresponds to English "-able", "-ible":
 - *__ebl__e* – perhaps, maybe
 - *mal__ebl__a* – impossible
 
-
 # The Imperative
 
-The verb ending for a command is *-u*.
+The verb ending for a command is *__-u__*:
 
-- *Manĝ__u__!*   – Eat! Eat up!
-- *Ir__u__!*   – Go! Go on!
+- *Manĝ__u__!* – Eat! Eat up!
+- *Ir__u__!* – Go! Go on!
 
-This form can also be expressed with a subject:
+It can also be used with a subject:
 
 - *Li lern__u__!* – Let him learn!
-- *Ni vid__u__.*  – Let's see.
- 
+- *Ni vid__u__.* – Let's see.

--- a/enhavo/tradukenda/en/gramatiko/03.md
+++ b/enhavo/tradukenda/en/gramatiko/03.md
@@ -21,7 +21,7 @@ Both can translate as "with", but they cover different meanings.
 - *Mi iris __kun__ la amiko.* – I went with the friend.
 - *Mi parolos __kun__ li.* – I will talk to him.
 
-**Memory aid:** *kun* is company (you do something *with* someone), *per* is the means (you do something *by means of* a thing).
+**💡 Memory aid:** *kun* is company (you do something *with* someone), *per* is the means (you do something *by means of* a thing).
 
 # The Preposition *post*
 
@@ -38,7 +38,7 @@ Both can translate as "with", but they cover different meanings.
 
 - *Li venis __malantaŭ__ mi.* – He came behind me (walking or driving along behind).
 
-**Watch out:** stress this word correctly — *mal__an__taŭ*. Note that it is just *mal-* + *antaŭ* (in front of), so "behind" is literally the opposite of "in front of".
+**⚠️ Watch out:** stress this word correctly — *mal__an__taŭ*. Note that it is just *mal-* + *antaŭ* (in front of), so "behind" is literally the opposite of "in front of".
 
 # The suffix *__-ul__*
 
@@ -56,7 +56,7 @@ forms the word for a place where something regularly happens:
 - *kuir__ej__o* – kitchen (*kuiri* – to cook)
 - *labor__ej__o* – workplace
 
-**Memory aid:** *-ej* turns an activity into its place: *lerni* (to learn) → *lernejo* (school), *kuiri* (to cook) → *kuirejo* (kitchen).
+**💡 Memory aid:** *-ej* turns an activity into its place: *lerni* (to learn) → *lernejo* (school), *kuiri* (to cook) → *kuirejo* (kitchen).
 
 # The suffix *__-ebl__*
 

--- a/enhavo/tradukenda/en/gramatiko/04.md
+++ b/enhavo/tradukenda/en/gramatiko/04.md
@@ -22,7 +22,7 @@ But a preposition of place may take the accusative *__-n__* to show motion towar
 - *La kato saltis sur la tablo__n__.* – The cat jumped onto the table.
 	- (Compare: *La kato saltis sur la tablo.* – The cat jumped around on the table.)
 
-**Memory aid:** the *-n* is exactly the difference between English "in" and "into", "on" and "onto": no *-n* = where (location), *-n* = where to (motion). *en la domo* = in the house, *en la domon* = into the house.
+**💡 Memory aid:** the *-n* is exactly the difference between English "in" and "into", "on" and "onto": no *-n* = where (location), *-n* = where to (motion). *en la domo* = in the house, *en la domon* = into the house.
 
 # The pronoun *oni*
 
@@ -31,7 +31,7 @@ The indefinite pronoun *oni* means "people (in general)", "they", or "you" (in t
 - *__Oni__ manĝas.* – People are eating.
 - *__Oni__ sidas.* – People are sitting.
 
-**Memory aid:** *oni* matches the English impersonal "one" — and conveniently even looks like it.
+**💡 Memory aid:** *oni* matches the English impersonal "one" — and conveniently even looks like it.
 
 # The reflexive pronoun *si*
 

--- a/enhavo/tradukenda/en/gramatiko/04.md
+++ b/enhavo/tradukenda/en/gramatiko/04.md
@@ -1,76 +1,55 @@
 # Numerals
 
-The numerals are listed in the appendix. Higher numbers are formed by combining elementary numerals as follows:
+The numerals are listed in the appendix. Higher numbers are formed by combining the basic numerals:
 
-- 1 238                     – *mil du-cent tri-dek ok*
-- 153 837                   – *cent kvin-dek tri mil ok-cent tri-dek sep*
-- Addition:      8 + 3 = 11 – *ok plus tri estas dek-unu*
-- Subtraction:   15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
+- 1 238 – *mil du-cent tri-dek ok*
+- 153 837 – *cent kvin-dek tri mil ok-cent tri-dek sep*
+- Addition: 8 + 3 = 11 – *ok plus tri estas dek-unu*
+- Subtraction: 15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
 
 # Accusative of Motion Towards
 
-Esperanto prepositions are normally followed by the nominative case:
+Esperanto prepositions are normally followed by the nominative:
 
 - *post mi* – after me
 - *sen ŝi* – without her
 - *en domo* – in a house
 
-However, prepositions describing place may be followed by an accusative to show motion toward, e.g.
+But a preposition of place may take the accusative *__-n__* to show motion toward something:
 
 - *Mi iras en la domo__n__.* – I am going into the house.
-- (Compare: *Ili manĝas en la domo.* – They are eating in the house.)
-
-Another example:
-
+	- (Compare: *Ili manĝas en la domo.* – They are eating in the house.)
 - *La kato saltis sur la tablo__n__.* – The cat jumped onto the table.
-- *La kato saltis sur la tablo.* – The cat jumped around on the table.
+	- (Compare: *La kato saltis sur la tablo.* – The cat jumped around on the table.)
+
+**Memory aid:** the *-n* is exactly the difference between English "in" and "into", "on" and "onto": no *-n* = where (location), *-n* = where to (motion). *en la domo* = in the house, *en la domon* = into the house.
 
 # The pronoun *oni*
 
-The indefinite pronoun *oni* means
-
-- people (in general)
-- they
-- you.
-
-Examples:
+The indefinite pronoun *oni* means "people (in general)", "they", or "you" (in the general sense):
 
 - *__Oni__ manĝas.* – People are eating.
 - *__Oni__ sidas.* – People are sitting.
- 
+
+**Memory aid:** *oni* matches the English impersonal "one" — and conveniently even looks like it.
 
 # The reflexive pronoun *si*
 
-The pronoun *si* (accusative *sin*) refers back to the subject of the clause:
-
-- himself
-- herself
-- itself
-- themselves
-- oneself
-
-Examples:
+*si* (accusative *sin*) refers back to the subject of the clause — himself, herself, itself, themselves, oneself:
 
 - *Li lavas __sin__.* – He washes himself.
 - *Ŝi rigardas __sin__.* – She looks at herself.
 - *Ili kantas al __si__.* – They are singing to themselves.
- 
-*si* is used only in referring to a third-person subject. It is never itself the subject of a sentence. Compare:
+
+*si* is used only for a third-person subject, and is never itself the subject of a sentence. Compare:
 
 - *Mi rigardas min.* – I look at myself.
 - *Ili rigardas sin.* – They look at themselves.
 
-# The prefix *re-*
+# The prefix *__re-__*
 
-Like English "re-", it can mean either
-
-- "again, a second time"
-- or "back".
-
-Examples:
+Like English "re-", it can mean either "again, a second time" or "back":
 
 - *__re__vidi* – to see again
-- *__re__doni* – to give back 
+- *__re__doni* – to give back
 - *__re__meti* – to put back, to replace
-
- 

--- a/enhavo/tradukenda/en/gramatiko/05.md
+++ b/enhavo/tradukenda/en/gramatiko/05.md
@@ -86,7 +86,7 @@ The particle *ĉi* is used with *ti-*correlatives to show nearness:
 - *tiu* – that one / *tiu __ĉi__* or *__ĉi__ tiu* – this one
 - *tie* – there / *tie __ĉi__* or *__ĉi__ tie* – here
 
-**Memory aid:** *ĉi* always pulls things close — *ĉi tie* is "here", the spot you could almost touch.
+**💡 Memory aid:** *ĉi* always pulls things close — *ĉi tie* is "here", the spot you could almost touch.
 
 # The suffix *__-ind__*
 

--- a/enhavo/tradukenda/en/gramatiko/05.md
+++ b/enhavo/tradukenda/en/gramatiko/05.md
@@ -1,36 +1,35 @@
 # Table of correlatives
 
-Study the table in the appendix, observing how logically it is built up: the meaning of each of the 45 words in it may be deduced from the meaning of the first element combined with the meaning of the second element. Memorize the following in particular:
+A family of 45 short, regular words (who, what, where, when, this, that, everything, nothing …) is built on a simple grid. Study the full table in the appendix — [Table of correlatives](/en/tabelvortoj/) — and notice how logically it is built up: the meaning of each word follows from its first part plus its second part. Memorize these in particular:
 
-- *ĉio*  – everything
-- *ĉiu*  – each, every, everyone
-- *ĉiuj*  – all (plural)
+- *ĉio* – everything
+- *ĉiu* – each, every, everyone
+- *ĉiuj* – all (plural)
 - *ĉiam* – always
 - *iom* – a bit, somewhat, rather
 
-Some of the words in the table may take the endings *-j* (plural) and *-n* (accusative):
+Some correlatives can take the endings *-j* (plural) and *-n* (accusative):
 
-- the *-j* ending can be attached to those ending in *-u* and *-a*
-- the *-n* ending to those with *-o*, *-u*, *-a* and *-e*:
+- *-j* attaches to those ending in *-u* and *-a*
+- *-n* to those ending in *-o*, *-u*, *-a* and *-e*
 
-## Kio 
+## Kio
 
-- *Kio* – what 
+- *kio* – what
 - *kion* – what (as object)
 
-Example: 
+Example:
 
-- *Kion vi manĝas? Kukon mi manĝas.*
+- *Kion vi manĝas? Kukon mi manĝas.* – What are you eating? I'm eating cake.
 
 ## Kiu
-- *Kiu* – who (singular), which
-- *kiun* – who(m) (singular), which (one, object of a transitive verb)
+
+- *kiu* – who (singular), which
+- *kiun* – who(m) (singular), which (one, as object)
 - *kiuj* – who (plural), which
-- *kiujn* – who(m) (plural), which (ones, objects of a transitive verb)
+- *kiujn* – who(m) (plural), which (ones, as objects)
 
 ## Kia
-
-Examples:
 
 - *Kia estas la vetero?* – What is the weather like?
 - *Kian aŭton vi havas?* – What kind of car do you have?
@@ -39,61 +38,57 @@ Examples:
 
 ## Kie
 
-- *Kie* – where (at)
-- *Kien* – where (to)
+- *kie* – where (at)
+- *kien* – where (to)
 
 Examples:
 
 - *Kie mi estas?* – Where am I?
 - *Kien vi iras?* – Where are you going?
 
-## With Prepositions
+## With prepositions
 
-- *Al kiu* – to whom, who to
+- *al kiu* – to whom, who to
 - *kun kiu* – with whom, who with
 - *al tiu* – to that one
 - *inter tiuj* – among those
 
 # Degrees of Comparison
 
-The comparative is formed with *pli* (more):
+The comparative uses *__pli__* (more) and the superlative *__plej__* (most) — there are no irregular forms like "good, better, best" to memorize:
 
 - *__pli__ bona* – better
 - *__pli__ granda* – bigger
-
-The superlative is formed with *plej* (most):
-
 - *__plej__ bona* – best
 - *__plej__ granda* – biggest
 
-"Than" is translated *ol*:
+"Than" is *ol*; with a superlative, "of" is *el*:
 
 - *pli bona __ol__ vi* – better than you
+- *la plej bona __el__ ĉiuj* – the best of all
 
-With a superlative, "of" is translated as *el*:
-
-- *La plej bona el ĉiuj* – the best of all.
-
-*Pli* and *plej* are also used with adverbs:
+*pli* and *plej* work with adverbs too:
 
 - *pli rapide* – more quickly
 - *plej rapide* – most quickly
 
-# *Dum* 
+# *Dum*
 
-*Dum* is both a preposition ("during") and a conjunction ("while"):
+*dum* is both a preposition ("during") and a conjunction ("while"):
 
 - *Li sidas __dum__ la manĝo.* – He sits during the meal.
 - *Ŝi skribas __dum__ li legas.* – She writes while he reads.
 
 # *Ĉi*
 
-The particle *ĉi* is used with *ti*-correlatives to show nearness. Compare:
+The particle *ĉi* is used with *ti-*correlatives to show nearness:
 
-- *tiu* – that one / *tiu ĉi* or *ĉi tiu* – this one
-- *tie* – there / *tie ĉi* or *ĉi tie* – here
+- *tiu* – that one / *tiu __ĉi__* or *__ĉi__ tiu* – this one
+- *tie* – there / *tie __ĉi__* or *__ĉi__ tie* – here
 
-# The suffix *-ind*
+**Memory aid:** *ĉi* always pulls things close — *ĉi tie* is "here", the spot you could almost touch.
+
+# The suffix *__-ind__*
 
 means "worth -ing" or "worthy":
 
@@ -101,5 +96,3 @@ means "worth -ing" or "worthy":
 - *leg__ind__a* – worth reading
 - *bedaŭr__ind__e* – unfortunately (literally: regret-worthily)
 - *nedank__ind__e* – polite reply to *dankon* (literally: not-thank-worthily)
-
- 

--- a/enhavo/tradukenda/en/gramatiko/06.md
+++ b/enhavo/tradukenda/en/gramatiko/06.md
@@ -1,50 +1,53 @@
 # *-u* in Noun Clauses
 
-The imperative ending *-u* is used not only (as we have already seen) in direct commands and so on, but also in indirect speech in clauses introduced by *ke* after verbs of commanding, requesting, advising, and wishing. (These often correspond to English clauses with "to".)
+The imperative ending *-u* is used not only in direct commands (as we have already seen) but also in clauses introduced by *ke* after verbs of commanding, requesting, advising and wishing. (These often correspond to English clauses with "to".)
 
-- *Mi deziras, __ke__ vi lern__u__.* – I want you to learn (lit.: I want that you learn.)
-- *La patro insistas, __ke__ mi iru.* – Father insists that I go. 
- 
+- *Mi deziras, __ke__ vi lern__u__.* – I want you to learn (literally: I want that you learn).
+- *La patro insistas, __ke__ mi ir__u__.* – Father insists that I go.
+
+**Memory aid:** a wish or command in the main clause pulls the verb of the *ke*-clause into the *-u* form — not *-as*.
+
 # The Preposition *je*
 
-The preposition *je* is like a wildcard. It has no precise meaning, but is used where no other preposition covers the exact meaning one wishes to express. Among other things, it is the usual word for translating "at" when telling the time.
+*je* is a wildcard: it has no precise meaning of its own and is used wherever no other preposition fits exactly. Among other things, it is the usual word for "at" when telling the time:
 
-- *__Je__ kioma horo vi venos?* – What time will you come? (lit.: At which-numbered hour?)
+- *__Je__ kioma horo vi venos?* – (At) what time will you come? (literally: at which-numbered hour?)
 - *__Je__ la kvina horo.* – At five o'clock.
- 
 
-# The Verb *Farti*
+**Tip:** when no preposition seems to fit, *je* is the safe default.
 
-This verb is mainly used in the expression:
+# The Verb *farti*
+
+mainly used in the greeting:
 
 - *Kiel vi __fartas__?* – How are you?
 
+# The Suffix *__-et__*
 
-# The Suffix *-et*
-
-is used to make diminutives:
+makes diminutives (small, slight):
 
 - *libr__et__o* – booklet
-- *bel__et__a*  – pretty
+- *bel__et__a* – pretty
 - *varm__et__a* – tepid
- 
 
-# The Suffix *-eg*
+# The Suffix *__-eg__*
 
-is used to make augmentatives:
+makes augmentatives (big, intense):
 
-- *libr_ego_*    – tome
-- *varm__eg__a*  – blazing hot
-- *bel__eg__a*   – superb
-- *bon__eg__a*   – excellent
- 
+- *libr__eg__o* – tome
+- *varm__eg__a* – blazing hot
+- *bel__eg__a* – superb
+- *bon__eg__a* – excellent
 
-# The Suffix *-iĝ*
+**Memory aid:** learn the pair together — *-et* shrinks (*libreto* = booklet), *-eg* magnifies (*librego* = a hefty tome).
+
+# The Suffix *__-iĝ__*
 
 means "to become", "to get":
 
-- *riĉiĝi*          – to grow rich
+- *riĉ__iĝ__i* – to grow rich
 - *trankvil__iĝ__i* – to calm down, to become calm
-- *resan__iĝ__i*    – to get well again, to recover
-- *geedz__iĝ__i*    – to get married, to wed
- 
+- *resan__iĝ__i* – to get well again, to recover
+- *geedz__iĝ__i* – to get married, to wed
+
+**Memory aid:** *-iĝ* = to become (a change the subject undergoes by itself). Its partner *-ig* ("to make something happen") follows in [lesson 8](/en/08/gramatiko/).

--- a/enhavo/tradukenda/en/gramatiko/06.md
+++ b/enhavo/tradukenda/en/gramatiko/06.md
@@ -5,7 +5,7 @@ The imperative ending *-u* is used not only in direct commands (as we have alrea
 - *Mi deziras, __ke__ vi lern__u__.* – I want you to learn (literally: I want that you learn).
 - *La patro insistas, __ke__ mi ir__u__.* – Father insists that I go.
 
-**Memory aid:** a wish or command in the main clause pulls the verb of the *ke*-clause into the *-u* form — not *-as*.
+**💡 Memory aid:** a wish or command in the main clause pulls the verb of the *ke*-clause into the *-u* form — not *-as*.
 
 # The Preposition *je*
 
@@ -14,7 +14,7 @@ The imperative ending *-u* is used not only in direct commands (as we have alrea
 - *__Je__ kioma horo vi venos?* – (At) what time will you come? (literally: at which-numbered hour?)
 - *__Je__ la kvina horo.* – At five o'clock.
 
-**Tip:** when no preposition seems to fit, *je* is the safe default.
+**💡 Tip:** when no preposition seems to fit, *je* is the safe default.
 
 # The Verb *farti*
 
@@ -39,7 +39,7 @@ makes augmentatives (big, intense):
 - *bel__eg__a* – superb
 - *bon__eg__a* – excellent
 
-**Memory aid:** learn the pair together — *-et* shrinks (*libreto* = booklet), *-eg* magnifies (*librego* = a hefty tome).
+**💡 Memory aid:** learn the pair together — *-et* shrinks (*libreto* = booklet), *-eg* magnifies (*librego* = a hefty tome).
 
 # The Suffix *__-iĝ__*
 
@@ -50,4 +50,4 @@ means "to become", "to get":
 - *resan__iĝ__i* – to get well again, to recover
 - *geedz__iĝ__i* – to get married, to wed
 
-**Memory aid:** *-iĝ* = to become (a change the subject undergoes by itself). Its partner *-ig* ("to make something happen") follows in [lesson 8](/en/08/gramatiko/).
+**💡 Memory aid:** *-iĝ* = to become (a change the subject undergoes by itself). Its partner *-ig* ("to make something happen") follows in [lesson 8](/en/08/gramatiko/).

--- a/enhavo/tradukenda/en/gramatiko/07.md
+++ b/enhavo/tradukenda/en/gramatiko/07.md
@@ -1,52 +1,45 @@
 # Negation
 
-The rules for negation are much as in English.
+The rules of negation are much as in English:
 
-
-- *__Nek__ li __nek__ ŝi respondis.*   – Neither he nor she answered.
+- *__Nek__ li __nek__ ŝi respondis.* – Neither he nor she answered.
 - *Vi __nek__ sidas __nek__ rigardas.* – You are neither sitting nor looking.
+- *Mi __neniam__ diros al iu.* – I shall never tell anyone.
 
-- *Mi __neniam__ diros al iu.* – I shall never tell anyone. (*Mi neniam diros al neniu* is wrong in Esperanto just as "I shan't never tell no-one" is in English.)
-
+**Watch out:** unlike colloquial English, Esperanto has no double negative. *Mi neniam diros al neniu* is wrong, just as "I shan't never tell no-one" is in English — one negative word is enough.
 
 # *Mem*
 
-*Mem* means "self" (myself, yourself, himself, etc.) and is used to emphasize the noun or pronoun it follows. (Compare *si*, reflexive, lesson 4.)
+*mem* means "-self" (myself, yourself, himself …) and emphasizes the word it follows. (Compare the reflexive *si* in [lesson 4](/en/04/gramatiko/).)
 
-- *Mi __mem__ faris tion.*  – I myself did that, I did that myself.
+- *Mi __mem__ faris tion.* – I myself did that; I did that myself.
 
 # Bye…
 
-There are various ways of saying "goodbye" in Esperanto, but the most usual is 
+There are several ways to say "goodbye" in Esperanto; the most usual is:
 
-- *ĝis la revido* – literally "until the re-seeing" (compare English "see you", French "au revoir".)
+- *ĝis la revido* – literally "until the re-seeing" (compare English "see you", French "au revoir")
 
-Alternatively it may be said without the article:
+It can also be shortened, without the article:
 
-- *ĝis revido*.
+- *ĝis revido*
 
+# The Prefix *__ek-__*
 
-# The Prefix *ek-*
+shows either the beginning of an action or a sudden, momentary one:
 
-shows
-
-1. the beginning of an action, or
-2. a sudden momentary action.
-
-Examples:
-
-- *__ek__paroli*  – to start speaking
+- *__ek__paroli* – to start speaking
 - *__ek__silenti* – to fall silent
-- *__ek__sidi*    – to sit down, to take a seat
-- *__ek__ridi*    – to burst out laughing
- 
+- *__ek__sidi* – to sit down, to take a seat
+- *__ek__ridi* – to burst out laughing
 
-# The Suffix *-aĵ*
+# The Suffix *__-aĵ__*
 
-means "thing", a concrete object:
+means a concrete "thing":
 
-- *manĝ__aĵ__o*  – food
+- *manĝ__aĵ__o* – food
 - *trink__aĵ__o* – drink, beverage
-- *bel__aĵ__o*   – something beautiful
-- *send__aĵ__o*  – something sent, a missive
- 
+- *bel__aĵ__o* – something beautiful
+- *send__aĵ__o* – something sent, a missive
+
+**Memory aid:** *-aĵ* turns an action or quality into a tangible thing: *manĝi* (to eat) → *manĝaĵo* (food).

--- a/enhavo/tradukenda/en/gramatiko/07.md
+++ b/enhavo/tradukenda/en/gramatiko/07.md
@@ -6,7 +6,7 @@ The rules of negation are much as in English:
 - *Vi __nek__ sidas __nek__ rigardas.* – You are neither sitting nor looking.
 - *Mi __neniam__ diros al iu.* – I shall never tell anyone.
 
-**Watch out:** unlike colloquial English, Esperanto has no double negative. *Mi neniam diros al neniu* is wrong, just as "I shan't never tell no-one" is in English — one negative word is enough.
+**⚠️ Watch out:** unlike colloquial English, Esperanto has no double negative. *Mi neniam diros al neniu* is wrong, just as "I shan't never tell no-one" is in English — one negative word is enough.
 
 # *Mem*
 
@@ -42,4 +42,4 @@ means a concrete "thing":
 - *bel__aĵ__o* – something beautiful
 - *send__aĵ__o* – something sent, a missive
 
-**Memory aid:** *-aĵ* turns an action or quality into a tangible thing: *manĝi* (to eat) → *manĝaĵo* (food).
+**💡 Memory aid:** *-aĵ* turns an action or quality into a tangible thing: *manĝi* (to eat) → *manĝaĵo* (food).

--- a/enhavo/tradukenda/en/gramatiko/08.md
+++ b/enhavo/tradukenda/en/gramatiko/08.md
@@ -1,25 +1,28 @@
-# The Preposition *Da*
+# The Preposition *da*
 
-is a preposition used in expressions of weight, measure, or quantity:
+*da* is used in expressions of weight, measure or quantity:
 
 - *kilogramo __da__ sukero* – a kilo of sugar
-- *glaso __da__ akvo* – a glass of water 
-- *multe __da__ ideoj* – a lot of ideas 
+- *glaso __da__ akvo* – a glass of water
+- *multe __da__ ideoj* – a lot of ideas
 
-# The Suffix *-ig*
+**Watch out:** after a quantity word, use *da*, not *de*. *glaso da akvo* = a glass of water.
 
-This "causative" suffix means "to make, cause to be":
+# The Suffix *__-ig__*
 
-- *bel__ig__i* – to beautify
+This "causative" suffix means "to make, to cause to be":
+
+- *bel__ig__i* – to beautify (make beautiful)
 - *malplen__ig__i* – to empty
 - *san__ig__i* – to cure, to heal
-- *mort__ig__i* – to kill 
+- *mort__ig__i* – to kill (cause to die)
 
-# The Suffix *-aĉ*
+**Watch out:** don't confuse *-ig* with *-iĝ* ([lesson 6](/en/06/gramatiko/)). *-ig* = to make something change (*beligi* – to make beautiful); *-iĝ* = to become (*beliĝi* – to grow beautiful).
 
-shows the speaker has a low opinion of the thing in question:
+# The Suffix *__-aĉ__*
 
-- *hund__aĉ__o* – cur
+shows the speaker's low opinion of the thing:
+
+- *hund__aĉ__o* – cur (a wretched dog)
 - *knab__aĉ__o* – brat
 - *skrib__aĉ__i* – to scribble
- 

--- a/enhavo/tradukenda/en/gramatiko/08.md
+++ b/enhavo/tradukenda/en/gramatiko/08.md
@@ -6,7 +6,7 @@
 - *glaso __da__ akvo* – a glass of water
 - *multe __da__ ideoj* – a lot of ideas
 
-**Watch out:** after a quantity word, use *da*, not *de*. *glaso da akvo* = a glass of water.
+**⚠️ Watch out:** after a quantity word, use *da*, not *de*. *glaso da akvo* = a glass of water.
 
 # The Suffix *__-ig__*
 
@@ -17,7 +17,7 @@ This "causative" suffix means "to make, to cause to be":
 - *san__ig__i* – to cure, to heal
 - *mort__ig__i* – to kill (cause to die)
 
-**Watch out:** don't confuse *-ig* with *-iĝ* ([lesson 6](/en/06/gramatiko/)). *-ig* = to make something change (*beligi* – to make beautiful); *-iĝ* = to become (*beliĝi* – to grow beautiful).
+**⚠️ Watch out:** don't confuse *-ig* with *-iĝ* ([lesson 6](/en/06/gramatiko/)). *-ig* = to make something change (*beligi* – to make beautiful); *-iĝ* = to become (*beliĝi* – to grow beautiful).
 
 # The Suffix *__-aĉ__*
 

--- a/enhavo/tradukenda/en/gramatiko/09.md
+++ b/enhavo/tradukenda/en/gramatiko/09.md
@@ -1,9 +1,13 @@
 # The Conditional Mood
 
-is expressed by the verb ending *-us*:
+is expressed by the verb ending *__-us__* — used for anything hypothetical ("would", "were to"):
 
 - *mi kred__us__* – I would believe, I should think
 - *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – If I were well, I would be very happy.
+
+**Watch out:** both halves of the sentence take *-us* (the "if" clause and the main clause) — unlike English, which mixes "were" and "would".
+
+**Memory aid:** that completes the verb system — *-i* (infinitive), *-as / -is / -os* (the three tenses), *-u* (command), *-us* (conditional). Six endings cover every verb.
 
 # *Kvazaŭ*
 
@@ -13,48 +17,38 @@ is used as a conjunction, normally followed by the conditional:
 
 It can also be used elliptically:
 
-- *Vi sidas tie __kvazaŭ__ riĉulo.* – You are sitting there as if you were rich.
- 
-# The Suffix *-ad*
+- *Vi sidas tie __kvazaŭ__ riĉulo.* – You are sitting there as if (you were) rich.
 
-is used to make a noun from a verb:
+# The Suffix *__-ad__*
 
-- *kanti* – to sing
-  - *kant__ad__o* – (the act of) singing
-- *suferi* – to suffer
-	- *sufer__ad__o* – suffering
+makes a noun from a verb, naming the action itself:
 
-It also conveys the idea of continued or repeated action:
+- *kanti* (to sing) → *kant__ad__o* – (the act of) singing
+- *suferi* (to suffer) → *sufer__ad__o* – suffering
 
-- *rigardi* – to look
-  - *rigard__ad__i* – to go on looking, to gaze
-- *demandi* – to ask a question
-	- *demand__ad__i* – to keep asking questions
-- *informo* – information
-	- *inform__ad__o* – publicity
+It also conveys continued or repeated action:
 
+- *rigardi* (to look) → *rigard__ad__i* – to go on looking, to gaze
+- *demandi* (to ask) → *demand__ad__i* – to keep asking questions
+- *informo* (information) → *inform__ad__o* – publicity
 
-# The Suffix *-ar*
+# The Suffix *__-ar__*
 
 indicates a collection of objects viewed as a whole:
 
-- *arbo* – tree
-	- *arb__ar__o* – wood, forest
-- *vagono* – coach
-	- *vagon__ar__o* – train
-- *vorto* – word
-	- *vort__ar__o* – dictionary
- 
+- *arbo* (tree) → *arb__ar__o* – wood, forest
+- *vagono* (coach) → *vagon__ar__o* – train
+- *vorto* (word) → *vort__ar__o* – dictionary
 
-# The Suffix *-um*
+**Memory aid:** *-ar* bundles individual items into a set: many an *arbo* (tree) make an *arbaro* (forest).
+
+# The Suffix *__-um__*
 
 is a joker suffix, with no fixed meaning:
 
-- *plena* – full
-  -  *plen__um__i* – to fulfil
-- *proksima* – close
-  -  *proksim__um__e* – approximately
-- *suno* – sun 
-	- *sun__um__i* – to sunbathe
+- *plena* (full) → *plen__um__i* – to fulfil
+- *proksima* (close) → *proksim__um__e* – approximately
+- *suno* (sun) → *sun__um__i* – to sunbathe
 - *malvarm__um__i* – to catch a cold
- 
+
+**Tip:** *-um* is the joker among suffixes, just as *je* ([lesson 6](/en/06/gramatiko/)) is the joker among prepositions — learn each *-um* word individually.

--- a/enhavo/tradukenda/en/gramatiko/09.md
+++ b/enhavo/tradukenda/en/gramatiko/09.md
@@ -5,9 +5,9 @@ is expressed by the verb ending *__-us__* — used for anything hypothetical ("w
 - *mi kred__us__* – I would believe, I should think
 - *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – If I were well, I would be very happy.
 
-**Watch out:** both halves of the sentence take *-us* (the "if" clause and the main clause) — unlike English, which mixes "were" and "would".
+**⚠️ Watch out:** both halves of the sentence take *-us* (the "if" clause and the main clause) — unlike English, which mixes "were" and "would".
 
-**Memory aid:** that completes the verb system — *-i* (infinitive), *-as / -is / -os* (the three tenses), *-u* (command), *-us* (conditional). Six endings cover every verb.
+**💡 Memory aid:** that completes the verb system — *-i* (infinitive), *-as / -is / -os* (the three tenses), *-u* (command), *-us* (conditional). Six endings cover every verb.
 
 # *Kvazaŭ*
 
@@ -40,7 +40,7 @@ indicates a collection of objects viewed as a whole:
 - *vagono* (coach) → *vagon__ar__o* – train
 - *vorto* (word) → *vort__ar__o* – dictionary
 
-**Memory aid:** *-ar* bundles individual items into a set: many an *arbo* (tree) make an *arbaro* (forest).
+**💡 Memory aid:** *-ar* bundles individual items into a set: many an *arbo* (tree) make an *arbaro* (forest).
 
 # The Suffix *__-um__*
 
@@ -51,4 +51,4 @@ is a joker suffix, with no fixed meaning:
 - *suno* (sun) → *sun__um__i* – to sunbathe
 - *malvarm__um__i* – to catch a cold
 
-**Tip:** *-um* is the joker among suffixes, just as *je* ([lesson 6](/en/06/gramatiko/)) is the joker among prepositions — learn each *-um* word individually.
+**💡 Tip:** *-um* is the joker among suffixes, just as *je* ([lesson 6](/en/06/gramatiko/)) is the joker among prepositions — learn each *-um* word individually.

--- a/enhavo/tradukenda/en/gramatiko/10.md
+++ b/enhavo/tradukenda/en/gramatiko/10.md
@@ -1,29 +1,28 @@
-# The Suffix *-an*
+# The Suffix *__-an__*
 
-member of, someone belonging to:
+a member of, someone belonging to:
 
-- *klub__an__o*    – club member
-- *amerik__an__o*  – American
+- *klub__an__o* – club member
+- *amerik__an__o* – American
 - *samland__an__o* – fellow-countryman
-- *samide__an__o*  – fellow-supporter (of an idea: in particular, a fellow Esperantist)
- 
+- *samide__an__o* – fellow-supporter of an idea (in particular, a fellow Esperantist)
 
-# The Suffix *-ec*
+# The Suffix *__-ec__*
 
-makes an abstract noun, indicating a state or quality:
+makes an abstract noun — a state or quality:
 
-- *bel__ec__o*   – beauty
-- *varm__ec__o*  – warmth
+- *bel__ec__o* – beauty
+- *varm__ec__o* – warmth
 - *simpl__ec__o* – simplicity
- 
 
-# The Suffix *-uj*
+**Memory aid:** *-ec* works like English "-ness" or "-ity": *bela* (beautiful) → *beleco* (beauty).
 
-forms the name of a container, country or plant:
+# The Suffix *__-uj__*
 
-- *manĝ__uj__o*  – manger, food-trough
+forms the name of a container, a country or a plant:
+
+- *manĝ__uj__o* – manger, food-trough
 - *cindr__uj__o* – ashtray
 - *Franc__uj__o* – France
 - *Aŭstr__uj__o* – Austria
-- *pomo*   – apple
-	- *pom__uj__o*   – apple tree
+- *pomo* (apple) → *pom__uj__o* – apple tree

--- a/enhavo/tradukenda/en/gramatiko/10.md
+++ b/enhavo/tradukenda/en/gramatiko/10.md
@@ -15,7 +15,7 @@ makes an abstract noun — a state or quality:
 - *varm__ec__o* – warmth
 - *simpl__ec__o* – simplicity
 
-**Memory aid:** *-ec* works like English "-ness" or "-ity": *bela* (beautiful) → *beleco* (beauty).
+**💡 Memory aid:** *-ec* works like English "-ness" or "-ity": *bela* (beautiful) → *beleco* (beauty).
 
 # The Suffix *__-uj__*
 

--- a/enhavo/tradukenda/en/gramatiko/11.md
+++ b/enhavo/tradukenda/en/gramatiko/11.md
@@ -1,8 +1,10 @@
-# The Suffix *-il*
+# The Suffix *__-il__*
 
-forms words for "tool", "implement", or "means":
+forms words for a tool, implement or means:
 
-- *tranĉ__il__o*    – knife
-- *hak__il__o*      – axe
-- *ŝlos__il__o*     – key
-- *timig__il__o*    – scarecrow
+- *tranĉ__il__o* – knife
+- *hak__il__o* – axe
+- *ŝlos__il__o* – key
+- *timig__il__o* – scarecrow
+
+**Memory aid:** *-il* names the instrument for an action: *tranĉi* (to cut) → *tranĉilo* (knife), *ŝlosi* (to lock) → *ŝlosilo* (key).

--- a/enhavo/tradukenda/en/gramatiko/11.md
+++ b/enhavo/tradukenda/en/gramatiko/11.md
@@ -7,4 +7,4 @@ forms words for a tool, implement or means:
 - *ŝlos__il__o* – key
 - *timig__il__o* – scarecrow
 
-**Memory aid:** *-il* names the instrument for an action: *tranĉi* (to cut) → *tranĉilo* (knife), *ŝlosi* (to lock) → *ŝlosilo* (key).
+**💡 Memory aid:** *-il* names the instrument for an action: *tranĉi* (to cut) → *tranĉilo* (knife), *ŝlosi* (to lock) → *ŝlosilo* (key).

--- a/enhavo/tradukenda/en/gramatiko/12.md
+++ b/enhavo/tradukenda/en/gramatiko/12.md
@@ -1,27 +1,33 @@
 # *Ju … des*
 
-- *Ju pli longe, des pli bone.* – the longer, the better
- 
+*ju pli … des pli* – "the more … the more":
+
+- *Ju pli longe, des pli bone.* – The longer, the better.
+
+**Memory aid:** *ju* goes in the first half, *des* in the second — fixed partners, like the English "the … the".
 
 # *Ajn*
 
-- *kiom ajn* – however much
- 
+makes a word indefinite or general:
 
-# The Prefix *dis-*
+- *kiom __ajn__* – however much
 
-denotes separation, dispersal:
+**Memory aid:** *ajn* opens a [correlative](/en/tabelvortoj/) right up: *kiom* (how much) → *kiom ajn* (however much).
+
+# The Prefix *__dis-__*
+
+denotes separation or dispersal — like English "dis-" in "distribute" or "disperse":
 
 - *__dis__ĵeti* – to scatter
 - *__dis__sendi* – to broadcast
- 
 
-# The Suffix *-on*
+# The Suffix *__-on__*
 
 denotes a fraction:
 
-- *du__on__o*   – half
-- *tri__on__o*  – third
+- *du__on__o* – half
+- *tri__on__o* – third
 - *kvar__on__o* – quarter
-- *ses__on__o*  – sixth
- 
+- *ses__on__o* – sixth
+
+**Memory aid:** *-on* turns a number into its fraction: *du* (two) → *duono* (half), *kvar* (four) → *kvarono* (quarter).

--- a/enhavo/tradukenda/en/gramatiko/12.md
+++ b/enhavo/tradukenda/en/gramatiko/12.md
@@ -4,7 +4,7 @@
 
 - *Ju pli longe, des pli bone.* – The longer, the better.
 
-**Memory aid:** *ju* goes in the first half, *des* in the second — fixed partners, like the English "the … the".
+**💡 Memory aid:** *ju* goes in the first half, *des* in the second — fixed partners, like the English "the … the".
 
 # *Ajn*
 
@@ -12,7 +12,7 @@ makes a word indefinite or general:
 
 - *kiom __ajn__* – however much
 
-**Memory aid:** *ajn* opens a [correlative](/en/tabelvortoj/) right up: *kiom* (how much) → *kiom ajn* (however much).
+**💡 Memory aid:** *ajn* opens a [correlative](/en/tabelvortoj/) right up: *kiom* (how much) → *kiom ajn* (however much).
 
 # The Prefix *__dis-__*
 
@@ -30,4 +30,4 @@ denotes a fraction:
 - *kvar__on__o* – quarter
 - *ses__on__o* – sixth
 
-**Memory aid:** *-on* turns a number into its fraction: *du* (two) → *duono* (half), *kvar* (four) → *kvarono* (quarter).
+**💡 Memory aid:** *-on* turns a number into its fraction: *du* (two) → *duono* (half), *kvar* (four) → *kvarono* (quarter).


### PR DESCRIPTION
## Resumo

Reverkas ĉiujn 12 anglajn gramatik-lecionojn (*enhavo/tradukenda/en/gramatiko/*) laŭ la samaj pedagogiaj normoj kiel la germana versio ([#205](https://github.com/Esperanto/kurso-zagreba-metodo/pull/205)). **La temoj kaj ĉiuj ekzemploj restas senŝanĝaj**; la angla strukturo (propra al la angla versio) estas konservita.

- Anglaj memorhelpiloj kaj kontrastoj anstataŭ germanaj: ekz. *j*=y, *c*=ts, *g* ĉiam malmola; pluralo *-j* ne *-s*; neniu 3-persona *-s*; *-in* ≈ "-ine" (hero→hero*ine*); *mal-* kiel "malfunction"; *da* ne *de*
- Konsekvenca kursivigo de ĉiu Esperanto-ero; novaj finaĵoj/afiksoj grasaj ĉe enkonduko; morfemoj grasaj en ekzemploj
- Lecion-referencoj ligitaj al `/en/0X/gramatiko/`; "Table of correlatives"/"correlative" ligitaj al `/en/tabelvortoj/`
- Riparita la fuŝa `libr_ego_` (kursiva "ego") → `librego`

## Testplano

- [x] `make check` sukcesas (konstruas la anglan)
- [x] Kontrolitaj: krucreferencaj ligiloj, morfema reliefigo, kursivo, `librego`-riparo
- [ ] Vida kontrolo en la retejo (en/01–12/gramatiko)

🤖 Generated with [Claude Code](https://claude.com/claude-code)