### PR TITLE
Aldonu redaktoligilojn al enhavpaĝoj

### DIFF
--- a/fonto/html/auxtoroj.html
+++ b/fonto/html/auxtoroj.html
@@ -15,24 +15,24 @@
 
 <h3>Enhavo</h3>
 
-<p>La aŭtoroj de la <em><a href="https://eo.wikipedia.org/wiki/Zagreba_metodo">Zagreba metodo</a></em> estas:</p>
+<p>La aŭtoroj de la <em><a href="https://eo.wikipedia.org/wiki/Zagreba_metodo" target="_blank" rel="noopener">Zagreba metodo</a></em> estas:</p>
 
 <ul>
-	<li><a href="https://eo.wikipedia.org/wiki/Zlatko_Ti%C5%A1ljar">Zlatko Tišljar</a></li>
-	<li><a href="https://eo.wikipedia.org/wiki/Spomenka_%C5%A0timec">Spomenka Štimec</a></li>
+	<li><a href="https://eo.wikipedia.org/wiki/Zlatko_Ti%C5%A1ljar" target="_blank" rel="noopener">Zlatko Tišljar</a></li>
+	<li><a href="https://eo.wikipedia.org/wiki/Spomenka_%C5%A0timec" target="_blank" rel="noopener">Spomenka Štimec</a></li>
 	<li>Ivica Špoljarec</li>
-	<li><a href="https://eo.wikipedia.org/wiki/Roger_Imbert">Roger Imbert</a></li>
+	<li><a href="https://eo.wikipedia.org/wiki/Roger_Imbert" target="_blank" rel="noopener">Roger Imbert</a></li>
 </ul>
 
 <h3>Retejo</h3>
 
 <dl>
   <dt>Programado</dt>
-	<dd><a href="https://github.com/georgjaehnig/">Georg Jähnig</a></dd>
+	<dd><a href="https://github.com/georgjaehnig/" target="_blank" rel="noopener">Georg Jähnig</a></dd>
   <dt>Voĉlego de tekstoj</dt>
-  <dd><a href="https://github.com/EmilioCid/">Emilio Cid</a></dd>
+  <dd><a href="https://github.com/EmilioCid/" target="_blank" rel="noopener">Emilio Cid</a></dd>
   <dt>Kreado de lecionaj desegnoj</dt>
-	<dd><a href="http://instagram.com/deviziaart/">Carlos Devizia</a></dd>
+	<dd><a href="http://instagram.com/deviziaart/" target="_blank" rel="noopener">Carlos Devizia</a></dd>
 </dl>
 
 
@@ -44,7 +44,7 @@
 {% for auxtoro in enhavo.lingvoj[enhavo.lingvo]['aŭtoroj'] %}
   <li>
 		{% if auxtoro.github %} 
-			<a href="https://github.com/{{auxtoro.github}}">{{auxtoro.nomo}}</a>
+			<a href="https://github.com/{{auxtoro.github}}" target="_blank" rel="noopener">{{auxtoro.nomo}}</a>
 		{% else %} 
 			{{auxtoro.nomo}}
 		{% endif %} 

--- a/fonto/html/hejmo.html
+++ b/fonto/html/hejmo.html
@@ -66,11 +66,15 @@
         <div class="footer-listo">
           <a
             href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/PERMESILO.md"
+            target="_blank"
+            rel="noopener"
             >Krea komunaĵo</a
           >
           <span>
             Surbaze de la
             <a href="https://eo.wikipedia.org/wiki/Zagreba_metodo"
+              target="_blank"
+              rel="noopener"
               >Zagreba metodo</a
             >
           </span>
@@ -78,16 +82,20 @@
         <div class="footer-listo">
           <a
             href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/AUTHORS.md"
+            target="_blank"
+            rel="noopener"
             >Kontribuantoj</a
           >
           <a
             href="https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/KONTRIBUADO.md"
+            target="_blank"
+            rel="noopener"
             >Kontribuu</a
           >
         </div>
         <div class="footer-listo">
-          <a href="https://jaehnig.org/impressum/">Kontakto</a>
-          <a href="https://jaehnig.org/privacy">Privateco</a>
+          <a href="https://jaehnig.org/impressum/" target="_blank" rel="noopener">Kontakto</a>
+          <a href="https://jaehnig.org/privacy" target="_blank" rel="noopener">Privateco</a>
           <span class="versio">⏱︎ Versio: {{versio}}</span>
         </div>
       </div>

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -134,7 +134,7 @@
       <div class="container">
         <div class="kurso-reklamo">
           Reklamo: Venu al la
-          <a target="_blank" href="https://www.uea.org/kongresoj">Universala Kongreso</a>
+          <a href="https://www.uea.org/kongresoj" target="_blank" rel="noopener">Universala Kongreso</a>
           en Aŭstrio, 1–8 aŭg. 2026
         </div>
       </div>
@@ -151,13 +151,13 @@
     <footer class="footer">
       <div class="container footer-kolumnoj">
         <div class="footer-listo">
-          <a class="footer-licenco" href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/PERMESILO.md">
+          <a class="footer-licenco" href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/PERMESILO.md" target="_blank" rel="noopener">
             <img src="/assets/img/cc-by.svg" alt="">
             <span>Krea komunaĵo</span>
           </a>
           <span>
             Surbaze de la
-            <a href="https://eo.wikipedia.org/wiki/Zagreba_metodo">Zagreba metodo</a>
+            <a href="https://eo.wikipedia.org/wiki/Zagreba_metodo" target="_blank" rel="noopener">Zagreba metodo</a>
           </span>
           <span class="footer-subteno">
             <img class="footer-uea" src="/assets/img/uea.png" alt="" />
@@ -173,15 +173,17 @@
           <a href="{{vojprefikso}}auxtoroj/">Kontribuantoj</a>
           <a
             href="https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/KONTRIBUADO.md"
+            target="_blank"
+            rel="noopener"
             >Kontribuu</a
           >
           {% for redakta_ligilo in redaktaj_ligiloj|default([]) %}
-            <a href="{{redakta_ligilo.url}}">{{redakta_ligilo.teksto}}</a>
+            <a href="{{redakta_ligilo.url}}" target="_blank" rel="noopener">{{redakta_ligilo.teksto}}</a>
           {% endfor %}
         </div>
         <div class="footer-listo">
-          <a href="https://jaehnig.org/impressum/">Kontakto</a>
-          <a href="https://jaehnig.org/privacy">Privateco</a>
+          <a href="https://jaehnig.org/impressum/" target="_blank" rel="noopener">Kontakto</a>
+          <a href="https://jaehnig.org/privacy" target="_blank" rel="noopener">Privateco</a>
           <span class="versio">⏱︎ Versio: {{enhavo.versio}}</span>
         </div>
       </div>

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -175,6 +175,9 @@
             href="https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/KONTRIBUADO.md"
             >Kontribuu</a
           >
+          {% for redakta_ligilo in redaktaj_ligiloj|default([]) %}
+            <a href="{{redakta_ligilo.url}}">{{redakta_ligilo.teksto}}</a>
+          {% endfor %}
         </div>
         <div class="footer-listo">
           <a href="https://jaehnig.org/impressum/">Kontakto</a>

--- a/fonto/html/pagxonumerado-komentejo.html
+++ b/fonto/html/pagxonumerado-komentejo.html
@@ -35,6 +35,6 @@
 		(d.head || d.body).appendChild(s);
 	};
 	</script>
-	<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+	<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" target="_blank" rel="noopener">comments powered by Disqus.</a></noscript>
 
 {%- endif %} 

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -19,6 +19,7 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 FONTO_DIR = ROOT_DIR / 'fonto'
 NODE_MODULES_DIR = ROOT_DIR / 'node_modules'
 OUTPUT_DIR = ROOT_DIR / 'eligo' / 'retejo'
+GITHUB_CONTENT_BASE = 'https://github.com/Esperanto/kurso-zagreba-metodo'
 
 
 def morfema_emfazo(md):
@@ -68,6 +69,58 @@ def render_page(name, enhavo, vojprefikso, env):
     )
 
     return rendered
+
+
+def github_content_url(lingvo, path, kind='blob'):
+    return f'{GITHUB_CONTENT_BASE}/{kind}/master/enhavo/tradukenda/{lingvo}/{path}'
+
+
+def redaktaj_ligiloj(lingvo, tab=None, leciono=None):
+    if tab is None:
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'enkonduko.md'),
+            }
+        ]
+
+    if tab in ('teksto', 'vortoj'):
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'vortaro', 'tree'),
+            }
+        ]
+
+    if tab == 'gramatiko':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'gramatiko', 'tree'),
+            }
+        ]
+
+    if tab == 'ekzerco1':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, f'ekzercoj/traduku/{leciono}.yml'),
+            }
+        ]
+
+    if tab == 'ekzerco3':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, f'ekzercoj/traduku/{leciono}.yml'),
+            },
+            {
+                'teksto': 'Redaktu respondojn',
+                'url': github_content_url(lingvo, f'ekzercoj/traduku-kaj-respondu/{leciono}.yml'),
+            },
+        ]
+
+    return []
 
 
 def write_file(filename, content):
@@ -326,6 +379,7 @@ def generate_html(
         ],
         url=url,
         vojprefikso=vojprefikso,
+        redaktaj_ligiloj=redaktaj_ligiloj(lingvo),
         tabs=tabs,
     )
 
@@ -376,7 +430,8 @@ def generate_html(
                 next_path=next_path,
                 tabs=tabs,
                 active_tab=tab,
-                identigilo=i_padded + '/' + href
+                identigilo=i_padded + '/' + href,
+                redaktaj_ligiloj=redaktaj_ligiloj(lingvo, tab, i_padded),
             )
 
             eligo[leciono_dir / href / 'index.html'] = tab_rendered

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -76,10 +76,11 @@ def render_markdown(text):
     return Markup(md(text))
 
 
-def render_page(name, enhavo, vojprefikso, env):
+def render_page(name, enhavo, vojprefikso, env, redaktaj_ligiloj=None):
     rendered = env.get_template(name + '.html').render(
         enhavo=enhavo,
         vojprefikso=vojprefikso,
+        redaktaj_ligiloj=redaktaj_ligiloj or [],
     )
 
     return rendered
@@ -110,7 +111,7 @@ def redaktaj_ligiloj(lingvo, tab=None, leciono=None):
         return [
             {
                 'teksto': 'Redaktu tiun ĉi enhavon',
-                'url': github_content_url(lingvo, 'gramatiko', 'tree'),
+                'url': github_content_url(lingvo, f'gramatiko/{leciono}.md'),
             }
         ]
 
@@ -126,12 +127,16 @@ def redaktaj_ligiloj(lingvo, tab=None, leciono=None):
         return [
             {
                 'teksto': 'Redaktu tiun ĉi enhavon',
-                'url': github_content_url(lingvo, f'ekzercoj/traduku/{leciono}.yml'),
-            },
-            {
-                'teksto': 'Redaktu respondojn',
                 'url': github_content_url(lingvo, f'ekzercoj/traduku-kaj-respondu/{leciono}.yml'),
             },
+        ]
+
+    if tab == 'post':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'post.md'),
+            }
         ]
 
     return []
@@ -408,7 +413,8 @@ def generate_html(
     eligo[output_path / 'eksporto' / (enhavo['lingvo'] + '.apkg')] = create_anki(enhavo)
 
     for tab_page in ['tabelvortoj', 'prepozicioj', 'konjunkcioj', 'afiksoj', 'diversajxoj', 'auxtoroj', 'post']:
-        eligo[output_path / tab_page / 'index.html'] = render_page(tab_page, enhavo, vojprefikso, env)
+        pagxaj_ligiloj = redaktaj_ligiloj(lingvo, 'post') if tab_page == 'post' else None
+        eligo[output_path / tab_page / 'index.html'] = render_page(tab_page, enhavo, vojprefikso, env, pagxaj_ligiloj)
 
     paths = []
     for i in range(1, 13):

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -53,6 +53,20 @@ class AnkrohavaHTMLRenderer(mistune.HTMLRenderer):
             text=text,
         )
 
+    def link(self, text, url, title=None):
+        title_attr = ''
+        if title:
+            title_attr = ' title="{}"'.format(mistune.escape(title))
+        target_attr = ''
+        if url.startswith(('http://', 'https://')):
+            target_attr = ' target="_blank" rel="noopener"'
+        return '<a href="{}"{}{}>{}</a>'.format(
+            mistune.escape_url(url),
+            title_attr,
+            target_attr,
+            text,
+        )
+
 
 def render_markdown(text):
     md = mistune.create_markdown(

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -178,13 +178,9 @@ def redaktaj_ligiloj(lingvo, tab=None, leciono=None):
     if tab == 'diversajxoj':
         return [
             {
-                'teksto': 'Redaktu gravajn esprimojn',
-                'url': github_content_url(lingvo, 'vortaro/grava_esprimo.yml'),
-            },
-            {
-                'teksto': 'Redaktu kolorojn',
-                'url': github_content_url(lingvo, 'vortaro/koloro.yml'),
-            },
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'vortaro', 'tree'),
+            }
         ]
 
     return []

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -139,6 +139,54 @@ def redaktaj_ligiloj(lingvo, tab=None, leciono=None):
             }
         ]
 
+    if tab == 'tabelvortoj':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'vortaro/tabelvorto.yml'),
+            }
+        ]
+
+    if tab == 'prepozicioj':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'vortaro/prepozicio.yml'),
+            }
+        ]
+
+    if tab == 'konjunkcioj':
+        return [
+            {
+                'teksto': 'Redaktu tiun ĉi enhavon',
+                'url': github_content_url(lingvo, 'vortaro/konjunkcio.yml'),
+            }
+        ]
+
+    if tab == 'afiksoj':
+        return [
+            {
+                'teksto': 'Redaktu prefiksojn',
+                'url': github_content_url(lingvo, 'vortaro/prefikso.yml'),
+            },
+            {
+                'teksto': 'Redaktu sufiksojn',
+                'url': github_content_url(lingvo, 'vortaro/sufikso.yml'),
+            },
+        ]
+
+    if tab == 'diversajxoj':
+        return [
+            {
+                'teksto': 'Redaktu gravajn esprimojn',
+                'url': github_content_url(lingvo, 'vortaro/grava_esprimo.yml'),
+            },
+            {
+                'teksto': 'Redaktu kolorojn',
+                'url': github_content_url(lingvo, 'vortaro/koloro.yml'),
+            },
+        ]
+
     return []
 
 
@@ -413,7 +461,7 @@ def generate_html(
     eligo[output_path / 'eksporto' / (enhavo['lingvo'] + '.apkg')] = create_anki(enhavo)
 
     for tab_page in ['tabelvortoj', 'prepozicioj', 'konjunkcioj', 'afiksoj', 'diversajxoj', 'auxtoroj', 'post']:
-        pagxaj_ligiloj = redaktaj_ligiloj(lingvo, 'post') if tab_page == 'post' else None
+        pagxaj_ligiloj = redaktaj_ligiloj(lingvo, tab_page)
         eligo[output_path / tab_page / 'index.html'] = render_page(tab_page, enhavo, vojprefikso, env, pagxaj_ligiloj)
 
     paths = []

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -163,6 +163,42 @@ test('piedo montras grizajn tri kolumnojn kun permesilaj ligiloj', async ({ page
   expect(Math.abs(footerBox.width - viewport.width)).toBeLessThan(1);
 });
 
+test('piedo ligas al redaktado de la aktuala enhavo', async ({ page }) => {
+  await page.goto('/en/');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/enhavo/tradukenda/en/enkonduko.md',
+  );
+
+  await page.goto('/en/01/');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/enhavo/tradukenda/en/vortaro',
+  );
+
+  await page.goto('/en/01/gramatiko/');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/enhavo/tradukenda/en/gramatiko',
+  );
+
+  await page.goto('/en/01/ekzerco1/');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/enhavo/tradukenda/en/ekzercoj/traduku/01.yml',
+  );
+
+  await page.goto('/en/01/ekzerco3/');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/enhavo/tradukenda/en/ekzercoj/traduku/01.yml',
+  );
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu respondojn' })).toHaveAttribute(
+    'href',
+    'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/enhavo/tradukenda/en/ekzercoj/traduku-kaj-respondu/01.yml',
+  );
+});
+
 test('malsupra pagxilo havas apartigan linion', async ({ page }) => {
   await page.goto('/en/02/');
 

--- a/tests/ui/en.spec.js
+++ b/tests/ui/en.spec.js
@@ -58,6 +58,8 @@ test('angla lingva startpaĝo montras kursan enkondukon', async ({ page }) => {
     'href',
     'https://apps.ankiweb.net/',
   );
+  await expect(page.getByRole('link', { name: 'Anki' })).toHaveAttribute('target', '_blank');
+  await expect(page.getByRole('link', { name: 'Anki' })).toHaveAttribute('rel', 'noopener');
   await expect(page.getByRole('link', { name: 'Start' })).toHaveAttribute('href', '/en/01');
 
   const languageButton = page.locator('.lingva-startpagxo-agoj .dropdown-toggle');
@@ -142,11 +144,15 @@ test('piedo montras grizajn tri kolumnojn kun permesilaj ligiloj', async ({ page
     'href',
     'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/PERMESILO.md',
   );
+  await expect(footer.getByRole('link', { name: 'Krea komunaĵo' })).toHaveAttribute('target', '_blank');
+  await expect(footer.getByRole('link', { name: 'Krea komunaĵo' })).toHaveAttribute('rel', 'noopener');
   await expect(footer.getByText('Surbaze de la')).toBeVisible();
   await expect(footer.getByRole('link', { name: 'Zagreba metodo' })).toHaveAttribute(
     'href',
     'https://eo.wikipedia.org/wiki/Zagreba_metodo',
   );
+  await expect(footer.getByRole('link', { name: 'Zagreba metodo' })).toHaveAttribute('target', '_blank');
+  await expect(footer.getByRole('link', { name: 'Zagreba metodo' })).toHaveAttribute('rel', 'noopener');
   await expect(footer.getByRole('link', { name: 'Kontribuantoj' })).toHaveAttribute(
     'href',
     /auxtoroj\/$/,
@@ -155,6 +161,8 @@ test('piedo montras grizajn tri kolumnojn kun permesilaj ligiloj', async ({ page
     'href',
     'https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/KONTRIBUADO.md',
   );
+  await expect(footer.getByRole('link', { name: 'Kontribuu' })).toHaveAttribute('target', '_blank');
+  await expect(footer.getByRole('link', { name: 'Kontribuu' })).toHaveAttribute('rel', 'noopener');
   await expect(footer.getByText(/⏱︎ Versio: [0-9a-f]{7}/)).toBeVisible();
 
   const footerBox = await footer.boundingBox();
@@ -169,6 +177,8 @@ test('piedo ligas al redaktado de la aktuala enhavo', async ({ page }) => {
     'href',
     'https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/enhavo/tradukenda/en/enkonduko.md',
   );
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute('target', '_blank');
+  await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute('rel', 'noopener');
 
   await page.goto('/en/01/');
   await expect(page.locator('.footer').getByRole('link', { name: 'Redaktu tiun ĉi enhavon' })).toHaveAttribute(


### PR DESCRIPTION
## Resumo
- aldonas piedan ligilon por redakti la fontan enhavon ĉe lingvaj startpaĝoj kaj lecionaj paĝoj
- ligas tekston kaj novajn vortojn al la lingva vortaro, gramatikon al la lingva gramatika dosierujo, kaj ekzercojn al la koncernaj YAML-dosieroj
- aldonas UI-kontrolon por la novaj redaktoligiloj

## Kontroloj
- make check
- make check-ui
- git diff --check