### PR TITLE
Aldonu reklamon por Universala Kongreso

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -19,7 +19,7 @@
 body {
   display: flex;
   flex-direction: column;
-  font-family: 'Fira Sans', sans-serif;
+  font-family: "Fira Sans", sans-serif;
   font-size: 18px;
   line-height: 30px;
   min-height: 100vh;
@@ -52,8 +52,8 @@ h3 {
   display: grid;
   grid-template-columns: minmax(2.75rem, 1fr) auto minmax(2.75rem, 1fr);
   margin-bottom: 20px;
-  margin-top: 20px;
   padding-bottom: 16px;
+  padding-top: 16px;
 }
 .leciona-titolo {
   align-items: center;
@@ -171,6 +171,28 @@ h3 {
   position: sticky;
   top: 0;
   z-index: 1030;
+}
+.kurso-reklamo {
+  margin: -0.5rem auto 1rem;
+  max-width: 48rem;
+  text-align: center;
+  text-wrap: balance;
+  font-weight: 500;
+  font-style: italic;
+  a {
+    margin: 0 -0.2em;
+    padding: 0.1em 0.4em;
+    border-radius: 0.8em 0.3em;
+    background: rgba(0, 0, 0, 0);
+    background-image: linear-gradient(
+      to right,
+      rgba(255, 193, 7, 0.1),
+      rgba(255, 193, 7, 0.7) 4%,
+      rgba(255, 193, 7, 0.3)
+    );
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
 }
 .navbar > .navbar-enhavo {
   align-items: center;

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -206,5 +206,18 @@
       async
       src="//gc.zgo.at/count.js"
     ></script>
+    <script>
+      document.addEventListener('click', function(event) {
+          var link = event.target.closest('a');
+          
+          if (link && link.href && !link.href.includes(window.location.hostname)) {
+              window.goatcounter.count({
+                  path:  'outbound-' + link.href,
+                  title: link.innerText.trim() || 'Externer Link',
+                  event: true, 
+              });
+          }
+      });
+    </script>
   </body>
 </html>

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -134,8 +134,8 @@
       <div class="container">
         <div class="kurso-reklamo">
           Reklamo: Venu al la
-          <a href="https://www.uea.org/kongresoj">Universala Kongreso</a>
-          en Austrio 1.8. - 8.8.2026
+          <a target="_blank" href="https://www.uea.org/kongresoj">Universala Kongreso</a>
+          en Aŭstrio, 1–8 aŭg. 2026
         </div>
       </div>
     {% endif %}

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -143,12 +143,6 @@
     <main class="container">
       <div class="row">
         <div class="col-sm-12">
-          <!--
-					<div class="ad" >
-						Vizitu la <a target="_blank" href="https://uk.esperanto.net/2026/">Universalan Kongreson en Graz</a> kaj renkontu 1000+ esperantistojn el la tuta mondo.
-					</div>
-						-->
-
           {% block content %} {% endblock %}
         </div>
       </div>

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -130,6 +130,16 @@
       </div>
     </nav>
 
+    {% if leciono_index is defined %}
+      <div class="container">
+        <div class="kurso-reklamo">
+          Reklamo: Venu al la
+          <a href="https://www.uea.org/kongresoj">Universala Kongreso</a>
+          en Austrio 1.8. - 8.8.2026
+        </div>
+      </div>
+    {% endif %}
+
     <main class="container">
       <div class="row">
         <div class="col-sm-12">


### PR DESCRIPTION
## Resumo
- aldonas reklaman tekston por la Universala Kongreso sur lecionaj kursopaĝoj
- metas supran borderon kaj paddingon ĉe la leciona titolo por apartigi la reklamon
- konservas la reklamon for de lingvaj startpaĝoj

## Kontroloj
- make html LINGVO=en
- git diff --check