### PR TITLE
Aldonu gramatikan enhavtabelon

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -140,13 +140,12 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem 0;
+  line-height: 1.5;
   margin-bottom: 0;
-  padding-left: 1.4rem;
+  padding-left: 0.5rem;
 }
 .gramatika-enhavtabelo li {
+  display: inline;
   list-style-position: inside;
   margin-right: 1.5rem;
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -136,7 +136,7 @@ h3 {
   border-radius: var(--bs-border-radius);
   font-size: 0.95rem;
   margin-bottom: 1rem;
-  margin-top: 0.75rem;
+  margin-top: 1.25rem;
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
@@ -148,6 +148,7 @@ h3 {
 }
 .gramatika-enhavtabelo li {
   margin-right: 1.5rem;
+  padding-left: 0.35rem;
 }
 .gramatika-enhavtabelo a {
   text-decoration: none;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -151,7 +151,7 @@ h3 {
   margin-right: 1.5rem;
 }
 .gramatika-enhavtabelo a {
-  margin-left: 0.35rem;
+  margin-left: 0.2rem;
   text-decoration: none;
 }
 .gramatika-teksto :is(h1, h2, h3, h4, h5, h6) {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -147,10 +147,11 @@ h3 {
   padding-left: 1.4rem;
 }
 .gramatika-enhavtabelo li {
+  list-style-position: inside;
   margin-right: 1.5rem;
-  padding-left: 0.35rem;
 }
 .gramatika-enhavtabelo a {
+  margin-left: 0.35rem;
   text-decoration: none;
 }
 .gramatika-teksto :is(h1, h2, h3, h4, h5, h6) {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -138,20 +138,23 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
+  counter-reset: gramatika-enhavo;
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 1.25rem;
   margin-bottom: 0;
-  padding-left: 1.25rem;
+  padding-left: 0;
+}
+.gramatika-enhavtabelo li {
+  counter-increment: gramatika-enhavo;
+  list-style: none;
+}
+.gramatika-enhavtabelo li::before {
+  content: counter(gramatika-enhavo) ".";
+  margin-right: 0.4rem;
 }
 .gramatika-enhavtabelo a {
   text-decoration: none;
-}
-.gramatika-reenligo {
-  font-size: 0.75em;
-  margin-left: 0.35rem;
-  text-decoration: none;
-  vertical-align: 0.08em;
 }
 
 .navbar {
@@ -336,6 +339,8 @@ h3 {
     float: inline-end;
     margin-left: 1.5rem;
     max-width: 15rem;
+    position: sticky;
+    top: calc(52px + 1rem);
     width: 35%;
   }
   .gramatika-enhavtabelo ol {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -140,12 +140,13 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
+  display: flex;
+  flex-wrap: wrap;
   line-height: 1.5;
   margin-bottom: 0;
   padding-left: 0.5rem;
 }
 .gramatika-enhavtabelo li {
-  display: inline;
   list-style-position: inside;
   margin-right: 1.5rem;
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -140,7 +140,7 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
-  line-height: 1.5;
+  line-height: 1.65;
   margin-bottom: 0;
   padding-left: 0.5rem;
 }

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -140,13 +140,18 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
-  display: flex;
-  flex-wrap: wrap;
   line-height: 1.5;
   margin-bottom: 0;
   padding-left: 0.5rem;
 }
+.gramatika-enhavtabelo ol::after {
+  clear: both;
+  content: "";
+  display: block;
+}
 .gramatika-enhavtabelo li {
+  display: list-item;
+  float: left;
   list-style-position: inside;
   margin-right: 1.5rem;
 }
@@ -352,6 +357,11 @@ h3 {
   }
   .gramatika-enhavtabelo ol {
     display: block;
+    padding-left: 1.25rem;
+  }
+  .gramatika-enhavtabelo li {
+    float: none;
+    margin-right: 0;
   }
   .gramatika-teksto {
     grid-column: 1;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -130,6 +130,7 @@ h3 {
   justify-content: end;
 }
 .gramatika-enhavtabelo {
+  background-color: var(--exercise-field-bg);
   border: 1px solid var(--bs-border-color);
   border-radius: var(--bs-border-radius);
   font-size: 0.95rem;
@@ -137,11 +138,20 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.25rem;
   margin-bottom: 0;
   padding-left: 1.25rem;
 }
 .gramatika-enhavtabelo a {
   text-decoration: none;
+}
+.gramatika-reenligo {
+  font-size: 0.75em;
+  margin-left: 0.35rem;
+  text-decoration: none;
+  vertical-align: 0.08em;
 }
 
 .navbar {
@@ -327,6 +337,9 @@ h3 {
     margin-left: 1.5rem;
     max-width: 15rem;
     width: 35%;
+  }
+  .gramatika-enhavtabelo ol {
+    display: block;
   }
   .cxefpagxo-kapo {
     flex-direction: column;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -136,20 +136,24 @@ h3 {
   border-radius: var(--bs-border-radius);
   font-size: 0.95rem;
   margin-bottom: 1rem;
+  margin-top: 0.75rem;
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem 1.25rem;
+  gap: 0.35rem 0;
   margin-bottom: 0;
   padding-left: 1.4rem;
 }
 .gramatika-enhavtabelo li {
-  padding-left: 0.35rem;
+  margin-right: 1.5rem;
 }
 .gramatika-enhavtabelo a {
   text-decoration: none;
+}
+.gramatika-teksto :is(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: calc(52px + 1rem);
 }
 
 .navbar {

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -5,6 +5,7 @@
   --bs-link-hover-color: #23527c;
   --bs-link-hover-color-rgb: 35, 82, 124;
   --exercise-field-bg: #f0f0f0;
+  --toc-bg: #f8f9fa;
 }
 
 .container {
@@ -130,7 +131,7 @@ h3 {
   justify-content: end;
 }
 .gramatika-enhavtabelo {
-  background-color: var(--exercise-field-bg);
+  background-color: var(--toc-bg);
   border: 1px solid var(--bs-border-color);
   border-radius: var(--bs-border-radius);
   font-size: 0.95rem;
@@ -138,20 +139,14 @@ h3 {
   padding: 0.75rem 1rem;
 }
 .gramatika-enhavtabelo ol {
-  counter-reset: gramatika-enhavo;
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 1.25rem;
   margin-bottom: 0;
-  padding-left: 0;
+  padding-left: 1.4rem;
 }
 .gramatika-enhavtabelo li {
-  counter-increment: gramatika-enhavo;
-  list-style: none;
-}
-.gramatika-enhavtabelo li::before {
-  content: counter(gramatika-enhavo) ".";
-  margin-right: 0.4rem;
+  padding-left: 0.35rem;
 }
 .gramatika-enhavtabelo a {
   text-decoration: none;
@@ -335,16 +330,27 @@ h3 {
 }
 
 @media (min-width: 768px) {
+  .gramatika-korpo {
+    align-items: start;
+    display: grid;
+    gap: 0 1.5rem;
+    grid-template-columns: minmax(0, 1fr) minmax(12rem, 15rem);
+  }
   .gramatika-enhavtabelo {
-    float: inline-end;
-    margin-left: 1.5rem;
+    grid-column: 2;
+    grid-row: 1;
     max-width: 15rem;
     position: sticky;
     top: calc(52px + 1rem);
-    width: 35%;
+    width: 100%;
   }
   .gramatika-enhavtabelo ol {
     display: block;
+  }
+  .gramatika-teksto {
+    grid-column: 1;
+    grid-row: 1;
+    min-width: 0;
   }
   .cxefpagxo-kapo {
     flex-direction: column;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -129,6 +129,20 @@ h3 {
 .leciona-sago-sekva {
   justify-content: end;
 }
+.gramatika-enhavtabelo {
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+}
+.gramatika-enhavtabelo ol {
+  margin-bottom: 0;
+  padding-left: 1.25rem;
+}
+.gramatika-enhavtabelo a {
+  text-decoration: none;
+}
 
 .navbar {
   margin-bottom: 20px;
@@ -308,6 +322,12 @@ h3 {
 }
 
 @media (min-width: 768px) {
+  .gramatika-enhavtabelo {
+    float: inline-end;
+    margin-left: 1.5rem;
+    max-width: 15rem;
+    width: 35%;
+  }
   .cxefpagxo-kapo {
     flex-direction: column;
   }

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -16,7 +16,7 @@
 
   <div dir="{{enhavo.tekstodirekto}}">
     {% if leciono.gramatiko.titoloj %}
-      <nav class="gramatika-enhavtabelo" aria-label="{{enhavo.fasado['Gramatiko']}}">
+      <nav id="gramatika-enhavtabelo" class="gramatika-enhavtabelo" aria-label="{{enhavo.fasado['Gramatiko']}}">
         <ol>
           {% for titolo in leciono.gramatiko.titoloj %}
             <li><a href="#{{titolo.ankro}}">{{titolo.titolo}}</a></li>
@@ -25,7 +25,7 @@
       </nav>
     {% endif %}
 
-  {{leciono.gramatiko.teksto|markdown}} 
+  {{leciono.gramatiko.teksto|markdown(true)}}
 
 	</div>
 

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -14,7 +14,7 @@
 
   {% include 'tabs.html' %}
 
-  <div dir="{{enhavo.tekstodirekto}}">
+  <div class="gramatika-korpo" dir="{{enhavo.tekstodirekto}}">
     {% if leciono.gramatiko.titoloj %}
       <nav id="gramatika-enhavtabelo" class="gramatika-enhavtabelo" aria-label="{{enhavo.fasado['Gramatiko']}}">
         <ol>
@@ -25,7 +25,9 @@
       </nav>
     {% endif %}
 
-  {{leciono.gramatiko.teksto|markdown}}
+    <div class="gramatika-teksto">
+      {{leciono.gramatiko.teksto|markdown}}
+    </div>
 
 	</div>
 

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -25,7 +25,7 @@
       </nav>
     {% endif %}
 
-  {{leciono.gramatiko.teksto|markdown(true)}}
+  {{leciono.gramatiko.teksto|markdown}}
 
 	</div>
 

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -15,6 +15,15 @@
   {% include 'tabs.html' %}
 
   <div dir="{{enhavo.tekstodirekto}}">
+    {% if leciono.gramatiko.titoloj %}
+      <nav class="gramatika-enhavtabelo" aria-label="{{enhavo.fasado['Gramatiko']}}">
+        <ol>
+          {% for titolo in leciono.gramatiko.titoloj %}
+            <li><a href="#{{titolo.ankro}}">{{titolo.titolo}}</a></li>
+          {% endfor %}
+        </ol>
+      </nav>
+    {% endif %}
 
   {{leciono.gramatiko.teksto|markdown}} 
 

--- a/fonto/py/ankroj.py
+++ b/fonto/py/ankroj.py
@@ -1,0 +1,33 @@
+import re
+import unicodedata
+
+
+def fari_ankron(teksto):
+    teksto = unicodedata.normalize('NFKD', teksto)
+    signoj = []
+    previous_separator = False
+
+    for signo in teksto.lower():
+        if signo.isalnum():
+            signoj.append(signo)
+            previous_separator = False
+        elif not previous_separator:
+            signoj.append('-')
+            previous_separator = True
+
+    ankro = ''.join(signoj).strip('-')
+    return ankro or 'sekcio'
+
+
+def unika_ankro(teksto, uzitaj):
+    ankro = fari_ankron(teksto)
+    if ankro not in uzitaj:
+        uzitaj[ankro] = 1
+        return ankro
+
+    uzitaj[ankro] += 1
+    return ankro + '-' + str(uzitaj[ankro])
+
+
+def forigu_html(teksto):
+    return re.sub(r'<[^>]+>', '', teksto)

--- a/fonto/py/generu.py
+++ b/fonto/py/generu.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from . import html as html_generilo
 from . import md as md_generilo
+from .ankroj import unika_ankro
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -34,7 +35,18 @@ def transpose_headlines(markdown, level):
 
 
 def get_markdown_headlines(s):
-    return [match.group(2).strip() for match in re.finditer(r'(^|\n)# (.+)\n', s)]
+    def purigu_titolon(markdown_titolo):
+        return re.sub(r'[`*_]+', '', markdown_titolo).strip()
+
+    uzitaj = {}
+    titoloj = []
+    for match in re.finditer(r'(^|\n)# (.+)\n', s):
+        titolo = purigu_titolon(match.group(2))
+        titoloj.append({
+            'titolo': titolo,
+            'ankro': unika_ankro(titolo, uzitaj),
+        })
+    return titoloj
 
 
 def load(language, gramatiko_transpose_headlines=2):

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -11,6 +11,7 @@ import jinja2
 from markupsafe import Markup
 import mistune
 
+from .ankroj import forigu_html, unika_ankro
 from . import pwa
 
 
@@ -36,6 +37,28 @@ def morfema_emfazo(md):
         parse_morfema_emfazo,
         before='emphasis',
     )
+
+
+class AnkrohavaHTMLRenderer(mistune.HTMLRenderer):
+    def __init__(self):
+        super().__init__()
+        self._uzitaj_ankroj = {}
+
+    def heading(self, text, level, **attrs):
+        ankro = unika_ankro(forigu_html(text), self._uzitaj_ankroj)
+        return '<h{level} id="{ankro}">{text}</h{level}>\n'.format(
+            ankro=mistune.escape(ankro),
+            level=level,
+            text=text,
+        )
+
+
+def render_markdown(text):
+    md = mistune.create_markdown(
+        renderer=AnkrohavaHTMLRenderer(),
+        plugins=[morfema_emfazo],
+    )
+    return Markup(md(text))
 
 
 def render_page(name, enhavo, vojprefikso, env):
@@ -257,7 +280,6 @@ def generate_html(
     cxefpagxaj_lingvoj=None,
 ):
     eligo = {}
-    md = mistune.create_markdown(plugins=[morfema_emfazo])
     versio = get_version_hash()
     enhavo['versio'] = versio
     if kopiu_statikan:
@@ -268,7 +290,7 @@ def generate_html(
         )
 
     env = jinja2.Environment(auto_reload=False)
-    env.filters['markdown'] = lambda text: Markup(md(text))
+    env.filters['markdown'] = render_markdown
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -40,30 +40,22 @@ def morfema_emfazo(md):
 
 
 class AnkrohavaHTMLRenderer(mistune.HTMLRenderer):
-    def __init__(self, kun_enhavtabela_ligilo=False):
+    def __init__(self):
         super().__init__()
-        self._kun_enhavtabela_ligilo = kun_enhavtabela_ligilo
         self._uzitaj_ankroj = {}
 
     def heading(self, text, level, **attrs):
         ankro = unika_ankro(forigu_html(text), self._uzitaj_ankroj)
-        enhavtabela_ligilo = ''
-        if self._kun_enhavtabela_ligilo:
-            enhavtabela_ligilo = (
-                ' <a class="gramatika-reenligo" href="#gramatika-enhavtabelo"'
-                ' aria-label="Enhavtabelo">⤴︎</a>'
-            )
-        return '<h{level} id="{ankro}">{text}{ligilo}</h{level}>\n'.format(
+        return '<h{level} id="{ankro}">{text}</h{level}>\n'.format(
             ankro=mistune.escape(ankro),
-            ligilo=enhavtabela_ligilo,
             level=level,
             text=text,
         )
 
 
-def render_markdown(text, kun_enhavtabela_ligilo=False):
+def render_markdown(text):
     md = mistune.create_markdown(
-        renderer=AnkrohavaHTMLRenderer(kun_enhavtabela_ligilo),
+        renderer=AnkrohavaHTMLRenderer(),
         plugins=[morfema_emfazo],
     )
     return Markup(md(text))

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -40,22 +40,30 @@ def morfema_emfazo(md):
 
 
 class AnkrohavaHTMLRenderer(mistune.HTMLRenderer):
-    def __init__(self):
+    def __init__(self, kun_enhavtabela_ligilo=False):
         super().__init__()
+        self._kun_enhavtabela_ligilo = kun_enhavtabela_ligilo
         self._uzitaj_ankroj = {}
 
     def heading(self, text, level, **attrs):
         ankro = unika_ankro(forigu_html(text), self._uzitaj_ankroj)
-        return '<h{level} id="{ankro}">{text}</h{level}>\n'.format(
+        enhavtabela_ligilo = ''
+        if self._kun_enhavtabela_ligilo:
+            enhavtabela_ligilo = (
+                ' <a class="gramatika-reenligo" href="#gramatika-enhavtabelo"'
+                ' aria-label="Enhavtabelo">⤴︎</a>'
+            )
+        return '<h{level} id="{ankro}">{text}{ligilo}</h{level}>\n'.format(
             ankro=mistune.escape(ankro),
+            ligilo=enhavtabela_ligilo,
             level=level,
             text=text,
         )
 
 
-def render_markdown(text):
+def render_markdown(text, kun_enhavtabela_ligilo=False):
     md = mistune.create_markdown(
-        renderer=AnkrohavaHTMLRenderer(),
+        renderer=AnkrohavaHTMLRenderer(kun_enhavtabela_ligilo),
         plugins=[morfema_emfazo],
     )
     return Markup(md(text))

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -8,10 +8,7 @@ import zipfile
 from pathlib import Path
 
 
-GRAMATIKO_PATTERN = re.compile(
-    r'<h3 id="alphabet">Alphabet\s+'
-    r'<a class="gramatika-reenligo" href="#gramatika-enhavtabelo"'
-)
+GRAMATIKO_PATTERN = re.compile(r'<h3 id="alphabet">Alphabet</h3>')
 GRAMATIKO_TOC_PATTERN = re.compile(
     r'<nav id="gramatika-enhavtabelo" class="gramatika-enhavtabelo"[^>]*>.*'
     r'<a href="#alphabet">Alphabet</a>.*'

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -8,7 +8,13 @@ import zipfile
 from pathlib import Path
 
 
-GRAMATIKO_PATTERN = re.compile(r'<div dir="ltr">\s*<h3>Alphabet</h3>')
+GRAMATIKO_PATTERN = re.compile(r'<h3 id="alphabet">Alphabet</h3>')
+GRAMATIKO_TOC_PATTERN = re.compile(
+    r'<nav class="gramatika-enhavtabelo"[^>]*>.*'
+    r'<a href="#alphabet">Alphabet</a>.*'
+    r'<a href="#pronunciation">Pronunciation</a>',
+    re.S,
+)
 GRAMATIKO_EMFAZO_PATTERN = re.compile(r'<em>labor<strong>i</strong></em>\s+–\s+to work')
 PWA_SERVICE_WORKER_PATTERN = re.compile(r'const PRECACHE_URLS = \[')
 BOOTSTRAP_PATTERN = re.compile(r'Bootstrap\s+v5\.3\.8')
@@ -120,6 +126,7 @@ def main():
     require_pattern(output_dir / 'vendor' / 'typeahead' / 'typeahead.bundle.min.js', TYPEAHEAD_PATTERN)
     gramatiko_path = lingvo_dir / '01' / 'gramatiko' / 'index.html'
     require_pattern(gramatiko_path, GRAMATIKO_PATTERN)
+    require_pattern(gramatiko_path, GRAMATIKO_TOC_PATTERN)
     require_pattern(gramatiko_path, GRAMATIKO_EMFAZO_PATTERN)
     require_apkg(lingvo_dir / 'eksporto' / (lingvo + '.apkg'))
 

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -8,9 +8,12 @@ import zipfile
 from pathlib import Path
 
 
-GRAMATIKO_PATTERN = re.compile(r'<h3 id="alphabet">Alphabet</h3>')
+GRAMATIKO_PATTERN = re.compile(
+    r'<h3 id="alphabet">Alphabet\s+'
+    r'<a class="gramatika-reenligo" href="#gramatika-enhavtabelo"'
+)
 GRAMATIKO_TOC_PATTERN = re.compile(
-    r'<nav class="gramatika-enhavtabelo"[^>]*>.*'
+    r'<nav id="gramatika-enhavtabelo" class="gramatika-enhavtabelo"[^>]*>.*'
     r'<a href="#alphabet">Alphabet</a>.*'
     r'<a href="#pronunciation">Pronunciation</a>',
     re.S,

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -303,6 +303,33 @@ test('poŝtelefone nur aktiva leciona langeto montras etikedon', async ({ page }
   await expect(grammarTab).toContainText('Grammar');
 });
 
+test('gramatika enhavtabelo aperas dekstre sur labortablo', async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 720 });
+  await page.goto('/en/01/gramatiko/');
+
+  const toc = page.locator('.gramatika-enhavtabelo');
+  await expect(toc).toBeVisible();
+  await expect(toc.getByRole('link', { name: 'Alphabet' })).toHaveAttribute('href', '#alphabet');
+  await expect(toc.getByRole('link', { name: 'Pronunciation' })).toHaveAttribute('href', '#pronunciation');
+  await expect(toc.getByRole('link', { name: 'Ĉu?' })).toBeVisible();
+  await expect(toc).not.toContainText('*Ĉu?*');
+  await expect(page.locator('h3#alphabet')).toHaveText('Alphabet');
+
+  const boxes = await page.evaluate(() => {
+    const content = document.querySelector('main .col-sm-12').getBoundingClientRect();
+    const tocBox = document.querySelector('.gramatika-enhavtabelo').getBoundingClientRect();
+    return {
+      contentLeft: content.left,
+      contentRight: content.right,
+      tocLeft: tocBox.left,
+      tocRight: tocBox.right,
+    };
+  });
+
+  expect(boxes.tocLeft).toBeGreaterThan(boxes.contentLeft + 0.5 * (boxes.contentRight - boxes.contentLeft));
+  expect(boxes.tocRight).toBeLessThanOrEqual(boxes.contentRight + 1);
+});
+
 test('aktiva leciona langeto havas kampecan fonon', async ({ page }) => {
   await page.goto('/en/01/ekzerco3/');
 

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -313,7 +313,11 @@ test('gramatika enhavtabelo aperas dekstre sur labortablo', async ({ page }) => 
   await expect(toc.getByRole('link', { name: 'Pronunciation' })).toHaveAttribute('href', '#pronunciation');
   await expect(toc.getByRole('link', { name: 'Ĉu?' })).toBeVisible();
   await expect(toc).not.toContainText('*Ĉu?*');
-  await expect(page.locator('h3#alphabet')).toHaveText('Alphabet');
+  await expect(page.locator('h3#alphabet')).toContainText('Alphabet');
+  await expect(page.locator('h3#alphabet .gramatika-reenligo')).toHaveAttribute(
+    'href',
+    '#gramatika-enhavtabelo',
+  );
 
   const boxes = await page.evaluate(() => {
     const content = document.querySelector('main .col-sm-12').getBoundingClientRect();
@@ -328,6 +332,21 @@ test('gramatika enhavtabelo aperas dekstre sur labortablo', async ({ page }) => 
 
   expect(boxes.tocLeft).toBeGreaterThan(boxes.contentLeft + 0.5 * (boxes.contentRight - boxes.contentLeft));
   expect(boxes.tocRight).toBeLessThanOrEqual(boxes.contentRight + 1);
+});
+
+test('gramatika enhavtabelo restas horizontala sur poŝtelefono', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 720 });
+  await page.goto('/en/01/gramatiko/');
+
+  const first = page.locator('.gramatika-enhavtabelo li').first();
+  const second = page.locator('.gramatika-enhavtabelo li').nth(1);
+  const boxes = await Promise.all([
+    first.boundingBox(),
+    second.boundingBox(),
+  ]);
+
+  expect(Math.abs(boxes[0].y - boxes[1].y)).toBeLessThan(8);
+  expect(boxes[1].x).toBeGreaterThan(boxes[0].x);
 });
 
 test('aktiva leciona langeto havas kampecan fonon', async ({ page }) => {

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -330,6 +330,20 @@ test('gramatika enhavtabelo aperas dekstre sur labortablo', async ({ page }) => 
 
   expect(boxes.tocLeft).toBeGreaterThan(boxes.contentLeft + 0.5 * (boxes.contentRight - boxes.contentLeft));
   expect(boxes.tocRight).toBeLessThanOrEqual(boxes.contentRight + 1);
+
+  const desktopItems = await page.locator('.gramatika-enhavtabelo li').evaluateAll((items) => {
+    return items.slice(0, 2).map((item) => {
+      const box = item.getBoundingClientRect();
+      return {
+        display: getComputedStyle(item).display,
+        y: box.y,
+      };
+    });
+  });
+
+  expect(desktopItems[0].display).toBe('list-item');
+  expect(desktopItems[1].display).toBe('list-item');
+  expect(desktopItems[1].y).toBeGreaterThan(desktopItems[0].y + 8);
 });
 
 test('gramatika enhavtabelo restas horizontala sur poŝtelefono', async ({ page }) => {
@@ -345,6 +359,7 @@ test('gramatika enhavtabelo restas horizontala sur poŝtelefono', async ({ page 
 
   expect(Math.abs(boxes[0].y - boxes[1].y)).toBeLessThan(8);
   expect(boxes[1].x).toBeGreaterThan(boxes[0].x);
+  await expect(first).toHaveCSS('display', 'list-item');
 });
 
 test('aktiva leciona langeto havas kampecan fonon', async ({ page }) => {

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -313,11 +313,9 @@ test('gramatika enhavtabelo aperas dekstre sur labortablo', async ({ page }) => 
   await expect(toc.getByRole('link', { name: 'Pronunciation' })).toHaveAttribute('href', '#pronunciation');
   await expect(toc.getByRole('link', { name: 'Ĉu?' })).toBeVisible();
   await expect(toc).not.toContainText('*Ĉu?*');
-  await expect(page.locator('h3#alphabet')).toContainText('Alphabet');
-  await expect(page.locator('h3#alphabet .gramatika-reenligo')).toHaveAttribute(
-    'href',
-    '#gramatika-enhavtabelo',
-  );
+  await expect(page.locator('h3#alphabet')).toHaveText('Alphabet');
+  await expect(page.locator('.gramatika-reenligo')).toHaveCount(0);
+  await expect(toc).toHaveCSS('position', 'sticky');
 
   const boxes = await page.evaluate(() => {
     const content = document.querySelector('main .col-sm-12').getBoundingClientRect();


### PR DESCRIPTION
## Resumo
- Kreas stabilajn ankrojn por Markdown-titoloj dum HTML-generado.
- Montras malgrandan enhavtabelon supre en gramatikaj paĝoj.
- Vicigas la enhavtabelon dekstre sur labortablo.
- Purigas Markdown-emfazajn signojn el enhavtabelaj titoloj.
- Aldonas smoke- kaj UI-kontrolojn por la nova konduto.

## Kontroloj
- `make check`
- `make check-ui`
- `git diff --check`