### PR TITLE
Uzu lernan titolon en paĝotitoloj

### DIFF
--- a/fonto/html/afiksoj.html
+++ b/fonto/html/afiksoj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	{{enhavo.fasado['Afiksoj']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/auxtoroj.html
+++ b/fonto/html/auxtoroj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	Aŭtoroj
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/diversajxoj.html
+++ b/fonto/html/diversajxoj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	{{enhavo.fasado['Diversaĵoj']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/ekzerco1.html
+++ b/fonto/html/ekzerco1.html
@@ -5,7 +5,7 @@
 	|
 	{{enhavo.fasado['Ekzerco 1']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/ekzerco2.html
+++ b/fonto/html/ekzerco2.html
@@ -5,7 +5,7 @@
 	|
 	{{enhavo.fasado['Ekzerco 2']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -5,7 +5,7 @@
 	|
 	{{enhavo.fasado['Ekzerco 3']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/gramatiko.html
+++ b/fonto/html/gramatiko.html
@@ -5,7 +5,7 @@
 	|
 	{{enhavo.fasado['Gramatiko']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/index.html
+++ b/fonto/html/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block title %}
-  {{ enhavo.fasado['Lerni Esperanton'] or enhavo.fasado['Esperanto en 12 lecionoj'] }}
+  {{ enhavo.fasado['Lerni Esperanton'] or enhavo.fasado['Lerni Esperanton en 12 lecionoj'] }}
 	|
   {{enhavo.fasado['La plej rapida kurso por la bazoj']}}
 {% endblock %}

--- a/fonto/html/konjunkcioj.html
+++ b/fonto/html/konjunkcioj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	{{enhavo.fasado['Konjunkcioj']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/post.html
+++ b/fonto/html/post.html
@@ -3,7 +3,7 @@
 {% block title %}
   Post la kurso
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/prepozicioj.html
+++ b/fonto/html/prepozicioj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	{{enhavo.fasado['Prepozicioj']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/tabelvortoj.html
+++ b/fonto/html/tabelvortoj.html
@@ -3,7 +3,7 @@
 {% block title %}
 	{{enhavo.fasado['Tabelvortoj']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/teksto.html
+++ b/fonto/html/teksto.html
@@ -5,7 +5,7 @@
 	|
 	{{enhavo.fasado['Teksto']}}
 	|
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/html/vortoj.html
+++ b/fonto/html/vortoj.html
@@ -5,7 +5,7 @@
   |
   {{enhavo.fasado['Novaj vortoj']}}
   |
-  {{enhavo.fasado['Esperanto en 12 lecionoj']}}
+  {{enhavo.fasado['Lerni Esperanton en 12 lecionoj']}}
 {% endblock %}
 
 {% block content %}

--- a/fonto/md/arangxo.md
+++ b/fonto/md/arangxo.md
@@ -1,5 +1,5 @@
 ---
-title: {{ enhavo.fasado['Lerni Esperanton'] or enhavo.fasado['Esperanto en 12 lecionoj'] }}
+title: {{ enhavo.fasado['Lerni Esperanton'] or enhavo.fasado['Lerni Esperanton en 12 lecionoj'] }}
 subtitle: {{enhavo.fasado['La plej rapida kurso por la bazoj']}}
 documentclass: scrartcl
 lang: {{ enhavo.lingvo }}


### PR DESCRIPTION
## Resumo
- anstataŭigas la malnovan fasado-ŝlosilon per la nova lernotitola ŝlosilo en HTML-paĝtitoloj
- ĝisdatigas ankaŭ la Markdown-metadatenan titolon por konsekvenco

## Kontroloj
- make html LINGVO=en
- konkreta kontrolo de angla gramatika paĝtitolo: 1. Amiko Marko | Grammar | Learn Esperanto in 12 Lessons
- make check
- git diff --check