### PR TITLE
Gramatika enhavtabelo: padding-right por la listeroj

### DIFF
--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -153,7 +153,7 @@ h3 {
   display: list-item;
   float: left;
   list-style-position: inside;
-  margin-right: 1.5rem;
+  padding-right: 1.5rem;
 }
 .gramatika-enhavtabelo a {
   margin-left: 0.2rem;
@@ -416,7 +416,7 @@ h3 {
   }
   .gramatika-enhavtabelo li {
     float: none;
-    margin-right: 0;
+    padding-right: 0;
   }
   .gramatika-teksto {
     grid-column: 1;

--- a/fonto/css/main.css
+++ b/fonto/css/main.css
@@ -416,6 +416,7 @@ h3 {
   }
   .gramatika-enhavtabelo li {
     float: none;
+    list-style-position: outside;
     padding-right: 0;
   }
   .gramatika-teksto {


### PR DESCRIPTION
## Resumo

La gramatika enhavtabelo (TOC) jam estas `<ol>`. Poŝtelefone la listeroj staras unu apud la alia (`float: left`); la interspaco nun estas farita per `padding-right` (1.5rem) anstataŭ `margin-right`, kun sufiĉa spaco. En la labortabla (sidebar) aranĝo la listeroj restas vertikalaj.

## Testplano

- [x] `make check` sukcesas
- [ ] Vida kontrolo: poŝtelefone TOC-eroj nebeneinander kun spaco; labortable kiel flanka listo

🤖 Generated with [Claude Code](https://claude.com/claude-code)