### PR TITLE
Movu ekzemplojn en memorhelpaj kestoj al apartaj listeroj (angla)

### DIFF
--- a/enhavo/tradukenda/en/gramatiko/02.md
+++ b/enhavo/tradukenda/en/gramatiko/02.md
@@ -62,7 +62,11 @@ To conjugate, simply replace the infinitive *-i* with the tense ending. The endi
 - *ni labor__os__* – we will work
 - *ili labor__os__* – they will work
 
-**💡 Memory aid:** the tense vowels run i–a–o: *-is* (past), *-as* (present), *-os* (future).
+**💡 Memory aid:** the tense vowels run i–a–o:
+
+- *-is* (past)
+- *-as* (present)
+- *-os* (future)
 
 # The conjunction *ke*
 

--- a/enhavo/tradukenda/en/gramatiko/03.md
+++ b/enhavo/tradukenda/en/gramatiko/03.md
@@ -56,7 +56,10 @@ forms the word for a place where something regularly happens:
 - *kuir__ej__o* – kitchen (*kuiri* – to cook)
 - *labor__ej__o* – workplace
 
-**💡 Memory aid:** *-ej* turns an activity into its place: *lerni* (to learn) → *lernejo* (school), *kuiri* (to cook) → *kuirejo* (kitchen).
+**💡 Memory aid:** *-ej* turns an activity into its place:
+
+- *lerni* (to learn) → *lernejo* (school)
+- *kuiri* (to cook) → *kuirejo* (kitchen)
 
 # The suffix *__-ebl__*
 

--- a/enhavo/tradukenda/en/gramatiko/07.md
+++ b/enhavo/tradukenda/en/gramatiko/07.md
@@ -42,4 +42,6 @@ means a concrete "thing":
 - *bel__aĵ__o* – something beautiful
 - *send__aĵ__o* – something sent, a missive
 
-**💡 Memory aid:** *-aĵ* turns an action or quality into a tangible thing: *manĝi* (to eat) → *manĝaĵo* (food).
+**💡 Memory aid:** *-aĵ* turns an action or quality into a tangible thing:
+
+- *manĝi* (to eat) → *manĝaĵo* (food)

--- a/enhavo/tradukenda/en/gramatiko/09.md
+++ b/enhavo/tradukenda/en/gramatiko/09.md
@@ -40,7 +40,9 @@ indicates a collection of objects viewed as a whole:
 - *vagono* (coach) → *vagon__ar__o* – train
 - *vorto* (word) → *vort__ar__o* – dictionary
 
-**💡 Memory aid:** *-ar* bundles individual items into a set: many an *arbo* (tree) make an *arbaro* (forest).
+**💡 Memory aid:** *-ar* bundles individual items into a set:
+
+- *arbo* (tree) → *arbaro* (forest)
 
 # The Suffix *__-um__*
 

--- a/enhavo/tradukenda/en/gramatiko/10.md
+++ b/enhavo/tradukenda/en/gramatiko/10.md
@@ -15,7 +15,9 @@ makes an abstract noun — a state or quality:
 - *varm__ec__o* – warmth
 - *simpl__ec__o* – simplicity
 
-**💡 Memory aid:** *-ec* works like English "-ness" or "-ity": *bela* (beautiful) → *beleco* (beauty).
+**💡 Memory aid:** *-ec* works like English "-ness" or "-ity":
+
+- *bela* (beautiful) → *beleco* (beauty)
 
 # The Suffix *__-uj__*
 

--- a/enhavo/tradukenda/en/gramatiko/11.md
+++ b/enhavo/tradukenda/en/gramatiko/11.md
@@ -7,4 +7,7 @@ forms words for a tool, implement or means:
 - *ŝlos__il__o* – key
 - *timig__il__o* – scarecrow
 
-**💡 Memory aid:** *-il* names the instrument for an action: *tranĉi* (to cut) → *tranĉilo* (knife), *ŝlosi* (to lock) → *ŝlosilo* (key).
+**💡 Memory aid:** *-il* names the instrument for an action:
+
+- *tranĉi* (to cut) → *tranĉilo* (knife)
+- *ŝlosi* (to lock) → *ŝlosilo* (key)

--- a/enhavo/tradukenda/en/gramatiko/12.md
+++ b/enhavo/tradukenda/en/gramatiko/12.md
@@ -12,7 +12,9 @@ makes a word indefinite or general:
 
 - *kiom __ajn__* – however much
 
-**💡 Memory aid:** *ajn* opens a [correlative](/en/tabelvortoj/) right up: *kiom* (how much) → *kiom ajn* (however much).
+**💡 Memory aid:** *ajn* opens a [correlative](/en/tabelvortoj/) right up:
+
+- *kiom* (how much) → *kiom ajn* (however much)
 
 # The Prefix *__dis-__*
 
@@ -30,4 +32,7 @@ denotes a fraction:
 - *kvar__on__o* – quarter
 - *ses__on__o* – sixth
 
-**💡 Memory aid:** *-on* turns a number into its fraction: *du* (two) → *duono* (half), *kvar* (four) → *kvarono* (quarter).
+**💡 Memory aid:** *-on* turns a number into its fraction:
+
+- *du* (two) → *duono* (half)
+- *kvar* (four) → *kvarono* (quarter)


### PR DESCRIPTION
## Resumo

En la anglaj gramatik-lecionoj, la ekzemploj post dupunkto en la 💡-memorhelpaj kestoj nun aperas kiel apartaj listeroj anstataŭ inline, por pli bona legebleco. Ekz.:

> **💡 Memory aid:** *-ec* works like English "-ness" or "-ity":
> - *bela* (beautiful) → *beleco* (beauty)

Tuŝitaj: lecionoj 2, 3, 7, 9, 10, 11, 12 (la memorhelpiloj kun "dupunkto + ekzemplo").

## Testplano

- [x] `make check` sukcesas
- [x] Kontrolite: la ekzemploj rendiĝas kiel `<ul><li>` sub la kesto

🤖 Generated with [Claude Code](https://claude.com/claude-code)