### PR TITLE
Plibonigu germanan laŭ ai/plibonigi-tradukon.md (ikonoj + listeroj)

### DIFF
--- a/enhavo/tradukenda/de/gramatiko/01.md
+++ b/enhavo/tradukenda/de/gramatiko/01.md
@@ -12,7 +12,7 @@ Die fünf Vokale *a, e, i, o, u* werden kurz und klar gesprochen, wie in den Wö
 
 - *aŭto*, *aŭtoro*, *Eŭropo*, *neŭtrala*
 
-**Achtung:** *eŭ* wird nicht wie das deutsche „eu" (oj) gesprochen, sondern – wie geschrieben – als *e* mit kurz nachklingendem *u*.
+**⚠️ Achtung:** *eŭ* wird nicht wie das deutsche „eu" (oj) gesprochen, sondern – wie geschrieben – als *e* mit kurz nachklingendem *u*.
 
 ## Abweichende Lautzeichen
 
@@ -29,7 +29,7 @@ Bei den Konsonanten müssen stimmhafte und stimmlose Laute genau unterschieden w
 
 **Stolperfallen für Deutschsprachige:** *c* ist immer „z" (nie „k"!) – *citrono* klingt wie „Zitrono". *v* ist immer „w" – *vagono* klingt wie „Wagono". Und *z* ist das stimmhafte (summende) s wie in „Rose", nicht das scharfe ß.
 
-**Eselsbrücke:** Die vier „Hut-Buchstaben" *ĉ, ŝ, ĝ, ĵ* bekommen durch ihr Dächlein einen Zischlaut – ganz wie sch/tsch/dsch.
+**💡 Eselsbrücke:** Die vier „Hut-Buchstaben" *ĉ, ŝ, ĝ, ĵ* bekommen durch ihr Dächlein einen Zischlaut – ganz wie sch/tsch/dsch.
 
 Das *r* soll, wenn möglich, als gerolltes Zungenspitzen-*r* gesprochen werden – wie in einigen deutschen Dialekten, im Polnischen, Russischen, Italienischen oder Spanischen.
 
@@ -67,7 +67,7 @@ Das ist der Schlüssel zu Esperanto: **Die Endung verrät die Wortart.** Man sie
 - *ili laboras* – sie arbeiten
 - *mi lernas* – ich lerne
 
-**Merke:** Anders als im Deutschen bleibt die Endung *-as* für jede Person gleich: *mi lernas, vi lernas, li lernas* … Es gibt nichts auswendig zu lernen.
+**💡 Merke:** Anders als im Deutschen bleibt die Endung *-as* für jede Person gleich: *mi lernas, vi lernas, li lernas* … Es gibt nichts auswendig zu lernen.
 
 # Mehrzahl
 
@@ -75,7 +75,7 @@ Die Mehrzahl bildet man bei Haupt- und Eigenschaftswörtern einfach durch angeh�
 
 - *amiko* – Freund / *amiko__j__* – Freunde
 
-**Achtung:** Die Mehrzahl ist *-j* (gesprochen wie das „j" in „ja"), nicht *-s* wie im Englischen. *amikoj* klingt also wie „amiko-j".
+**⚠️ Achtung:** Die Mehrzahl ist *-j* (gesprochen wie das „j" in „ja"), nicht *-s* wie im Englischen. *amikoj* klingt also wie „amiko-j".
 
 # Artikel
 
@@ -109,7 +109,7 @@ Die besitzanzeigenden Fürwörter entstehen ganz regelmäßig – aus dem persö
 - *vi* – ihr / *vi__a__* – euer
 - *ili* – sie / *ili__a__* – ihr
 
-**Hinweis:** *ĝi* (es) steht nur für Dinge und Tiere. Ein grammatisches Geschlecht wie im Deutschen (der/die/das) gibt es nicht.
+**💡 Hinweis:** *ĝi* (es) steht nur für Dinge und Tiere. Ein grammatisches Geschlecht wie im Deutschen (der/die/das) gibt es nicht.
 
 # sein – *esti*
 
@@ -122,7 +122,7 @@ Die besitzanzeigenden Fürwörter entstehen ganz regelmäßig – aus dem persö
 - *vi estas* – ihr seid
 - *ili estas* – sie sind
 
-**Merke:** Ein Verb, eine Form – *estas* gilt für alle. Das deutsche „bin/bist/ist/sind/seid" schrumpft auf ein einziges Wort.
+**💡 Merke:** Ein Verb, eine Form – *estas* gilt für alle. Das deutsche „bin/bist/ist/sind/seid" schrumpft auf ein einziges Wort.
 
 # Fragewörter
 
@@ -144,7 +144,7 @@ Im Deutschen bildet man einfache Fragen durch Umstellung („Sie arbeiten." → 
 - *__Ĉu__ ili nun laboras?* – Arbeiten sie jetzt?
 - *__Ĉu__ la patrino instruas?* – Unterrichtet die Mutter?
 
-**Eselsbrücke:** *ĉu* ist das Fragezeichen am Satzanfang – steht es vorn, wird der ganze Satz zur Ja/Nein-Frage.
+**💡 Eselsbrücke:** *ĉu* ist das Fragezeichen am Satzanfang – steht es vorn, wird der ganze Satz zur Ja/Nein-Frage.
 
 Die Reihenfolge der Satzteile ist im Esperanto frei; in der Regel wird Subjekt – Prädikat – Objekt bevorzugt. Eine andere Reihenfolge dient meist der Hervorhebung des ersten Satzteils.
 
@@ -159,7 +159,7 @@ bezeichnet den Beruf oder eine weltanschauliche Einstellung – ganz wie das deu
 
 # Nachsilbe *__-in__*
 
-bedeutet „weiblich". **Eselsbrücke:** Es ist dasselbe „-in" wie in der deutschen „Lehrerin" oder „Schülerin":
+bedeutet „weiblich". **💡 Eselsbrücke:** Es ist dasselbe „-in" wie in der deutschen „Lehrerin" oder „Schülerin":
 
 - *patro* – Vater / *patr__in__o* – Mutter
 - *lernanto* – Schüler / *lernant__in__o* – Schülerin

--- a/enhavo/tradukenda/de/gramatiko/01.md
+++ b/enhavo/tradukenda/de/gramatiko/01.md
@@ -27,7 +27,7 @@ Bei den Konsonanten müssen stimmhafte und stimmlose Laute genau unterschieden w
 - *Ĝ* – dsch (*ĝangalo* – Dschungel)
 - *Ĥ* – ch (*eĥo* – Echo)
 
-**Stolperfallen für Deutschsprachige:** *c* ist immer „z" (nie „k"!) – *citrono* klingt wie „Zitrono". *v* ist immer „w" – *vagono* klingt wie „Wagono". Und *z* ist das stimmhafte (summende) s wie in „Rose", nicht das scharfe ß.
+**⚠️ Stolperfallen für Deutschsprachige:** *c* ist immer „z" (nie „k"!) – *citrono* klingt wie „Zitrono". *v* ist immer „w" – *vagono* klingt wie „Wagono". Und *z* ist das stimmhafte (summende) s wie in „Rose", nicht das scharfe ß.
 
 **💡 Eselsbrücke:** Die vier „Hut-Buchstaben" *ĉ, ŝ, ĝ, ĵ* bekommen durch ihr Dächlein einen Zischlaut – ganz wie sch/tsch/dsch.
 

--- a/enhavo/tradukenda/de/gramatiko/02.md
+++ b/enhavo/tradukenda/de/gramatiko/02.md
@@ -33,9 +33,9 @@ Die Konjugation – beim Sprachenlernen sonst der schwierigste Teil – ist in E
 - *vi labor__os__* – ihr werdet arbeiten
 - *ili labor__os__* – sie werden arbeiten
 
-**Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o: *-is* (Vergangenheit), *-as* (Gegenwart), *-os* (Zukunft).
+**💡 Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o: *-is* (Vergangenheit), *-as* (Gegenwart), *-os* (Zukunft).
 
-**Merke:** Wie schon in [Lektion 1](/de/01/gramatiko/) ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
+**💡 Merke:** Wie schon in [Lektion 1](/de/01/gramatiko/) ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
 
 - *Mi estas* – ich bin
 - *vi estas* – du bist
@@ -68,7 +68,7 @@ Neue Wörter entstehen auf drei Wegen:
     - *malbono* – schlecht
     - *patrino* – Mutter
 
-**Tipp:** Diese Baukasten-Logik ist das Herz von Esperanto: Aus wenigen Wurzeln und Silben bildet man selbst unzählige Wörter.
+**💡 Tipp:** Diese Baukasten-Logik ist das Herz von Esperanto: Aus wenigen Wurzeln und Silben bildet man selbst unzählige Wörter.
 
 # Akkusativ
 
@@ -91,14 +91,14 @@ Er steht dort, wo man fragt:
 - Mehrzahl: *libroj__n__* – die Bücher (sehe ich)
 - Fürwort: *mi__n__* – mich
 
-**Merke:** Das *-n* steht immer ganz hinten – auch nach dem Mehrzahl-*j*: *libroj__n__*.
+**💡 Merke:** Das *-n* steht immer ganz hinten – auch nach dem Mehrzahl-*j*: *libroj__n__*.
 
 ## Beispiele
 
 - *Ĉu vi havas novan amikon?* – Hast du einen neuen Freund?
 - *Kiun libron vi havas?* – Welches Buch hast du?
 
-**Hinweis:** Wo das Deutsche Genitiv oder Dativ gebraucht, steht im Esperanto der Nominativ in Verbindung mit einem Verhältniswort:
+**💡 Hinweis:** Wo das Deutsche Genitiv oder Dativ gebraucht, steht im Esperanto der Nominativ in Verbindung mit einem Verhältniswort:
 
 - *la libro de la patro* – das Buch des Vaters
 - *La patro donas al ŝi libron.* – Der Vater gibt ihr ein Buch.
@@ -110,7 +110,7 @@ bildet das genaue Gegenteil:
 - *amiko* – Freund / *__mal__amiko* – Feind
 - *granda* – groß / *__mal__granda* – klein
 
-**Eselsbrücke:** Ein einziges *mal-* ersetzt ein ganzes Heer von Gegenwörtern – statt eigener Vokabeln für „klein, kurz, langsam, schlecht" genügen *malgranda, mallonga, malrapida, malbona*.
+**💡 Eselsbrücke:** Ein einziges *mal-* ersetzt ein ganzes Heer von Gegenwörtern – statt eigener Vokabeln für „klein, kurz, langsam, schlecht" genügen *malgranda, mallonga, malrapida, malbona*.
 
 # Vorsilbe *__ge-__*
 
@@ -127,7 +127,7 @@ fasst Personen beiderlei Geschlechts zusammen (die Mehrzahl-Endung *-j* muss dab
 - *Mi ne komprenas, __ke__ vi ne havas tempon.* – Ich verstehe nicht, dass du keine Zeit hast.
 - *Ĉu vi povas kompreni, __ke__ li ne skribis?* – Kannst du verstehen, dass er nicht schrieb?
 
-**Achtung:** *ke* (dass) nicht mit *kio* (was) verwechseln – *ke* leitet nur einen Nebensatz ein und fragt nach nichts.
+**⚠️ Achtung:** *ke* (dass) nicht mit *kio* (was) verwechseln – *ke* leitet nur einen Nebensatz ein und fragt nach nichts.
 
 # Fürwörter
 
@@ -144,7 +144,7 @@ Hinweisende Fürwörter beginnen mit *ti-*. Zwischen den *ki-* und *ti-*-Wörter
 - *kion / tion* – was / das
     - *__Kion__ mi volas, __tion__ mi havas.* – Was ich will, das habe ich.
 
-**Tipp:** Das vollständige System dieser Wörter steht im Anhang als [Tabellwörter](/de/tabelvortoj/). Hier genügt es, das Paar-Prinzip *ki-* → *ti-* zu erkennen.
+**💡 Tipp:** Das vollständige System dieser Wörter steht im Anhang als [Tabellwörter](/de/tabelvortoj/). Hier genügt es, das Paar-Prinzip *ki-* → *ti-* zu erkennen.
 
 # Eigenschaftswörter
 

--- a/enhavo/tradukenda/de/gramatiko/02.md
+++ b/enhavo/tradukenda/de/gramatiko/02.md
@@ -33,7 +33,11 @@ Die Konjugation – beim Sprachenlernen sonst der schwierigste Teil – ist in E
 - *vi labor__os__* – ihr werdet arbeiten
 - *ili labor__os__* – sie werden arbeiten
 
-**💡 Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o: *-is* (Vergangenheit), *-as* (Gegenwart), *-os* (Zukunft).
+**💡 Eselsbrücke:** Die drei Zeiten folgen den Vokalen i–a–o:
+
+- *-is* (Vergangenheit)
+- *-as* (Gegenwart)
+- *-os* (Zukunft)
 
 **💡 Merke:** Wie schon in [Lektion 1](/de/01/gramatiko/) ist die Endung für alle Personen gleich – ob Einzahl oder Mehrzahl:
 

--- a/enhavo/tradukenda/de/gramatiko/03.md
+++ b/enhavo/tradukenda/de/gramatiko/03.md
@@ -23,7 +23,7 @@ Beide heißen auf Deutsch „mit" – Esperanto unterscheidet aber sauber zwisch
 - *Ĉu vi venis __per__ aŭto?* – Kamst du mit dem Auto?
 - *Li salutis __per__ la mano.* – Er grüßte mit der Hand.
 
-**Eselsbrücke:** *kun* = in Gesellschaft (ein Kumpan kommt *kun*), *per* = das Mittel zum Zweck (per Bahn, per Hand).
+**💡 Eselsbrücke:** *kun* = in Gesellschaft (ein Kumpan kommt *kun*), *per* = das Mittel zum Zweck (per Bahn, per Hand).
 
 # *Post*
 
@@ -40,7 +40,7 @@ Beide heißen auf Deutsch „mit" – Esperanto unterscheidet aber sauber zwisch
 - *Mi iras __malantaŭ__ vi.* – Ich gehe hinter dir. (örtlich)
 - *Ŝi sidas __malantaŭ__ la tablo.* – Sie sitzt hinter dem Tisch.
 
-**Merke:** *post* meint die Zeit (nachher), *malantaŭ* den Ort (dahinter). Folgerichtig ist *malantaŭ* das *mal-*-Gegenteil von *antaŭ* (vor).
+**💡 Merke:** *post* meint die Zeit (nachher), *malantaŭ* den Ort (dahinter). Folgerichtig ist *malantaŭ* das *mal-*-Gegenteil von *antaŭ* (vor).
 
 # Befehlsform
 
@@ -66,7 +66,7 @@ Ort, Raum, Stelle:
 - *labor__ej__o* – Arbeitsplatz
 - *halt__ej__o* – Haltestelle
 
-**Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: *lerni* (lernen) → *lernejo* (Schule), *labori* (arbeiten) → *laborejo* (Arbeitsplatz).
+**💡 Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: *lerni* (lernen) → *lernejo* (Schule), *labori* (arbeiten) → *laborejo* (Arbeitsplatz).
 
 # Nachsilbe *__-ebl__*
 

--- a/enhavo/tradukenda/de/gramatiko/03.md
+++ b/enhavo/tradukenda/de/gramatiko/03.md
@@ -66,7 +66,10 @@ Ort, Raum, Stelle:
 - *labor__ej__o* – Arbeitsplatz
 - *halt__ej__o* – Haltestelle
 
-**💡 Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort: *lerni* (lernen) → *lernejo* (Schule), *labori* (arbeiten) → *laborejo* (Arbeitsplatz).
+**💡 Eselsbrücke:** *-ej* macht aus der Tätigkeit den Ort:
+
+- *lerni* (lernen) → *lernejo* (Schule)
+- *labori* (arbeiten) → *laborejo* (Arbeitsplatz)
 
 # Nachsilbe *__-ebl__*
 

--- a/enhavo/tradukenda/de/gramatiko/04.md
+++ b/enhavo/tradukenda/de/gramatiko/04.md
@@ -15,7 +15,7 @@ Eine Bewegung auf ein Ziel zu (wohin?) zeigt Esperanto mit der Akkusativ-Endung 
 - *Mi metis la libron sur la tablo__n__.* – Ich habe das Buch auf den Tisch gelegt.
 - *Li falis en la akvo__n__.* – Er fiel ins Wasser.
 
-**Eselsbrücke:** Wie im Deutschen „in dem Zimmer" (wo?) ↔ „in das Zimmer" (wohin?): Steht Bewegung dahinter, kommt das *-n* ans Ziel. *en la ĉambro* = im Zimmer, *en la ĉambron* = ins Zimmer.
+**💡 Eselsbrücke:** Wie im Deutschen „in dem Zimmer" (wo?) ↔ „in das Zimmer" (wohin?): Steht Bewegung dahinter, kommt das *-n* ans Ziel. *en la ĉambro* = im Zimmer, *en la ĉambron* = ins Zimmer.
 
 # Das rückbezügliche Fürwort *si*
 
@@ -30,7 +30,7 @@ Das rückbezügliche Fürwort *si* (sich) gebraucht man nur in der dritten Perso
 - *Ili lavas __sin__.* – Sie waschen sich.
     - (Aber: *Ili lavas ilin.* – Sie waschen sie / die anderen.)
 
-**Achtung:** *sin* und *ŝin/ilin* sind nicht dasselbe! *si* zeigt zurück auf das Subjekt (er wäscht sich selbst), *ŝin/ilin* meint eine andere Person.
+**⚠️ Achtung:** *sin* und *ŝin/ilin* sind nicht dasselbe! *si* zeigt zurück auf das Subjekt (er wäscht sich selbst), *ŝin/ilin* meint eine andere Person.
 
 # *Sia*
 
@@ -39,7 +39,7 @@ Das rückbezügliche Fürwort *si* (sich) gebraucht man nur in der dritten Perso
 - *Ŝi iris kun __sia__ amikino en la teatron.* – Sie ging mit ihrer Freundin ins Theater.
 - *Li iris kun __siaj__ amikoj en la parkon.* – Er ging mit seinen Freunden in den Park.
 
-**Merke:** *sia* ist das besitzanzeigende Gegenstück zu *si* (*si* + *-a*) – und meint stets den Besitz des Satzsubjekts.
+**💡 Merke:** *sia* ist das besitzanzeigende Gegenstück zu *si* (*si* + *-a*) – und meint stets den Besitz des Satzsubjekts.
 
 # *Meti*
 
@@ -59,4 +59,4 @@ wieder-, zurück-:
 - *__re__veni* – zurückkommen
 - *__re__meti* – zurücklegen
 
-**Eselsbrücke:** *re-* ist das lateinische „re-" wie in Re-vision oder Re-tour – etwas geschieht erneut oder zurück.
+**💡 Eselsbrücke:** *re-* ist das lateinische „re-" wie in Re-vision oder Re-tour – etwas geschieht erneut oder zurück.

--- a/enhavo/tradukenda/de/gramatiko/05.md
+++ b/enhavo/tradukenda/de/gramatiko/05.md
@@ -24,7 +24,7 @@ Zusammengesetzt ergibt das zum Beispiel:
 - *tio* – das (dort) / *__ĉi__ tio* – das hier
 - *tien* – dorthin / *__ĉi__ tien* – hierher
 
-**Eselsbrücke:** *ĉi* holt alles in die Nähe – „*ĉi* tie" ist das Hier, das man fast anfassen kann.
+**💡 Eselsbrücke:** *ĉi* holt alles in die Nähe – „*ĉi* tie" ist das Hier, das man fast anfassen kann.
 
 # Komparativ, Superlativ
 
@@ -72,4 +72,4 @@ Die Vergleichswörter merkt man sich gleich mit: *kiel* (wie) beim Gleichstand, 
 
 - *__Kioma__ horo estas?* – Wie spät ist es?
 
-**Hinweis:** *kioma* fragt nach der Reihenfolge (die wievielte Stunde?) – daher lautet die Antwort „die dritte (Stunde)".
+**💡 Hinweis:** *kioma* fragt nach der Reihenfolge (die wievielte Stunde?) – daher lautet die Antwort „die dritte (Stunde)".

--- a/enhavo/tradukenda/de/gramatiko/06.md
+++ b/enhavo/tradukenda/de/gramatiko/06.md
@@ -44,7 +44,10 @@ Vergrößerung, Verstärkung:
 - *__eg__e* – in hohem Maß
 - *grand__eg__a* – riesig
 
-**💡 Eselsbrücke:** Das Gegensatzpaar merkt man sich am besten zusammen: *-et* macht klein (*dom__et__o* = Häuschen), *-eg* macht riesig (*dom__eg__o* = Riesenhaus).
+**💡 Eselsbrücke:** Das Gegensatzpaar merkt man sich am besten zusammen:
+
+- *-et* macht klein: *dom__et__o* = Häuschen
+- *-eg* macht riesig: *dom__eg__o* = Riesenhaus
 
 # Nachsilbe *__-iĝ__*
 

--- a/enhavo/tradukenda/de/gramatiko/06.md
+++ b/enhavo/tradukenda/de/gramatiko/06.md
@@ -4,7 +4,7 @@ Drückt der Hauptsatz einen Wunsch oder ein Gebot aus (wünschen, befehlen, bitt
 
 - *Mi deziras, __ke__ vi lern__u__.* – Ich wünsche, dass du lernst!
 
-**Merke:** Nach einem Wunsch folgt *ke* + Verb auf *-u* (nicht auf *-as*). Der Wunsch im Hauptsatz „färbt" das Verb des Nebensatzes.
+**💡 Merke:** Nach einem Wunsch folgt *ke* + Verb auf *-u* (nicht auf *-as*). Der Wunsch im Hauptsatz „färbt" das Verb des Nebensatzes.
 
 # Mögen
 
@@ -22,7 +22,7 @@ Drückt der Hauptsatz einen Wunsch oder ein Gebot aus (wünschen, befehlen, bitt
 - *__Je__ kioma horo vi venos?* – Um wie viel Uhr wirst du kommen?
 - *__Je__ via sano!* – Auf deine Gesundheit!
 
-**Tipp:** *je* ist der „Joker" unter den Verhältniswörtern – im Zweifel passt *je*.
+**💡 Tipp:** *je* ist der „Joker" unter den Verhältniswörtern – im Zweifel passt *je*.
 
 # Nachsilbe *__-et__*
 
@@ -44,7 +44,7 @@ Vergrößerung, Verstärkung:
 - *__eg__e* – in hohem Maß
 - *grand__eg__a* – riesig
 
-**Eselsbrücke:** Das Gegensatzpaar merkt man sich am besten zusammen: *-et* macht klein (*dom__et__o* = Häuschen), *-eg* macht riesig (*dom__eg__o* = Riesenhaus).
+**💡 Eselsbrücke:** Das Gegensatzpaar merkt man sich am besten zusammen: *-et* macht klein (*dom__et__o* = Häuschen), *-eg* macht riesig (*dom__eg__o* = Riesenhaus).
 
 # Nachsilbe *__-iĝ__*
 
@@ -55,7 +55,7 @@ werden, sich … machen (das Subjekt ändert von selbst seinen Zustand):
 - *proksim__iĝ__i* – sich nähern
 - *trankvil__iĝ__i* – sich beruhigen
 
-**Merke:** *-iĝ* heißt „von selbst werden". In [Lektion 8](/de/08/gramatiko/) folgt das Gegenstück *-ig* („etwas machen, bewirken") – das Dächlein auf *ĝ* zeigt nach innen, auf das Subjekt selbst.
+**💡 Merke:** *-iĝ* heißt „von selbst werden". In [Lektion 8](/de/08/gramatiko/) folgt das Gegenstück *-ig* („etwas machen, bewirken") – das Dächlein auf *ĝ* zeigt nach innen, auf das Subjekt selbst.
 
 # *Farti*
 

--- a/enhavo/tradukenda/de/gramatiko/07.md
+++ b/enhavo/tradukenda/de/gramatiko/07.md
@@ -5,14 +5,14 @@
 - *Li __neniam__ ridas.* – Er lacht nie.
 - *Ŝi __nenion__ diris, sed rapide foriris.* – Sie sagte nichts, sondern ging schnell fort.
 
-**Merke:** Anders als im Deutschen gibt es keine doppelte Verneinung. Ein einziges *neni-*-Wort verneint bereits den ganzen Satz: *Ŝi diris nenion* (wörtlich „Sie sagte nichts").
+**💡 Merke:** Anders als im Deutschen gibt es keine doppelte Verneinung. Ein einziges *neni-*-Wort verneint bereits den ganzen Satz: *Ŝi diris nenion* (wörtlich „Sie sagte nichts").
 
 # *Mem / Sola*
 
 - *Mi __mem__ faris tion.* – Ich habe das selbst gemacht.
 - *Mi __sola__ faris tion.* – Ich habe das allein gemacht.
 
-**Achtung:** *mem* (selbst, eigenhändig) ist nicht *sola* (allein, ohne andere) – „ich selbst" ist nicht „ich allein".
+**⚠️ Achtung:** *mem* (selbst, eigenhändig) ist nicht *sola* (allein, ohne andere) – „ich selbst" ist nicht „ich allein".
 
 # *Estas …-e*
 
@@ -30,7 +30,7 @@ Das unpersönliche „es" bleibt unübersetzt. Manchmal kann man sogar *estas* w
 - *Bone, ke vi venis.* – Gut, dass du gekommen bist.
 - *Malbone, ke vi ne povas veni.* – Schlecht, dass du nicht kommen kannst.
 
-**Merke:** Kein „Ding" im Satz → Endung *-e*, nicht *-a*. Vergleiche *estas bone* (es ist gut – allgemein) mit *la libro estas bona* (das Buch ist gut).
+**💡 Merke:** Kein „Ding" im Satz → Endung *-e*, nicht *-a*. Vergleiche *estas bone* (es ist gut – allgemein) mit *la libro estas bona* (das Buch ist gut).
 
 # Vorsilbe *__ek-__*
 
@@ -41,7 +41,7 @@ beginnende Handlung:
 - *__ek__krii* – aufschreien
 - *__ek__manĝi* – beginnen zu essen
 
-**Eselsbrücke:** *ek-* ist der Startschuss – der Moment, in dem die Handlung losgeht (*ekkrii* = einen Schrei ausstoßen).
+**💡 Eselsbrücke:** *ek-* ist der Startschuss – der Moment, in dem die Handlung losgeht (*ekkrii* = einen Schrei ausstoßen).
 
 # Nachsilbe *__-aĵ__*
 
@@ -52,4 +52,4 @@ konkrete Sache:
 - *send__aĵ__o* – Sendung
 - *skrib__aĵ__o* – Schriftstück
 
-**Eselsbrücke:** *-aĵ* macht aus einer Tätigkeit ein greifbares Ding: *manĝi* (essen) → *manĝaĵo* (die Speise).
+**💡 Eselsbrücke:** *-aĵ* macht aus einer Tätigkeit ein greifbares Ding: *manĝi* (essen) → *manĝaĵo* (die Speise).

--- a/enhavo/tradukenda/de/gramatiko/07.md
+++ b/enhavo/tradukenda/de/gramatiko/07.md
@@ -52,4 +52,6 @@ konkrete Sache:
 - *send__aĵ__o* – Sendung
 - *skrib__aĵ__o* – Schriftstück
 
-**💡 Eselsbrücke:** *-aĵ* macht aus einer Tätigkeit ein greifbares Ding: *manĝi* (essen) → *manĝaĵo* (die Speise).
+**💡 Eselsbrücke:** *-aĵ* macht aus einer Tätigkeit ein greifbares Ding:
+
+- *manĝi* (essen) → *manĝaĵo* (die Speise)

--- a/enhavo/tradukenda/de/gramatiko/08.md
+++ b/enhavo/tradukenda/de/gramatiko/08.md
@@ -6,7 +6,7 @@
 - *iom __da__ tempo* – etwas Zeit
 - *tiom __da__ mono* – so viel Geld
 
-**Merke:** Nach Mengenwörtern (Glas, etwas, so viel) steht *da*, nicht *de*. *glaso da akvo* = ein Glas (voll) Wasser.
+**💡 Merke:** Nach Mengenwörtern (Glas, etwas, so viel) steht *da*, nicht *de*. *glaso da akvo* = ein Glas (voll) Wasser.
 
 # Nachsilbe *__-ig__*
 
@@ -16,7 +16,7 @@ machen, in einen Zustand bringen, veranlassen:
 - *for__ig__i* – entfernen
 - *ebl__ig__i* – ermöglichen
 
-**Achtung:** *-ig* und *-iĝ* ([Lektion 6](/de/06/gramatiko/)) nicht verwechseln! *-ig* = etwas oder jemanden verändern (*beligi* – schön machen), *-iĝ* = selbst werden (*beliĝi* – schön werden). Das Dächlein auf *ĝ* zeigt die Veränderung am Subjekt selbst.
+**⚠️ Achtung:** *-ig* und *-iĝ* ([Lektion 6](/de/06/gramatiko/)) nicht verwechseln! *-ig* = etwas oder jemanden verändern (*beligi* – schön machen), *-iĝ* = selbst werden (*beliĝi* – schön werden). Das Dächlein auf *ĝ* zeigt die Veränderung am Subjekt selbst.
 
 # Nachsilbe *__-aĉ__*
 
@@ -26,4 +26,4 @@ machen, in einen Zustand bringen, veranlassen:
 - *parol__aĉ__o* – Kauderwelsch
 - *rid__aĉ__i* – grinsen
 
-**Eselsbrücke:** *-aĉ* ist das abwertende Suffix – schon der kratzige Laut „atsch" klingt nach Pfusch (ein *domaĉo* ist eine schäbige Bruchbude).
+**💡 Eselsbrücke:** *-aĉ* ist das abwertende Suffix – schon der kratzige Laut „atsch" klingt nach Pfusch (ein *domaĉo* ist eine schäbige Bruchbude).

--- a/enhavo/tradukenda/de/gramatiko/09.md
+++ b/enhavo/tradukenda/de/gramatiko/09.md
@@ -5,9 +5,9 @@ Die Bedingungsform (*kondicionalo*) des Zeitwortes trägt die Endung *__-us__*. 
 - *Li certe redon__us__ la monon, se li hav__us__ la eblon.* – Sicherlich würde er das Geld zurückgeben, wenn er die Möglichkeit hätte.
 - *Se mi hav__us__ tempon, mi rest__us__ pli longe.* – Wenn ich Zeit hätte, würde ich länger bleiben.
 
-**Merke:** Im *se*-Satz (wenn) und im Folgesatz steht beide Male *-us* – anders als im Deutschen, das „hätte … würde" mischt.
+**💡 Merke:** Im *se*-Satz (wenn) und im Folgesatz steht beide Male *-us* – anders als im Deutschen, das „hätte … würde" mischt.
 
-**Eselsbrücke:** Jetzt sind alle Verb-Endungen beisammen: *-i* (Grundform), *-as/-is/-os* (die drei Zeiten), *-u* (Befehl), *-us* (Bedingung). Sechs Endungen – ein vollständiges Verbsystem.
+**💡 Eselsbrücke:** Jetzt sind alle Verb-Endungen beisammen: *-i* (Grundform), *-as/-is/-os* (die drei Zeiten), *-u* (Befehl), *-us* (Bedingung). Sechs Endungen – ein vollständiges Verbsystem.
 
 # *Se / Kiam*
 
@@ -18,7 +18,7 @@ Die Bedingungsform (*kondicionalo*) des Zeitwortes trägt die Endung *__-us__*. 
 - *__Kiam__ mi malsanis, (tiam) mi malmulte manĝis.* – Als ich krank war, habe ich wenig gegessen.
 - *__Kiam__ la patro venos, (tiam) mi estos en la lito.* – Wenn der Vater kommt, werde ich im Bett sein.
 
-**Achtung:** Das deutsche „wenn" ist doppeldeutig. Geht es um eine Bedingung → *se*; geht es um einen Zeitpunkt → *kiam*. Probe: Lässt sich „falls" einsetzen, ist es *se*.
+**⚠️ Achtung:** Das deutsche „wenn" ist doppeldeutig. Geht es um eine Bedingung → *se*; geht es um einen Zeitpunkt → *kiam*. Probe: Lässt sich „falls" einsetzen, ist es *se*.
 
 # *Kvazaŭ*
 
@@ -46,7 +46,7 @@ Sammelbegriff, Menge gleichartiger Dinge:
 - *vagon__ar__o* – Zug
 - *hom__ar__o* – Menschheit
 
-**Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: *arbo* (Baum) → *arbaro* (Wald), *vorto* (Wort) → *vortaro* (Wörterbuch).
+**💡 Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: *arbo* (Baum) → *arbaro* (Wald), *vorto* (Wort) → *vortaro* (Wörterbuch).
 
 # Nachsilbe *__-um__*
 
@@ -57,4 +57,4 @@ verwandter Begriff – das „Joker-Suffix" ohne feste Bedeutung:
 - *sun__um__i* – sich sonnen
 - *malvarm__um__i* – sich erkälten
 
-**Tipp:** *-um* ist der Nachsilben-Joker, *je* der Verhältniswort-Joker ([Lektion 6](/de/06/gramatiko/)) – beide springen ein, wo nichts Genaueres passt. Ihre Bedeutung lernt man Wort für Wort.
+**💡 Tipp:** *-um* ist der Nachsilben-Joker, *je* der Verhältniswort-Joker ([Lektion 6](/de/06/gramatiko/)) – beide springen ein, wo nichts Genaueres passt. Ihre Bedeutung lernt man Wort für Wort.

--- a/enhavo/tradukenda/de/gramatiko/09.md
+++ b/enhavo/tradukenda/de/gramatiko/09.md
@@ -46,7 +46,10 @@ Sammelbegriff, Menge gleichartiger Dinge:
 - *vagon__ar__o* – Zug
 - *hom__ar__o* – Menschheit
 
-**💡 Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit: *arbo* (Baum) → *arbaro* (Wald), *vorto* (Wort) → *vortaro* (Wörterbuch).
+**💡 Eselsbrücke:** *-ar* bündelt Einzelnes zur Gesamtheit:
+
+- *arbo* (Baum) → *arbaro* (Wald)
+- *vorto* (Wort) → *vortaro* (Wörterbuch)
 
 # Nachsilbe *__-um__*
 

--- a/enhavo/tradukenda/de/gramatiko/10.md
+++ b/enhavo/tradukenda/de/gramatiko/10.md
@@ -17,7 +17,7 @@ abstrakter Begriff (-heit, -keit, -schaft):
 - *hom__ec__o* – Menschlichkeit
 - *amik__ec__o* – Freundschaft
 
-**Eselsbrücke:** *-ec* macht aus einer Eigenschaft einen Begriff – wie das deutsche „-heit/-keit": *bela* (schön) → *beleco* (Schönheit).
+**💡 Eselsbrücke:** *-ec* macht aus einer Eigenschaft einen Begriff – wie das deutsche „-heit/-keit": *bela* (schön) → *beleco* (Schönheit).
 
 # Nachsilbe *__-uj__*
 
@@ -29,7 +29,7 @@ Behälter, Land, Baum:
 - *Angl__uj__o* – England
 - *pom__uj__o* – Apfelbaum
 
-**Eselsbrücke:** *-uj* ist das, was etwas „enthält": Geld → Geldbörse, Äpfel (am Baum) → Apfelbaum, ein Volk → sein Land.
+**💡 Eselsbrücke:** *-uj* ist das, was etwas „enthält": Geld → Geldbörse, Äpfel (am Baum) → Apfelbaum, ein Volk → sein Land.
 
 # Umstandsbeziehungen
 
@@ -51,4 +51,4 @@ Da die Funktion jedes Wortes an seiner Endung leicht erkennbar ist, braucht Espe
 
 Den internationalen Stil der Sätze lernt man am besten bei der Lektüre.
 
-**Merke:** *ne* wirkt wie ein Scheinwerfer – es verneint genau das Wort, vor dem es steht. Verschiebt man *ne*, verschiebt sich die Bedeutung.
+**💡 Merke:** *ne* wirkt wie ein Scheinwerfer – es verneint genau das Wort, vor dem es steht. Verschiebt man *ne*, verschiebt sich die Bedeutung.

--- a/enhavo/tradukenda/de/gramatiko/10.md
+++ b/enhavo/tradukenda/de/gramatiko/10.md
@@ -17,7 +17,9 @@ abstrakter Begriff (-heit, -keit, -schaft):
 - *hom__ec__o* – Menschlichkeit
 - *amik__ec__o* – Freundschaft
 
-**💡 Eselsbrücke:** *-ec* macht aus einer Eigenschaft einen Begriff – wie das deutsche „-heit/-keit": *bela* (schön) → *beleco* (Schönheit).
+**💡 Eselsbrücke:** *-ec* macht aus einer Eigenschaft einen Begriff – wie das deutsche „-heit/-keit":
+
+- *bela* (schön) → *beleco* (Schönheit)
 
 # Nachsilbe *__-uj__*
 

--- a/enhavo/tradukenda/de/gramatiko/11.md
+++ b/enhavo/tradukenda/de/gramatiko/11.md
@@ -8,6 +8,6 @@ Werkzeug, Gerät, Mittel:
 - *vojmontr__il__o* – Wegweiser
 - *sanig__il__o* – Heilmittel, Medizin
 
-**Eselsbrücke:** *-il* ist das Mittel zum Zweck: *skribi* (schreiben) → *skribilo* (Schreibgerät), *ludi* (spielen) → *ludilo* (Spielzeug).
+**💡 Eselsbrücke:** *-il* ist das Mittel zum Zweck: *skribi* (schreiben) → *skribilo* (Schreibgerät), *ludi* (spielen) → *ludilo* (Spielzeug).
 
-**Tipp:** *manĝ__il__aro* verbindet zwei Silben aus früheren Lektionen: *-il* (Werkzeug) + *-ar* (Sammlung) = die ganze Garnitur Essgeräte, das Besteck.
+**💡 Tipp:** *manĝ__il__aro* verbindet zwei Silben aus früheren Lektionen: *-il* (Werkzeug) + *-ar* (Sammlung) = die ganze Garnitur Essgeräte, das Besteck.

--- a/enhavo/tradukenda/de/gramatiko/11.md
+++ b/enhavo/tradukenda/de/gramatiko/11.md
@@ -8,6 +8,9 @@ Werkzeug, Gerät, Mittel:
 - *vojmontr__il__o* – Wegweiser
 - *sanig__il__o* – Heilmittel, Medizin
 
-**💡 Eselsbrücke:** *-il* ist das Mittel zum Zweck: *skribi* (schreiben) → *skribilo* (Schreibgerät), *ludi* (spielen) → *ludilo* (Spielzeug).
+**💡 Eselsbrücke:** *-il* ist das Mittel zum Zweck:
+
+- *skribi* (schreiben) → *skribilo* (Schreibgerät)
+- *ludi* (spielen) → *ludilo* (Spielzeug)
 
 **💡 Tipp:** *manĝ__il__aro* verbindet zwei Silben aus früheren Lektionen: *-il* (Werkzeug) + *-ar* (Sammlung) = die ganze Garnitur Essgeräte, das Besteck.

--- a/enhavo/tradukenda/de/gramatiko/12.md
+++ b/enhavo/tradukenda/de/gramatiko/12.md
@@ -4,7 +4,7 @@
 
 - *Ju pli longe, des pli bone.* – Je länger, desto besser.
 
-**Merke:** *ju* gehört zum ersten, *des* zum zweiten Satzteil – fest verbunden wie das deutsche „je … desto".
+**💡 Merke:** *ju* gehört zum ersten, *des* zum zweiten Satzteil – fest verbunden wie das deutsche „je … desto".
 
 # *Ajn*
 
@@ -13,7 +13,7 @@
 - *kiu __ajn__* – wer auch immer
 - *iu __ajn__* – ein x-beliebiger
 
-**Eselsbrücke:** *ajn* macht ein [Tabellwort](/de/tabelvortoj/) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
+**💡 Eselsbrücke:** *ajn* macht ein [Tabellwort](/de/tabelvortoj/) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
 
 # Vorsilbe *__dis-__*
 
@@ -22,7 +22,7 @@ Trennung, Teilung (ent-, zer-, auseinander-):
 - *__dis__ĵeti* – zerstreuen
 - *__dis__sendi* – versenden
 
-**Eselsbrücke:** *dis-* ist das lateinische „dis-" wie in dis-tribuieren – etwas wird in alle Richtungen verteilt.
+**💡 Eselsbrücke:** *dis-* ist das lateinische „dis-" wie in dis-tribuieren – etwas wird in alle Richtungen verteilt.
 
 # Nachsilbe *__-on__*
 
@@ -32,4 +32,4 @@ Bruchzahl:
 - *tri__on__o* – Drittel
 - *kvar__on__o* – Viertel
 
-**Eselsbrücke:** *-on* macht aus einer Grundzahl den Bruch: *du* (zwei) → *duono* (Hälfte), *kvar* (vier) → *kvarono* (Viertel).
+**💡 Eselsbrücke:** *-on* macht aus einer Grundzahl den Bruch: *du* (zwei) → *duono* (Hälfte), *kvar* (vier) → *kvarono* (Viertel).

--- a/enhavo/tradukenda/de/gramatiko/12.md
+++ b/enhavo/tradukenda/de/gramatiko/12.md
@@ -13,7 +13,9 @@
 - *kiu __ajn__* – wer auch immer
 - *iu __ajn__* – ein x-beliebiger
 
-**💡 Eselsbrücke:** *ajn* macht ein [Tabellwort](/de/tabelvortoj/) beliebig: aus *kiu* (wer) wird *kiu ajn* (wer auch immer).
+**💡 Eselsbrücke:** *ajn* macht ein [Tabellwort](/de/tabelvortoj/) beliebig:
+
+- aus *kiu* (wer) wird *kiu ajn* (wer auch immer)
 
 # Vorsilbe *__dis-__*
 
@@ -32,4 +34,7 @@ Bruchzahl:
 - *tri__on__o* – Drittel
 - *kvar__on__o* – Viertel
 
-**💡 Eselsbrücke:** *-on* macht aus einer Grundzahl den Bruch: *du* (zwei) → *duono* (Hälfte), *kvar* (vier) → *kvarono* (Viertel).
+**💡 Eselsbrücke:** *-on* macht aus einer Grundzahl den Bruch:
+
+- *du* (zwei) → *duono* (Hälfte)
+- *kvar* (vier) → *kvarono* (Viertel)


### PR DESCRIPTION
## Resumo

Alportas la germanan al la nuna nivelo de `ai/plibonigi-tradukon.md` (kiel en/ru).

**Gramatiko (12 lecionoj):**
- Aldonitaj ⚠️/💡-ikonoj al la kestoj (⚠️ Achtung/Stolperfallen; 💡 Eselsbrücke/Merke/Hinweis/Tipp)
- Ekzemploj post dupunkto movitaj al apartaj listeroj (kiel en/ru)
- (La pedagogio, memorhelpiloj kaj krucreferencaj ligiloj jam ekzistis ekde antaŭe)

**Vortaro & Ekzercoj 1/3:**
- Reviziitaj: la germanaj tradukoj jam estas denask-kvalitaj kaj kompletaj — neniuj malplenaj valoroj, neniuj anglaj restaĵoj, valida YAML, jam kun bonaj variantoj. Do neniuj substancaj ŝanĝoj necesis.

Fasado kaj enkonduko jam estis korektaj de antaŭe.

## Testplano

- [x] `make check` sukcesas
- [x] `make html LINGVO=de` — ikonoj kaj listeroj rendiĝas ĝuste
- [x] YAML de ĉiuj de-vortaro/ekzercoj validaj, neniuj malplenaj valoroj

🤖 Generated with [Claude Code](https://claude.com/claude-code)