### PR TITLE
Plibonigu la polan tradukon (vortaro, ekzercoj, gramatikaj eraroj)

### DIFF
--- a/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/03.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/03.yml
@@ -11,7 +11,7 @@
     - lingvojn: języków
     - '?'
 -
-  demando: Czy wiesz, że Anna lubi nową piosenę o biedaku i pięknej kobiecie?
+  demando: Czy wiesz, że Anna lubi nową piosenkę o biedaku i pięknej kobiecie?
   rektatraduko: 
     - Ĉu: Czy
     - vi: ty

--- a/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/09.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/09.yml
@@ -42,7 +42,7 @@
     - tempo: czas
     - '?'
 - 
-  demando: Czy planujecie jechać autem do Patyża, czy nie wydaje się wam, że dużo lepiej jechać pociągiem?
+  demando: Czy planujecie jechać autem do Paryża, czy nie wydaje się wam, że dużo lepiej jechać pociągiem?
   rektatraduko: 
     - Ĉu: Czy
     - vi: wy

--- a/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/11.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku-kaj-respondu/11.yml
@@ -42,7 +42,7 @@
     - gondolo: gondola
     - '?'
 - 
-  demando: Czy bedzięsz mógł zasnąć kiedy zrobiło się cicho?
+  demando: Czy będziesz mógł zasnąć, kiedy zrobi się cicho?
   rektatraduko: 
     - Ĉu: Czy
     - vi: ty

--- a/enhavo/tradukenda/pl/ekzercoj/traduku/04.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku/04.yml
@@ -3,7 +3,7 @@
 - scivola: 
   - żądny wiedzy
   - ciekawy
-- trilingva: trójęzyczny
+- trilingva: trójjęzyczny
 - reiri: powracać
 - enmeti: wsadzać
 - dektaga: trwający dziesięć dni

--- a/enhavo/tradukenda/pl/ekzercoj/traduku/06.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku/06.yml
@@ -10,9 +10,9 @@
 - prizorgi: 
   - opiekować się
   - pielęgnować
-- espereble: 
-  - prawpdopodobnie
-  - przypuszczalnie
+- espereble:
+  - miejmy nadzieję
+  - mam nadzieję, że
 - altkvalita: 
   - wysokojakościowy
   - wysokiej jakości
@@ -28,7 +28,7 @@
   - wielokrotnie
   - częstokroć
 - nomiĝi: 
-  - nazwyać się
+  - nazywać się
   - mieć na imię
 - ruĝiĝi: 
   - czerwienić się

--- a/enhavo/tradukenda/pl/ekzercoj/traduku/06.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku/06.yml
@@ -11,6 +11,7 @@
   - opiekować się
   - pielęgnować
 - espereble:
+  - oby
   - miejmy nadzieję
   - mam nadzieję, że
 - altkvalita: 

--- a/enhavo/tradukenda/pl/ekzercoj/traduku/07.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku/07.yml
@@ -29,7 +29,9 @@
   - bezużyteczny
   - bezużyteczna
   - bezużyteczne
-- elkuri: nie mieć już
+- elkuri:
+  - wybiec
+  - wybiegać
 - ekami: pokochać
 - ĝisnuna:
   - dotychczasowy

--- a/enhavo/tradukenda/pl/ekzercoj/traduku/12.yml
+++ b/enhavo/tradukenda/pl/ekzercoj/traduku/12.yml
@@ -4,7 +4,9 @@
   - gryzmolić
 - klarigi: wyjaśniać
 - pretigi: przygotowywać
-- ĉevalaĉo: koń
+- ĉevalaĉo:
+  - szkapa
+  - chabeta
 - disdoni: rozdawać
 - dekono: jedna dziesiąta
 - duonigi: przepołowić

--- a/enhavo/tradukenda/pl/gramatiko/01.md
+++ b/enhavo/tradukenda/pl/gramatiko/01.md
@@ -3,7 +3,7 @@
 Esperancki alfabet składa się z 28 liter: a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z. Litery czytamy, jak w języku polskim, z następującymi różnicami:
 - __ĉ__ = cz;
 - __ĝ__ = dż;
-- __ĥ__ = ch, we współczesnym esperancie litera ĥ prawie zupełnie została zastąpiona prze literę k np.: ĥemio=kemio (*chemia*);
+- __ĥ__ = ch, we współczesnym esperancie litera ĥ prawie zupełnie została zastąpiona przez literę k np.: ĥemio=kemio (*chemia*);
 - __ĵ__ = ż;
 - __ŝ__ = sz;
 - __ŭ__ = ł, jak *u* w E__u__ropa, a__u__to;
@@ -21,7 +21,7 @@ Wyrazy akcentujemy, jak w języku polskim, na przedostatniej sylabie: te-le-_fo_
 
 Przedimek _la_, nieodmienny i jeden dla wszystkich rodzajów, przypadków i liczb, wyróżnia konkretny rzeczownik spośród wielu innych.
 
-Seĝo estas en cxambro. – *Krzesło (jakieś) jest w pokoju.*
+Seĝo estas en ĉambro. – *Krzesło (jakieś) jest w pokoju.*
 
 La seĝo estas mia. – *(To) krzesło jest moje.*
 
@@ -51,7 +51,7 @@ La seĝo estas mia. – *(To) krzesło jest moje.*
 
 *Li* używamy wyłącznie w stosunku do mężczyzn; *ŝi* do kobiet; *ĝi* do przedmiotów i zwierząt.
 
-Zaimki dzierżawcze tworzymy dodając do zaimków końcówkę przemiotnikową  __-a__.
+Zaimki dzierżawcze tworzymy dodając do zaimków końcówkę przymiotnikową __-a__.
 
 # Rzeczownik
 
@@ -96,7 +96,7 @@ Końcówka czasowników w czasie teraźniejszym to __-as__.
 
 Końcówka bezokoliczników to __-i__.
    - *est__i__* – być
-   - *mangx__i__* – jeść
+   - *manĝ__i__* – jeść
 
 # *Ĉu?*
 
@@ -110,7 +110,7 @@ Końcówka bezokoliczników to __-i__.
 - *__Kio__ vi estas?* – Czym jesteś? (zawód)
 - *__Kiu__ instruisto sidas?* – Który nauczyciel siedzi?
 
-#jes/ne
+# *jes/ne*
 
 - *__Jes__* – Tak; *__Ne__* – Nie
 - *Ĉu la patro estas en la ĉambro?* – Czy tata jest w pokoju?

--- a/enhavo/tradukenda/pl/gramatiko/01.md
+++ b/enhavo/tradukenda/pl/gramatiko/01.md
@@ -1,29 +1,59 @@
 # Alfabet
 
-Esperancki alfabet składa się z 28 liter: a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z. Litery czytamy, jak w języku polskim, z następującymi różnicami:
-- __ĉ__ = cz;
-- __ĝ__ = dż;
-- __ĥ__ = ch, we współczesnym esperancie litera ĥ prawie zupełnie została zastąpiona przez literę k np.: ĥemio=kemio (*chemia*);
-- __ĵ__ = ż;
-- __ŝ__ = sz;
-- __ŭ__ = ł, jak *u* w E__u__ropa, a__u__to;
-- __v__ = w
+Esperanto pisze się tak, jak się wymawia: każda litera odpowiada zawsze jednemu dźwiękowi, bez wyjątków. Kto pozna alfabet, przeczyta na głos każdy wyraz. Alfabet liczy 28 liter: *a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z*.
+
+Większość liter czytamy jak po polsku. Zwróć uwagę na następujące:
+
+- *ĉ* = cz
+- *ĝ* = dż
+- *ĥ* = ch (jak w *chleb*); we współczesnym esperancie litera *ĥ* jest rzadka i często zastępowana przez *k*, np. *ĥemio = kemio* (*chemia*)
+- *ĵ* = ż
+- *ŝ* = sz
+- *ŭ* = ł, jak *u* w *E__u__ropa*, *a__u__to*
+- *v* = w
+
+**💡 Wskazówka:** wymowa esperanta jest dla Polaka łatwa — głoski *ĉ, ĝ, ĵ, ŝ, ŭ* to po prostu *cz, dż, ż, sz, ł*, a *c* oraz *j* brzmią dokładnie jak po polsku (*c* jak w *co*, *j* jak w *jajko*).
+
+**⚠️ Uwaga:** esperanto rozróżnia *h* (dźwięczne, jak w *hej*) i *ĥ* (jak *ch* w *chleb*), które w polszczyźnie często brzmią tak samo. Tu są to dwie różne litery.
 
 # Wymowa
 
-Wyrazy czytamy dokładnie tak, jak zostały napisane, wymawiając wszystkie litery np.: ĉambro = [*czambro*]; seĝo = [*sedżo*, nie *sedźo*]; kio = [*k-i-o*, nie *kijo*, *kjo*]; nia = [*n-i-a*, nie *nija*].
+Wyrazy czytamy dokładnie tak, jak są napisane, wymawiając każdą literę:
+
+- *ĉambro* = [*czambro*]
+- *seĝo* = [*sedżo*, nie *sedźo*]
+- *kio* = [*k-i-o*, nie *kjo*]
+- *nia* = [*n-i-a*, nie *nija*]
+
+**⚠️ Uwaga:** nie zmiękczaj spółgłosek przed *i*. W esperancie *n*, *s*, *t* itd. brzmią zawsze twardo — *ni* to [*n-i*], a nie [*ni*] jak w polskim *nie*.
 
 # Akcent
 
-Wyrazy akcentujemy, jak w języku polskim, na przedostatniej sylabie: te-le-_fo_-no, a-_mi_-ko, ra-_di_-o. Wyrazy jednosylabowe akcentujemy na jedynej sylabie: _kaj, en_.
+Wyrazy wielosylabowe akcentujemy zawsze na przedostatniej sylabie — bez wyjątków:
 
-# Przedimek la
+- *te-le-FO-no*
+- *a-MI-ko*
+- *ra-DI-o*
 
-Przedimek _la_, nieodmienny i jeden dla wszystkich rodzajów, przypadków i liczb, wyróżnia konkretny rzeczownik spośród wielu innych.
+Wyrazy jednosylabowe akcentujemy na jedynej sylabie: *kaj*, *en*.
 
-Seĝo estas en ĉambro. – *Krzesło (jakieś) jest w pokoju.*
+**💡 Wskazówka:** to ta sama zasada co w polszczyźnie — akcent pada na drugą sylabę od końca. Pamiętaj tylko, że sąsiednie samogłoski liczą się jako osobne sylaby: *radio* to ra-DI-o (trzy sylaby).
 
-La seĝo estas mia. – *(To) krzesło jest moje.*
+# Przedimek *la*
+
+Przedimek określony *__la__* wyróżnia konkretny, znany rzeczownik spośród innych. Jest jeden dla wszystkich rodzajów, przypadków i liczb — nigdy się nie odmienia. Przedimka nieokreślonego (jak angielskie „a") esperanto nie ma:
+
+- *la seĝo* – (to konkretne) krzesło
+  - *seĝo* – (jakieś) krzesło
+
+Przykłady:
+
+- *Seĝo estas en ĉambro.* – Krzesło (jakieś) jest w pokoju.
+- *La seĝo estas mia.* – (To) krzesło jest moje.
+
+**⚠️ Uwaga:** w polszczyźnie nie ma rodzajników, więc *la* jest dla nas nowością. Używamy go, gdy mówimy o czymś znanym lub już wspomnianym; o czymś nieokreślonym mówimy bez *la*.
+
+**💡 Wskazówka:** jedno słówko *la*, niezmienne — żadnych form do nauczenia.
 
 # Zaimki osobowe
 
@@ -31,109 +61,121 @@ La seĝo estas mia. – *(To) krzesło jest moje.*
 - *vi* – ty
 - *li* – on
 - *ŝi* – ona
-- *ĝi* – ono
+- *ĝi* – ono (rzecz, zwierzę)
 - *ni* – my
 - *vi* – wy
-- *ili* – oni
+- *ili* – oni, one
+
+*Li* odnosi się tylko do mężczyzn, *ŝi* tylko do kobiet, a *ĝi* do rzeczy i zwierząt.
+
+**💡 Wskazówka:** jedno *vi* znaczy zarówno „ty", jak i „wy" (oraz grzecznościowe „pan/pani") — esperanto nie rozróżnia tu liczby ani formy grzecznościowej.
 
 # Zaimki dzierżawcze
 
-- *mia* – mój
-- *via* – twój
-- *lia* – jego
-- *ŝia* – jej
-- *ĝia* – tego
-- *nia* – nasz
-- *via* – wasz
-- *ilia* – ich
- 
-*Vi* używamy zarówno w liczbie pojedynczej, jak i mnogiej.
+Tworzymy je całkiem regularnie, dodając do zaimka osobowego końcówkę *__-a__*:
 
-*Li* używamy wyłącznie w stosunku do mężczyzn; *ŝi* do kobiet; *ĝi* do przedmiotów i zwierząt.
+- *mi__a__* – mój
+- *vi__a__* – twój
+- *li__a__* – jego
+- *ŝi__a__* – jej
+- *ĝi__a__* – jego (o rzeczy)
+- *ni__a__* – nasz
+- *vi__a__* – wasz
+- *ili__a__* – ich
 
-Zaimki dzierżawcze tworzymy dodając do zaimków końcówkę przymiotnikową __-a__.
+**💡 Wskazówka:** zaimek + *-a* i gotowe. Ta sama końcówka *-a* tworzy też przymiotniki.
 
 # Rzeczownik
 
-Końcówka rzeczowników to __-o__.
+Każdy rzeczownik kończy się na *__-o__*. Nie ma rodzaju gramatycznego; w razie potrzeby płeć żeńską zaznacza przyrostek *__-in__*:
 
 - *tabl__o__* – stół
 - *lernant__o__* – uczeń
 - *patr__o__* – ojciec
 
+**💡 Wskazówka:** końcówka *-o* od razu zdradza, że wyraz jest rzeczownikiem.
+
 # Liczba mnoga
 
-Liczbę mnogą tworzymy przy pomocy końcówki __-j__, dodajemy ją do rzeczowników, przymiotników i zaimków dzierżawczych.
+Liczbę mnogą tworzy końcówka *__-j__*. Dodajemy ją do rzeczowników, przymiotników i zaimków dzierżawczych:
 
 - *tablo__j__* – stoły
 - *instruisto__j__* – nauczyciele
 - *via__j__ lernanto__j__* – twoi uczniowie
 
+**⚠️ Uwaga:** liczba mnoga to *-j* (czytane jak polskie „j"), a nie *-s* czy inna zmiana tematu. „Stoły" to *tabloj*, nigdy *tablos*.
+
 # Czasownik
 
-Końcówka czasowników w czasie teraźniejszym to __-as__.
+Końcówka czasownika jest **taka sama dla wszystkich osób** — nie ma odmiany przez osoby jak w polszczyźnie. Czas teraźniejszy kończy się na *__-as__*:
 
-- *mi estas* – jestem
-- *vi estas* – jesteś
-- *li estas* – on jest
-- *ŝi estas* – ona jest
-- *ĝi estas* – to jest (dziecko, lalka)
-- *ni estas* – jesteśmy
-- *vi estas* – jesteście
-- *ili estas* – są
+- *mi est__as__* – jestem
+- *vi est__as__* – jesteś
+- *li/ŝi/ĝi est__as__* – on/ona/ono jest
+- *ni est__as__* – jesteśmy
+- *vi est__as__* – jesteście
+- *ili est__as__* – są
 
+Tak samo zachowuje się każdy inny czasownik:
 
-- *mi sidas* – siedzę
-- *vi sidas* – siedzisz
-- *li sidas* – on siedzi
-- *ŝi sidas* – ona siedzi
-- *ĝi sidas* – to siedzi (zwierzę)
-- *ni sidas* – siedzimy
-- *vi sidas* – siedzicie
-- *ili sidas* – siedzą
+- *mi sid__as__* – siedzę
+- *ŝi sid__as__* – ona siedzi
+- *ili sid__as__* – siedzą
+
+**💡 Wskazówka:** jedna forma *-as* zastępuje całą polską odmianę (siedzę, siedzisz, siedzi…).
+
+**⚠️ Uwaga:** ponieważ czasownik nie pokazuje osoby, zaimek (*mi, vi, li*…) jest obowiązkowy. Nie powiemy samego *estas* w znaczeniu „jestem" — zawsze *mi estas*.
 
 # Bezokolicznik
 
-Końcówka bezokoliczników to __-i__.
-   - *est__i__* – być
-   - *manĝ__i__* – jeść
+Bezokolicznik kończy się na *__-i__*:
+
+- *est__i__* – być
+- *manĝ__i__* – jeść
+- *labor__i__* – pracować
 
 # *Ĉu?*
 
-- *__Ĉu__* – czy
+*__ĉu__* zamienia zdanie oznajmujące w pytanie o odpowiedź „tak/nie" — odpowiada polskiemu *czy*. Stawiamy je na początku, a szyk zdania się nie zmienia:
+
 - *__Ĉu__ vi laboras?* – Czy pracujesz?
 - *__Ĉu__ vi estas instruisto?* – Czy jesteś nauczycielem?
 
-# *Kiu/Kio*
-- *__Kiu__* – kto, który; *__Kio__* – co, czym
+# *Kiu / Kio*
+
+*__kiu__* znaczy „kto, który", a *__kio__* – „co":
+
 - *__Kiu__ vi estas?* – Kim jesteś? (imię, nazwisko)
 - *__Kio__ vi estas?* – Czym jesteś? (zawód)
 - *__Kiu__ instruisto sidas?* – Który nauczyciel siedzi?
 
-# *jes/ne*
+Więcej takich słówek poznasz w [lekcji 5](/pl/05/gramatiko/) oraz w [tabeli korelatywów](/pl/tabelvortoj/).
 
-- *__Jes__* – Tak; *__Ne__* – Nie
+# *jes / ne*
+
+Na pytanie z *ĉu* odpowiadamy *__jes__* (tak) lub *__ne__* (nie). Słówko *ne* znaczy też „nie" jako przeczenie i stoi tuż przed zaprzeczanym wyrazem:
+
 - *Ĉu la patro estas en la ĉambro?* – Czy tata jest w pokoju?
-- __Jes__, la patro estas en la ĉambro – Tak, tata jest w pokoju.
-- __Ne__, la libro __ne__ estas sur la tablo – Nie, książka nie jest na stole.
+  - *__Jes__, la patro estas en la ĉambro.* – Tak, tata jest w pokoju.
+  - *__Ne__, la libro __ne__ estas sur la tablo.* – Nie, książka nie jest na stole.
 
-# *-ist*
+# Przyrostek *__-ist__*
 
-zawód:
+oznacza osobę wykonującą jakiś zawód lub stałe zajęcie — jak polskie „-ista/-ysta":
 
 - *instru__ist__o* – nauczyciel
 - *sport__ist__o* – sportowiec
 - *labor__ist__o* – pracownik
 - *esperant__ist__o* – esperantysta
 
+**💡 Wskazówka:** to ten sam „-ista", co w *artyst-a*, *dentyst-a*.
 
-# *-in*
+# Przyrostek *__-in__*
 
-rodz. żeński
-- *patro* – ojciec
-    - *patr__in__o* – matka
-- *lernanto* – uczeń
-    - *lernant__in__o* – uczennica
-- *instruisto* – nauczyciel
-    - *instruist__in__o* – nauczycielka
+tworzy formę żeńską:
 
+- *patro* – ojciec → *patr__in__o* – matka
+- *lernanto* – uczeń → *lernant__in__o* – uczennica
+- *instruisto* – nauczyciel → *instruist__in__o* – nauczycielka
+
+**💡 Wskazówka:** przypomina polskie *-yni* (gospodarz → gospod__yni__, mistrz → mistrz__yni__) — sygnał formy żeńskiej.

--- a/enhavo/tradukenda/pl/gramatiko/02.md
+++ b/enhavo/tradukenda/pl/gramatiko/02.md
@@ -1,116 +1,130 @@
 # Przymiotnik
 
-Końcówka przymiotników to *__-a__*.
+Końcówka przymiotników to *__-a__*:
 
 - *bel__a__* – piękny
 - *grand__a__ frato* – duży brat
 - *malgrand__a__ fratino* – mała siostra
 
+**💡 Wskazówka:** przymiotnik kończy się na *-a*, rzeczownik na *-o*. Wystarczy spojrzeć na końcówkę, by rozpoznać część mowy.
+
 # Biernik
 
-Esperancki biernik (kogo? co?) ma końcówkę *__-n__* i wskazuje osoby oraz przedmioty, na które działa czasownik przechodni. Końcówkę *__-n__* możemy dodać do rzeczowników, przymiotników, zaimków.
+Esperancki biernik (kogo? co?) ma końcówkę *__-n__* i wskazuje osobę lub przedmiot, na które działa czasownik przechodni. Końcówkę *__-n__* dodajemy do rzeczowników, przymiotników i zaimków:
 
-
-- *Mi vidas amiko__n__* – Widzę przyjaciela.
-- *Mi vidas bonan amiko__n__* – Widzę dobrego przyjaciela.
-- *Mi vidas li__n__* – Widzę go.
-- *Mi vidas mian amiko__n__* – Widzę mojego przyjaciela.
-- *Mi vidas miajn bon__ajn__ amik__ojn__* – Widzę moich dobrych przyjaciół.
+- *Mi vidas amiko__n__.* – Widzę przyjaciela.
+- *Mi vidas bonan amiko__n__.* – Widzę dobrego przyjaciela.
+- *Mi vidas li__n__.* – Widzę go.
+- *Mi vidas mian amiko__n__.* – Widzę mojego przyjaciela.
+- *Mi vidas miajn bon__ajn__ amik__ojn__.* – Widzę moich dobrych przyjaciół.
 - *Kio__n__ mi vidas?* – Co widzę?
 - *Kiu__n__ mi vidas?* – Kogo widzę?
 - *Kiu__n__ instruist__on__ mi vidas?* – Którego nauczyciela widzę?
 
-Biernika nigdy nie używamy po czasownikach: *estas, sidas*, a zawsze po *havas, vidas*
+**💡 Wskazówka:** to nasz biernik — Polak już myśli w tym przypadku. W esperancie jest jednak prostszy: zawsze jedna końcówka *-n*, bez względu na rodzaj.
 
-- *Vi estas bon__a__ amik__o__* – Jesteś dobrym przyjacielem.
-- *Vi estas bon__aj__ amik__oj__* – Jesteście dobrymi przyjaciółmi.
+**⚠️ Uwaga:** biernika nie używamy po czasowniku *esti* (być). Po nim rzeczownik zostaje bez *-n* (po polsku użylibyśmy narzędnika):
+
+- *Vi estas bon__a__ amik__o__.* – Jesteś dobrym przyjacielem.
+- *Vi estas bon__aj__ amik__oj__.* – Jesteście dobrymi przyjaciółmi.
 
 # Szyk zdania
 
-Poniższe dwa zdania znaczą dokładnie to samo:
+Dzięki końcówce biernika *-n* szyk zdania jest swobodny — to biernik, a nie kolejność wyrazów, pokazuje, kto wykonuje czynność, a kto jej podlega. Oba zdania znaczą to samo:
 
 - *Mi legas libron.* = *Libron legas mi.* – Ja czytam książkę.
-Zależności między wyrazami w zdaniu określa biernik (__-n__) a nie szyk zdania.
 
-*Lernanto demandas instruiston.* – Uczeń pyta nauczyciela.
+Porównaj jednak, jak biernik zmienia sens:
 
-*Lernanton demandas instruisto* – Ucznia pyta nauczyciel.
+- *Lernanto demandas instruiston.* – Uczeń pyta nauczyciela.
+- *Lernanton demandas instruisto.* – Ucznia pyta nauczyciel.
 
-# Czas przyszły i przeszły 
+**💡 Wskazówka:** tak jak w polszczyźnie, końcówki (a nie szyk) niosą znaczenie — dlatego wyrazy można swobodnie przestawiać.
 
-## Bezokolicznik: *-i*
-  
-- *labor__i__*          – pracować
+# Czasy
 
-## Czas teraźniejszy: *-as*
+Wszystkie czasy mają **jedną końcówkę dla wszystkich osób**. Zmienia się tylko samogłoska: *__-is__* (przeszły), *__-as__* (teraźniejszy), *__-os__* (przyszły).
 
-- *mi labor__as__*      – Pracuję
-- *vi labor__as__*      – Pracujesz/Pracujecie.
-- *li/ŝi labor__as__*   – On/ona pracuje
-- *ni labor__as__*      – My pracujemy
-- *ili labor__as__*     – Oni pracują
+Bezokolicznik *__-i__*:
 
-## Czas przeszły: *-is*
+- *labor__i__* – pracować
 
-- *mi labor__is__*      – Pracowałem.
-- *vi labor__is__*      – Pracowałeś./Pracowaliście.
-- *li/ŝi labor__is__*   – Pracował/pracowała.
-- *ni labor__is__*      – Pracowaliśmy.
-- *ili labor__is__*     – Pracowali.
+Czas teraźniejszy *__-as__*:
 
-## Czas przyszły: *-os*
+- *mi labor__as__* – pracuję
+- *vi labor__as__* – pracujesz / pracujecie
+- *li/ŝi labor__as__* – on/ona pracuje
+- *ni labor__as__* – pracujemy
+- *ili labor__as__* – oni pracują
 
-- *mi labor__os__*      – Będę pracował/a.
-- *vi labor__os__*      – Będziesz pracował/pracowała. / Będziecie pracowali/pracowały.
-- *li/ŝi labor__os__*   – On będzie pracował. / Ona będzie pracowała.
-- *ni labor__os__*      – My będziemy pracowali/pracowały.
-- *ili labor__os__*     – Oni będą pracowali. / One będą pracowały.
+Czas przeszły *__-is__*:
+
+- *mi labor__is__* – pracowałem
+- *vi labor__is__* – pracowałeś / pracowaliście
+- *li/ŝi labor__is__* – pracował / pracowała
+- *ni labor__is__* – pracowaliśmy
+- *ili labor__is__* – pracowali
+
+Czas przyszły *__-os__*:
+
+- *mi labor__os__* – będę pracował
+- *vi labor__os__* – będziesz pracował / będziecie pracowali
+- *li/ŝi labor__os__* – on będzie pracował / ona będzie pracowała
+- *ni labor__os__* – będziemy pracowali
+- *ili labor__os__* – będą pracowali
+
+**💡 Wskazówka:** zapamiętaj samogłoski czasów po kolei **i – a – o**: przesz**ł**y, ter**a**źniejszy, przysz**ł**y. Jedna sylaba zamiast całej polskiej odmiany.
 
 # *ke*
 
-- *__ke__* – że
-- *Vi vidas, __ke__ mi manĝas* – Widzisz, że jem.
-- *Li diras, __ke__ li iros* – On mówi, że pójdzie.
+*__ke__* znaczy „że" i łączy dwa zdania:
 
-# *mal-*
+- *Vi vidas, __ke__ mi manĝas.* – Widzisz, że jem.
+- *Li diras, __ke__ li iros.* – On mówi, że pójdzie.
 
-przeciwieństwo:
+# Przedrostek *__mal-__*
 
-- *bona* – dobry
-  - *__mal__bona* – zły
-- *granda* – wielki
-  - *__mal__granda* – mały
-- *bela* – piękny
-  - *__mal__bela* – brzydki
+tworzy przeciwieństwo (dokładny antonim):
 
-# *ge-*
+- *bona* – dobry → *__mal__bona* – zły
+- *granda* – wielki → *__mal__granda* – mały
+- *bela* – piękny → *__mal__bela* – brzydki
 
-osobnicy obojga płci, para:
+**💡 Wskazówka:** *mal-* odwraca znaczenie na przeciwne — jeden przedrostek zastępuje dziesiątki osobnych słówek.
 
-- *__ge__fratoj* – bracia i siostry
+# Przedrostek *__ge-__*
+
+oznacza osoby obojga płci razem:
+
+- *__ge__fratoj* – rodzeństwo (bracia i siostry)
 - *__ge__patroj* – rodzice
 
 # Kilka zwrotów
 
-- *__Bonvolu__* – Proszę, zechciej, pozwól
-- *__Dankon__* – Dziękuję
-- *__Saluton__* – Cześć
+- *__Bonvolu__* – proszę, zechciej, pozwól
+- *__Dankon__* – dziękuję
+- *__Saluton__* – cześć
 
 # Pytania
 
-Na pytanie KIO odpowiada wyraz z końcówką -O.
-Na pytanie KION odpowiada wyraz z końcówką -ON.
-Na pytanie KIA odpowiada wyraz z końcówką -A.
-Na pytanie KIAN odpowiada wyraz z końcówką -AN.
-Na pytanie KIAJ odpowiada wyraz z końcówką -AJ.
-Na pytanie KIAJN odpowiada wyraz z końcówką -AJN.
+Na każde pytanie odpowiadamy wyrazem z taką samą końcówką:
+
+- na *KIO* → wyraz z końcówką *-o*
+- na *KIO__N__* → wyraz z końcówką *-o__n__*
+- na *KIA* → wyraz z końcówką *-a*
+- na *KIA__N__* → wyraz z końcówką *-a__n__*
+- na *KIA__J__* → wyraz z końcówką *-a__j__*
+- na *KIA__JN__* → wyraz z końcówką *-a__jn__*
+
+Przykłady:
 
 - *__Kio__ estas tio? Libro.* – Co to jest? Książka.
-- *__Kion__ mi vidas? Mi vidas tablon* – Co widzę? Widzę stół.
-- *__Kian__ kafon mi ŝatas? Mi ŝatas varman kafon* – Jaką kawę lubię? Lubię ciepłą kawę.
-- *__Kiajn__ okulojn ŝi havas? Ŝi havas belajn okulojn* – Jakie ona ma oczy? Ona ma ładne oczy.
+- *__Kion__ mi vidas? Mi vidas tablon.* – Co widzę? Widzę stół.
+- *__Kian__ kafon mi ŝatas? Mi ŝatas varman kafon.* – Jaką kawę lubię? Lubię ciepłą kawę.
+- *__Kiajn__ okulojn ŝi havas? Ŝi havas belajn okulojn.* – Jakie ona ma oczy? Ona ma ładne oczy.
 
-Na pytania KION może odpowiadać również czasownik:
+Na pytanie *KION* może odpowiadać również czasownik:
 
-- *__Kion__ ŝi faras? Ŝi legas* – Co ona robi? Ona czyta.
+- *__Kion__ ŝi faras? Ŝi legas.* – Co ona robi? Ona czyta.
 
+Więcej takich słówek pytajnych poznasz w [lekcji 5](/pl/05/gramatiko/) oraz w [tabeli korelatywów](/pl/tabelvortoj/).

--- a/enhavo/tradukenda/pl/gramatiko/03.md
+++ b/enhavo/tradukenda/pl/gramatiko/03.md
@@ -1,65 +1,70 @@
-# Przysłówki		
+# Przysłówki
 
-Końcówka przysłówków to *-e*.
+Końcówka przysłówków to *__-e__*:
 
-- *bel__e__*   – pięknie
-- *fort__e__*  – mocno
-- *rapid__a__ aŭto*   – szybki samochód
-	- *veturi rapid__e__*   – jechać szybko
+- *bel__e__* – pięknie
+- *fort__e__* – mocno
+- *rapid__a__ aŭto* – szybki samochód
+  - *veturi rapid__e__* – jechać szybko
 
+**💡 Wskazówka:** *-o* rzeczownik, *-a* przymiotnik, *-e* przysłówek. Z jednego rdzenia zrobisz wszystkie trzy.
 
 # Przyimki *per* i *kun*
 
-## *Per* - przy pomocy, tworzy odpowiednik polskiego narzędnika
+## *per* – za pomocą
+
+*per* odpowiada polskiemu narzędnikowi (kim? czym?):
 
 - *Manĝi __per__ kulero* – Jeść łyżką
 - *Ŝi kantis __per__ tre bela voĉo.* – Śpiewała bardzo pięknym głosem.
- 
-## *Kun* - z (kim, czym)        
 
-- *Mi iras __kun__ la amiko.*    – Idę z przyjacielem.
-- *Mi parolos __kun__ li.*       – Porozmawiam z nim.
+**💡 Wskazówka:** *per* = narzędzie czynności, czyli nasz narzędnik. *per kulero* = „łyżką".
 
+## *kun* – z (kim, czym)
 
+*kun* oznacza towarzystwo (z kim, razem z czym):
+
+- *Mi iras __kun__ la amiko.* – Idę z przyjacielem.
+- *Mi parolos __kun__ li.* – Porozmawiam z nim.
+
+**⚠️ Uwaga:** polskie „z" oddają dwa różne przyimki: *per* (narzędzie: *pisać długopisem*) i *kun* (towarzystwo: *iść z kolegą*). Nie myl ich.
 
 # Przyimek *post*
 
-*post* – po, za (odnosząc się do czasy)
+*post* znaczy „po" w odniesieniu do czasu:
 
-- *Li venis __post__ mi.*   – Przyszedł po mnie (po tym jak ja przyszedem).
+- *Li venis __post__ mi.* – Przyszedł po mnie (po tym, jak ja przyszedłem).
 - *__post__ du horoj* – za dwie godziny
 - *Li venos __post__ tri horoj.* – Przyjdzie za trzy godziny.
 - *poste* – potem, następnie
 
+# Przyimek *malantaŭ*
 
-# Przyimek *Malantaŭ*
-
-*malantaŭ* - za, lecz tylko w przestrzeni
+*malantaŭ* znaczy „za", ale tylko w przestrzeni:
 
 - *Li staras __malantaŭ__ mi.* – On stoi za mną.
 
-# Przyrostek *-ul*
+**⚠️ Uwaga:** „za" w sensie czasu to *post* (*post du horoj*), a „za" w sensie miejsca to *malantaŭ* (*malantaŭ la domo*). Polskie „za" rozdziela się tu na dwa słowa.
 
-człowiek z daną cechą:
+# Przyrostek *__-ul__*
 
-- *grand__ul__o*  – wielki człowiek, wielkolud
-- *malbon__ul__o* – zły czowiek
-- *bel__ul__ino*  – piękna dziewczyna
+oznacza człowieka o danej cesze:
 
- 
+- *grand__ul__o* – wielkolud
+- *malbon__ul__o* – zły człowiek
+- *bel__ul__ino* – piękna dziewczyna
 
-# Przyrostek *-ej*
+# Przyrostek *__-ej__*
 
-pomieszczenie:
+oznacza pomieszczenie lub miejsce:
 
-- *lern__ej__o*  – szkoła
-- *kuir__ej__o*  – kuchnia
+- *lern__ej__o* – szkoła
+- *kuir__ej__o* – kuchnia
 - *labor__ej__o* – miejsce pracy
- 
 
-# Przyrostek *-ebl*
+# Przyrostek *__-ebl__*
 
-możliwy, nadający się:
+oznacza „możliwy, dający się":
 
 - *manĝ__ebl__a* – jadalny
 - *vid__ebl__a* – widzialny
@@ -67,16 +72,20 @@ możliwy, nadający się:
 - *__ebl__e* – może
 - *mal__ebl__a* – niemożliwy
 
-
 # Tryb rozkazujący
 
-Końcówka tryby rozkazującego to *-u*.
-- *Ni manĝ__u__!*  – Jedzmy!
-W drugiej osobie l.p. i l.m. możemy pominąć zaimek osobowy *vi*, a w pozostałych osobach musimy pamiętać o zaimku.
-- *Manĝ__u__!*   – Jedz! Jedzcie!
-- *Ir__u__!*   – Idż! Idźcie!
+Końcówka trybu rozkazującego to *__-u__*:
 
-Trybu rozkazującego używamy również, gdy pytamy o zgodę na naszą sugestię:
-- *Ĉu ni ir__u__ al kafejo?* – Czy pójdziemy do kawiarni?
-- *Ĉu ni trink__u__ kafon?*  – Czy napijemy się kawy?
- 
+- *Ni manĝ__u__!* – Jedzmy!
+
+W drugiej osobie liczby pojedynczej i mnogiej możemy pominąć zaimek *vi*; w pozostałych osobach zaimek zostawiamy:
+
+- *Manĝ__u__!* – Jedz! Jedzcie!
+- *Ir__u__!* – Idź! Idźcie!
+
+Trybu rozkazującego używamy też, gdy pytamy o zgodę na propozycję:
+
+- *Ĉu ni ir__u__ al kafejo?* – Może pójdziemy do kawiarni?
+- *Ĉu ni trink__u__ kafon?* – Może napijemy się kawy?
+
+**💡 Wskazówka:** jedna końcówka *-u* dla wszystkich osób — *mi iru*, *ni iru*, *li iru* („niech idzie").

--- a/enhavo/tradukenda/pl/gramatiko/04.md
+++ b/enhavo/tradukenda/pl/gramatiko/04.md
@@ -1,62 +1,55 @@
 # Liczby
 
-Liczby można znaleźć w dodatku. Większe liczby zostają utworzone z podstawowych liczb w następujący sposób:
+Liczby znajdziesz w załączniku. Większe liczby tworzymy z podstawowych w następujący sposób:
 
-- 1 238                     – *mil du-cent tri-dek ok*
-- 153 837                   – *cent kvin-dek tri mil ok-cent tri-dek sep*
-- Addition:      8 + 3 = 11 – *ok plus tri estas dek-unu*
-- Subtraction:   15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
+- 1 238 – *mil du-cent tri-dek ok*
+- 153 837 – *cent kvin-dek tri mil ok-cent tri-dek sep*
+- dodawanie: 8 + 3 = 11 – *ok plus tri estas dek-unu*
+- odejmowanie: 15 − 6 = 9 – *dek-kvin minus ses estas naŭ*
 
-# Biernik ruchu
+# Biernik kierunku
 
-W wyrażeniach przyimkowych rzeczowniki (lub zaimki) nie przyjmują końcówki biernika __n__:
+W zwykłych wyrażeniach przyimkowych rzeczownik (lub zaimek) nie przyjmuje końcówki biernika *-n*:
 
 - *post mi* – za mną
 - *sen ŝi* – bez niej
 - *en domo* – w domu
 
-Po przyimkach określających miejsce, *ĉe* – przy; *en* – w; *sub* – pod; *sur* – na, możemy używać biernika, aby określić kierunek ruchu:
+Po przyimkach miejsca (*ĉe* – przy, *en* – w, *sub* – pod, *sur* – na) dodajemy jednak *__-n__*, gdy chcemy wskazać kierunek ruchu:
 
-- *Mi iras en la domo__n__.* – Idę do domu.
-- (Compare: *Ili manĝas en la domo.* – Oni jedzą w domu.)
-
-Another example:
-
+- *Mi iras en la domo__n__.* – Idę do domu (do środka).
+  - *Ili manĝas en la domo.* – Oni jedzą w domu.
 - *La kato saltis sur la tablo__n__.* – Kot skoczył na stół (z podłogi).
-- *La kato saltis sur la tablo.* – Kot skacze na stole.
+  - *La kato saltas sur la tablo.* – Kot skacze na stole.
+
+**💡 Wskazówka:** to ta sama różnica co w polszczyźnie między miejscem a kierunkiem — *na stole* / *na stół*, *w domu* / *do domu*. Esperanto zaznacza kierunek końcówką *-n*: *sur la tablo* / *sur la tablon*.
 
 # Zaimek *oni*
 
-Formę bezosobową czasownika tworzymy przy pomocy słowka *__oni__*
-
-Przykłady:
+*__oni__* tworzy formę bezosobową — odpowiada polskiemu „się":
 
 - *__Oni__ diras.* – Mówi się.
 - *__Oni__ kantas.* – Śpiewa się.
 - *__Oni__ laboras.* – Pracuje się.
- 
 
 # Zaimek zwrotny *si*
 
-Zaimek zwrotny *si* (w bierniku *sin*) oznacza skierowanie działania w kierunku osoby wykonującej czynność. Zaimka *si* używamy jedynie w relacji do 3 os. l. poj.:
+Zaimek zwrotny *__si__* (w bierniku *__sin__*) wskazuje, że czynność wraca do jej wykonawcy. Używamy go tylko w 3. osobie:
 
-Przykłady:
+- *Li lavas __sin__ kaj li lavas lin.* – On myje się i myje go (kogoś innego).
 
-- *Mi lavas lavas min kaj mi lavas lin.* – Myję się (mnie) i myję go.
-- *Vi lavas vin kaj vi lavas lin.* – Myjesz się (ciebie) i myjesz go.
-- *Li lavas __sin__ kaj li lavas lin.* – On myje się i myje go.
- 
-- *Li iras al __sia__ amikino.* – On idzie do swojej przyjaciółki.
+To samo dotyczy zaimka dzierżawczego *__sia__* (swój):
+
+- *Li iras al __sia__ amikino.* – On idzie do swojej (własnej) przyjaciółki.
 - *Li iras al __lia__ amikino.* – On idzie do jego (innego mężczyzny) przyjaciółki.
 
-# Zaimek zwrotny *re-*
+**💡 Wskazówka:** to dokładnie nasze „swój" kontra „jego". *sia* = własny (wraca do podmiotu), *lia* = cudzy. Polak czuje tę różnicę od razu.
 
-Robić coś ponownie, po raz drugi:
+# Przedrostek *__re-__*
 
-Przykłady:
+oznacza powtórzenie czynności — zrobić coś ponownie albo z powrotem:
 
 - *__re__vidi* – zobaczyć ponownie
-- *__re__doni* – oddawać 
-- *__re__meti* – odkładać, odłożyć
-- *__re__veni* – powracać
- 
+- *__re__doni* – oddać (dać z powrotem)
+- *__re__meti* – odłożyć
+- *__re__veni* – wrócić

--- a/enhavo/tradukenda/pl/gramatiko/05.md
+++ b/enhavo/tradukenda/pl/gramatiko/05.md
@@ -1,46 +1,47 @@
 # Tabela zaimków korelatywnych
 
-Przestudiuj tabelę zaimków korelatywnych z załącznika. Zwróć uwagę, że wszystkie zaimki zbudowane są według tego samego schematu, zamiast uczyć się ich na pamięć, naucz się je tworzyć. Szczególnie zapamiętaj poniższe:
+Przestudiuj [tabelę korelatywów](/pl/tabelvortoj/). Wszystkie te słówka zbudowane są według tego samego schematu — zamiast uczyć się ich na pamięć, naucz się je tworzyć. Szczególnie zapamiętaj:
 
-- *ĉio*  – wszystko
-- *ĉiu*  –każdy, każda, każde
-- *ĉiuj*  – wszyscy
+- *ĉio* – wszystko
+- *ĉiu* – każdy, każda, każde
+- *ĉiuj* – wszyscy
 - *ĉiam* – zawsze
 - *iom* – trochę
 
-Zaimki z tabeli mogą przyjmować końcówki *-j* (liczba mnoga) i *-n* (biernik):
+**💡 Wskazówka:** korelatywy to siatka: początek mówi „jaki rodzaj pytania" (*ki-* pytanie, *ti-* wskazanie, *i-* nieokreśloność, *ĉi-* ogół, *neni-* przeczenie), a końcówka mówi „o co chodzi" (*-o* rzecz, *-u* osoba, *-e* miejsce, *-am* czas…). Znając obie osie, ułożysz każde słówko sam.
 
-- końcówka *-j* może być dołączona do słów kończących się na *-u* i *-a*
-- końcówka *-n* do słów zakończonych na *-o*, *-u*, *-a* i *-e*:
+Korelatywy mogą przyjmować końcówki *-j* (liczba mnoga) i *-n* (biernik):
 
-## Kio 
+- końcówkę *-j* dodajemy do słów zakończonych na *-u* i *-a*
+- końcówkę *-n* do słów zakończonych na *-o*, *-u*, *-a* i *-e*
 
-- *Kio* – co 
-- *kion* – co (w bierniku)
+## *kio*
 
-Przykład: 
+- *kio* – co
+- *kio__n__* – co (w bierniku)
 
-- *Kion vi manĝas? Kukon mi manĝas.*
+Przykład:
 
-## Kiu
-- *Kiu* – kto (liczba pojedyncza), który
-- *kiun* – kogo (liczba pojedyncza), którego/którą/które (biernik)
-- *kiuj* – kto (liczba mnoga), którzy/które
-- *kiujn* – kogo (liczba mnoga), których (biernik)
+- *__Kion__ vi manĝas? Kukon mi manĝas.* – Co jesz? Jem ciastko.
 
-## Kia
+## *kiu*
 
-Przykłady:
+- *kiu* – kto (liczba pojedyncza), który
+- *kiu__n__* – kogo, którego/którą/które (biernik)
+- *kiu__j__* – kto (liczba mnoga), którzy/które
+- *kiu__jn__* – kogo (liczba mnoga), których (biernik)
+
+## *kia*
 
 - *Kia estas la vetero?* – Jaka jest pogoda?
 - *Kian aŭton vi havas?* – Jaki masz samochód?
 - *Kiaj estas ŝiaj leteroj?* – Jakie są jej listy?
 - *Kiajn fotojn vi faris?* – Jakie zrobiłeś zdjęcia?
 
-## Kie
+## *kie*
 
-- *Kie* – gdzie
-- *Kien* – dokąd
+- *kie* – gdzie
+- *kie__n__* – dokąd
 
 Przykłady:
 
@@ -49,55 +50,54 @@ Przykłady:
 
 ## Z przyimkami
 
-- *Al kiu* – do kogo, komu
+- *al kiu* – do kogo, komu
 - *kun kiu* – z kim
 - *al tiu* – temu, do tego
 - *inter tiuj* – między tymi
 
 # Stopniowanie przymiotników
 
-Stopień wyższy przymiotników tworzymy przy pomocy słówka *pli* (bardziej); a najwyższy przy pomocy słówka *plej* (najbardziej):
+Stopień wyższy tworzymy słówkiem *__pli__* (bardziej), a najwyższy słówkiem *__plej__* (najbardziej):
 
 - *bona* – dobry
 - *__pli__ bona* – lepszy
 - *__plej__ bona* – najlepszy
 
-Inne słówka używane przy porównaniach:
+Inne słówka przydatne przy porównaniach:
 
 - *kiel* – jak
 - *ol* – niż, od
 - *el* – z, spośród
 
+Przykłady:
+
 - *Forta __kiel__ ĉevalo* – Silny jak koń.
 - *Pli granda __ol__ vi* – Większy od ciebie.
-- *La plej bona __el__ ĉiuj* – Najlepszy ze wszystkich
-- *Marko estas la __pli__ juna frato* – Marek jest (tym) młodszym bratem.
-- *Li kantas __plej__ bone* – On śpiewa najlepiej
+- *La plej bona __el__ ĉiuj* – Najlepszy ze wszystkich.
+- *Marko estas la __pli__ juna frato.* – Marek jest (tym) młodszym bratem.
+- *Li kantas __plej__ bone.* – On śpiewa najlepiej.
 
-# *Dum* 
+**💡 Wskazówka:** *pli … ol* = „bardziej … niż". Esperanto stopniuje opisowo (*pli bona*), jak polskie „bardziej znany", a nie przez końcówkę.
 
-*Dum* podczas, w czasie, w czasie gdy:
+# *dum*
+
+*__dum__* znaczy „podczas, w czasie gdy":
 
 - *Li sidas __dum__ la manĝo.* – On siedzi podczas jedzenia.
-- *Ŝi skribas __dum__ li legas.* – Ona pisze w czasie, gdy czyta.
+- *Ŝi skribas __dum__ li legas.* – Ona pisze, podczas gdy on czyta.
 
-# *Ĉi*
+# *ĉi*
 
-*Ĉi* używane przy zaimkach korelatywnych określa bezpośrednią bliskość:
+*__ĉi__* przy korelatywach oznacza bliskość (tu, blisko):
 
-- *tiu* – tamten / *tiu ĉi* lub *ĉi tiu* – ten
-- *tie* – tam / *tie ĉi* lub *ĉi tie* – tutaj
+- *tiu* – tamten → *ĉi tiu* (lub *tiu ĉi*) – ten
+- *tie* – tam → *ĉi tie* (lub *tie ĉi*) – tutaj
 
-# The suffix *-ind*
+# Przyrostek *__-ind__*
 
-godzien, wart:
+oznacza „godny, wart":
 
-- *kredi* – wierzyć
-- *kred__ind__a* – wiarygodny
-- *puni* – karać
-- *pun__ind__a* – karygodny
-- *bedaŭri* – żałować
-- *bedaŭr__ind__a* – pożałowania godny
-- *bedaŭr__ind__e* – niestety
-
- 
+- *kredi* – wierzyć → *kred__ind__a* – wiarygodny
+- *puni* – karać → *pun__ind__a* – karygodny
+- *bedaŭri* – żałować → *bedaŭr__ind__a* – godny pożałowania
+  - *bedaŭr__ind__e* – niestety

--- a/enhavo/tradukenda/pl/gramatiko/06.md
+++ b/enhavo/tradukenda/pl/gramatiko/06.md
@@ -33,7 +33,7 @@ pomniejszenie:
 
 powiększenie:
 
-- *libr_ego_*    – księga
+- *libr__eg__o*    – księga
 - *pluv__eg__i*   – lać (o deszczu)
 - *varm__eg__a*  – gorący
  

--- a/enhavo/tradukenda/pl/gramatiko/06.md
+++ b/enhavo/tradukenda/pl/gramatiko/06.md
@@ -1,50 +1,48 @@
 # Mowa zależna
 
-Końcówka trybu rozkazującego *-u* jest używana nie tylko do wyrażania bezpośrednich komend (patrz Lekcja 3) ale również do tworzenia mowy zależnej wprowadzanej spójnikiem *ke* – że, żeby, aby, po czasownikach wyrażających prośbę, polecenie, życzenie, radę.
+Końcówki trybu rozkazującego *__-u__* używamy nie tylko do bezpośrednich poleceń (zob. [lekcję 3](/pl/03/gramatiko/)), lecz także w mowie zależnej wprowadzanej spójnikiem *ke* (że, żeby, aby) — po czasownikach wyrażających prośbę, polecenie, życzenie lub radę:
 
 - *Mi deziras, __ke__ vi lern__u__.* – Chcę, abyś się uczył.
-- *La patro insistas, __ke__ mi iru.* – Tato nalega, bym poszedł. 
- 
+- *La patro insistas, __ke__ mi ir__u__.* – Tato nalega, bym poszedł.
+
+**💡 Wskazówka:** „żeby" + czasownik to po prostu *ke* + końcówka *-u*. Tam, gdzie polski mówi „chcę, żebyś **przyszedł**", esperanto stawia *-u*: *ke vi ven__u__*.
+
 # Przyimek *je*
 
-Przyimek uniwersalny *je* to swojego rodzaju joker, używamy go, gdy żaden inny nie może być użyty w sposób logiczny, oto najczęstsze przykłady:
+*__je__* to przyimek uniwersalny — swego rodzaju joker. Używamy go, gdy żaden inny przyimek nie pasuje logicznie. Najczęściej przy godzinach:
 
 - *__Je__ kioma horo vi venos?* – O której godzinie przyjdziesz?
 - *__Je__ la kvina horo.* – O piątej godzinie.
- 
 
-# Czasownik *Farti*
+# Czasownik *farti*
 
-Czasownik *farti* – czuć się używany jest najczęściej w wyrażeniu:
+*__farti__* znaczy „czuć się" (mieć się). Najczęściej w zwrocie:
 
 - *Kiel vi __fartas__?* – Jak się masz?
 
+# Przyrostek *__-et__*
 
-# Przyrostek *-et*
-
-pomniejszenie:
+oznacza pomniejszenie (zdrobnienie):
 
 - *libr__et__o* – książeczka
-- *pluv__et__i*  – ktopić
-- *varm__et__a* – letni
- 
+- *pluv__et__i* – mżyć
+- *varm__et__a* – letni (ciepławy)
 
-# Przyrostek *-eg*
+# Przyrostek *__-eg__*
 
-powiększenie:
+oznacza powiększenie (zgrubienie):
 
-- *libr__eg__o*    – księga
-- *pluv__eg__i*   – lać (o deszczu)
-- *varm__eg__a*  – gorący
- 
+- *libr__eg__o* – księga
+- *pluv__eg__i* – lać (o deszczu)
+- *varm__eg__a* – gorący
 
-# Przyrostek *-iĝ*
+**💡 Wskazówka:** *-et* zmniejsza, *-eg* zwiększa. *domo* (dom) → *dom__et__o* (domek) → *dom__eg__o* (gmach).
 
-oznacza "stawać się", "stawać się":
+# Przyrostek *__-iĝ__*
 
-- *riĉiĝi*          – wzbogacić się
-- *trankvil__iĝ__i* – uspokoić sie
-- *resan__iĝ__i*    – wyzdrowieć
-- *geedz__iĝ__i*    – ożenić się/wyjść za mąż
- 
+oznacza „stawać się, stać się" (samoczynną zmianę stanu):
 
+- *riĉ__iĝ__i* – wzbogacić się
+- *trankvil__iĝ__i* – uspokoić się
+- *resan__iĝ__i* – wyzdrowieć
+- *geedz__iĝ__i* – pobrać się (ożenić się / wyjść za mąż)

--- a/enhavo/tradukenda/pl/gramatiko/07.md
+++ b/enhavo/tradukenda/pl/gramatiko/07.md
@@ -1,52 +1,45 @@
 # Przeczenie
 
-W języku esperanto, w przeciwieństwie do języka polskiego nie stosujemy podwójnego przeczenia.
+W esperancie — inaczej niż w polszczyźnie — **nie stosujemy podwójnego przeczenia**. Jedno słowo przeczące w zdaniu wystarczy:
 
-- *Mi __neniam__ diros tion.* – Nigdy tego nie powiem (dosłownie: Nigdy powiem to)
-- *__Nek__ li __nek__ ŝi scias kanti.*   – Ani on, ani ona nie umieją śpiewać.
-- *Vi __nek__ laboras __nek__ lernas.* – Ani nie pracujesz, ani nie uczysz się.
-- *Ŝi __nenion__ diris.* – Ona nic nie powiedziała.
+- *Mi __neniam__ diros tion.* – Nigdy tego nie powiem. (dosłownie: „Nigdy powiem to")
+- *Ŝi __nenion__ diris.* – Ona nic nie powiedziała. (dosłownie: „Ona nic powiedziała")
+- *__Nek__ li __nek__ ŝi scias kanti.* – Ani on, ani ona nie umieją śpiewać.
+- *Vi __nek__ laboras __nek__ lernas.* – Ani nie pracujesz, ani się nie uczysz.
 
+**⚠️ Uwaga:** to największa pułapka dla Polaka. Mówimy „nikt nie wie", „nigdy nie powiem" — z dwoma przeczeniami. W esperancie zostaje tylko jedno: *neniu scias*, *mi neniam diros*. Nie dokładaj drugiego *ne*.
 
+# *mem*
 
+Przysłówek *__mem__* znaczy „sam, osobiście" (nie myl go z *sola* – sam, samotny):
 
-# *Mem*
-
-Przyszłowek *mem* oznacza sam, osobiście (nie należy go mylić z sola - sam, samotny):
-
-- *Mi __mem__ faris tion.*  – Sam (osobiście) to zrobiłem.
-- *Mi sola faris tion.*  – Sam (w pojedynkę) to zrobiłem.
+- *Mi __mem__ faris tion.* – Sam (osobiście) to zrobiłem.
+- *Mi __sola__ faris tion.* – Sam (w pojedynkę) to zrobiłem.
 
 # Do widzenia
 
-Istnieje kilka sposobów, aby powiedzieć "do widzenia" w esperanto, ale najczęściej używa się:
+Jest kilka sposobów na pożegnanie; najczęstszy to:
 
-- *ĝis la revido* – dosłownie  "do ponownego zobaczenia"
+- *ĝis la revido* – dosłownie „do ponownego zobaczenia"
 
 Można też pominąć przedimek:
 
-- *ĝis revido*.
+- *ĝis revido*
 
+# Przedrostek *__ek-__*
 
-# Przedrostek *ek-*
+oznacza początek lub krótkotrwałość czynności:
 
-początek lub krótkotrwałość czynności
-
-
-Examples:
-
-- *__ek__vidi*  – zobaczyć
+- *__ek__vidi* – dostrzec, ujrzeć
 - *__ek__dormi* – zasnąć
-- *__ek__kanti*    – zaśpiewać
-- *__ek__i*    – rozpoczynać
- 
+- *__ek__kanti* – zaśpiewać
+- *__ek__i* – ruszyć, rozpocząć
 
-# The Suffix *-aĵ*
+# Przyrostek *__-aĵ__*
 
-przedmiot, potrawa:
+oznacza rzecz konkretną, wytwór, potrawę:
 
-- *manĝ__aĵ__o*  – coś do zjedzenia
+- *manĝ__aĵ__o* – coś do jedzenia
 - *trink__aĵ__o* – napój
-- *verd__aĵ__o*   – zieleń (trawa)
-- *pork__aĵ__o*  – wieprzowina
- 
+- *verd__aĵ__o* – zieleń (trawa)
+- *pork__aĵ__o* – wieprzowina

--- a/enhavo/tradukenda/pl/gramatiko/08.md
+++ b/enhavo/tradukenda/pl/gramatiko/08.md
@@ -1,32 +1,30 @@
-# Przyimek *Da*
+# Przyimek *da*
 
-służy do tworzenia dopełniacza (w miejsce DE) po pojęciach określających ilość:
+*__da__* tworzy odpowiednik polskiego dopełniacza po słowach oznaczających ilość lub miarę:
 
 - *kilogramo __da__ sukero* – kilogram cukru
-- *glaso __da__ akvo* – szklanka wody 
+- *glaso __da__ akvo* – szklanka wody
 - *multe __da__ ideoj* – dużo pomysłów
 - *iom __da__ tempo* – trochę czasu
 - *tiom __da__ mono* – tyle pieniędzy
 
+**💡 Wskazówka:** po mierze (*kilogram*, *szklanka*, *dużo*) polski daje dopełniacz: „kilogram **cukru**". Esperanto zaznacza to przyimkiem *da*: *kilogramo da sukero*.
 
-# Przyrostek *-ig*
+# Przyrostek *__-ig__*
 
-czynić kogoś, coś jakimś:
+oznacza „czynić kogoś/coś jakimś" (sprawiać):
 
 - *bel__ig__i* – upiększać
 - *malplen__ig__i* – opróżnić
 - *san__ig__i* – wyleczyć
-- *mort__ig__i* – zabić 
-- *ebl__ig__i* – umożliwić 
-- *trankvil__ig__i* – uspokajać 
+- *mort__ig__i* – zabić (sprawić, że ktoś umrze)
+- *ebl__ig__i* – umożliwić
+- *trankvil__ig__i* – uspokajać
 
+# Przyrostek *__-aĉ__*
 
-
-# Przyrostek *-aĉ*
-
-zła jakość, obrzydzenie:
+oznacza złą jakość, lekceważenie, obrzydzenie:
 
 - *dom__aĉ__o* – rudera
-- *srib__aĉ__i* – bazgrać
+- *skrib__aĉ__i* – bazgrać
 - *__aĉ__a* – brzydki, wstrętny
- 

--- a/enhavo/tradukenda/pl/gramatiko/09.md
+++ b/enhavo/tradukenda/pl/gramatiko/09.md
@@ -1,50 +1,44 @@
 # Tryb warunkowy
 
-Do tworzenia trybu warunkowego czasowników używamy końcówki *-us*:
+Tryb warunkowy tworzymy końcówką *__-us__* — jednakową dla wszystkich osób:
 
-- *Mi kred__us__* – IUwierzyłbym
-- *Se mi hav__us__ tempon, mi rest__us__ pli longe.* – Jeśli miałbym czas, zostałbym dłużej.
+- *Mi kred__us__.* – Uwierzyłbym.
+- *Se mi hav__us__ tempon, mi rest__us__ pli longe.* – Gdybym miał czas, zostałbym dłużej.
 
-# *Kvazaŭ*
+**💡 Wskazówka:** *-us* to nasze „-by". *mi farus* = „zrobiłbym", *vi farus* = „zrobiłbyś" — jedna końcówka zamiast całej polskiej odmiany przez osoby.
 
-Po *kvazaŭ* (=jakby) zazwyczaj używamy czasownika w trybie warunkowym:
+# *kvazaŭ*
+
+Po *__kvazaŭ__* (jakby) zwykle stawiamy czasownik w trybie warunkowym:
 
 - *Vi sidas tie __kvazaŭ__ vi estus riĉulo.* – Siedzisz tam, jakbyś był bogaczem.
 
-Można również powiedzieć:
+Można też powiedzieć krócej:
 
-- *Vi sidas tie __kvazaŭ__ riĉulo.* – Siedzisz tam, jak bogacz.
- 
-# Przyrostek *-ad*
+- *Vi sidas tie __kvazaŭ__ riĉulo.* – Siedzisz tam jak bogacz.
 
-czynność długotrwała lub powtarzana
-- *paroli* – to sing
-  - *parol__ad__o* – przemówienie
-- *legi* – czytać
-	- *leg__ad__o* – czytywać, czytać długo
+# Przyrostek *__-ad__*
 
+oznacza czynność długotrwałą lub powtarzaną:
 
-# Przyrostek *-ar*
+- *paroli* – mówić → *parol__ad__o* – przemówienie
+- *legi* – czytać → *leg__ad__o* – czytanie (długie, wielokrotne)
 
-zbiór, zestaw:
+# Przyrostek *__-ar__*
 
-- *arbo* – drzewo
-	- *arb__ar__o* – las
-- *vagono* – wagon
-	- *vagon__ar__o* – pociąg
-- *vorto* – słowo
-	- *vort__ar__o* – słownik
- 
+oznacza zbiór, zestaw:
 
-# Przyrostek *-um*
+- *arbo* – drzewo → *arb__ar__o* – las
+- *vagono* – wagon → *vagon__ar__o* – pociąg
+- *vorto* – słowo → *vort__ar__o* – słownik
 
-sufiks uniwersalny, bez określonego znaczenia:
+# Przyrostek *__-um__*
 
-- *plena* – pełny
-  -  *plen__um__i* – spełniać
-- *malvarma* – chłodny
-  -  *malvarm__um__i* – przeziębić się
-- *aero* – powietrze 
-	- *aer__um__i* – wietrzyć 
-- *kolo* – szyja 
-	- *kol__um__o* – kołnierz  
+to przyrostek uniwersalny, bez ściśle określonego znaczenia:
+
+- *plena* – pełny → *plen__um__i* – spełniać
+- *malvarma* – chłodny → *malvarm__um__i* – przeziębić się
+- *aero* – powietrze → *aer__um__i* – wietrzyć
+- *kolo* – szyja → *kol__um__o* – kołnierz
+
+**💡 Wskazówka:** *-um* to „dziki" przyrostek na specjalne przypadki — jego znaczenia trzeba uczyć się osobno dla każdego słowa.

--- a/enhavo/tradukenda/pl/gramatiko/10.md
+++ b/enhavo/tradukenda/pl/gramatiko/10.md
@@ -1,48 +1,49 @@
-# *-iĝ-/-ig-*
+# Przyrostki *__-iĝ__* i *__-ig__*
 
-Czasowniki przechodnie z przyrostkiem -iĝ- stają się nieprzechodnie.
-- *trovi*    – znaleźć
-- *trov__iĝ__i*    – znajdować się
+Przyrostek *__-iĝ__* czyni czasownik nieprzechodnim (czynność dzieje się sama):
 
-Natomiast czasowniki nieprzechodnie z przyrostkiem -ig- stają się przechodnie:
+- *trovi* – znaleźć → *trov__iĝ__i* – znajdować się
 
-- *dormi*    – spać
-- *dorm__ig__i*  – usypiać
+Przyrostek *__-ig__* czyni czasownik przechodnim (ktoś wywołuje czynność):
+
+- *dormi* – spać → *dorm__ig__i* – usypiać
 
 Wiąże się to z użyciem biernika:
-- *Mi ŝanĝas mian opinion* – Zmieniam (moją) opinię
-- *Mia opinio ŝanĝ__iĝ__as*  – Moja opinia się zmienia
-- *La libro falis* – Książka spadła
-- *Mi fal__ig__is la libron*  – Ja zrzuciłem książkę
 
-# Przyrostek *-an*
+- *Mi ŝanĝas mian opinion.* – Zmieniam (swoją) opinię.
+- *Mia opinio ŝanĝ__iĝ__as.* – Moja opinia się zmienia.
+- *La libro falis.* – Książka spadła.
+- *Mi fal__ig__is la libron.* – Ja zrzuciłem książkę.
 
-członek, mieszkaniec, wyznawca:
+**💡 Wskazówka:** *-iĝ* to nasze „się" (zmienia **się**, otwiera **się**), a *-ig* znaczy „sprawić, że…" (z dopełnieniem w bierniku). *-iĝ* w środku, *-ig* na zewnątrz.
 
-- *klub__an__o*    – członek klubu
-- *amerik__an__o*  – Amerykanin
+# Przyrostek *__-an__*
+
+oznacza członka, mieszkańca lub wyznawcę:
+
+- *klub__an__o* – członek klubu
+- *amerik__an__o* – Amerykanin
 - *krist__an__o* – chrześcijanin
-- *varsovi__an__o*  – warszawiak
- 
+- *varsovi__an__o* – warszawiak
 
-# Przyrostek *-ec*
+# Przyrostek *__-ec__*
 
-cecha, pojęcie abstrakcyjne:
+oznacza cechę lub pojęcie abstrakcyjne:
 
-- *bel__ec__o*   – piękno
-- *varm__ec__o*  – ciepło
+- *bel__ec__o* – piękno
+- *varm__ec__o* – ciepło
 - *simpl__ec__o* – prostota
 - *amik__ec__o* – przyjaźń
 - *jun__ec__o* – młodość
- 
 
-# Przyrostek *-uj*
+**💡 Wskazówka:** *-ec* tworzy rzeczowniki abstrakcyjne, jak polskie *-ość* (*bel__ec__o* → pięk-no, *jun__ec__o* → młod-ość).
 
-pojemnik, drzewo, kraj:
+# Przyrostek *__-uj__*
 
-- mon__uj__o*  – portmonetka/portfel
+oznacza pojemnik, drzewo owocowe lub (dawniej) kraj:
+
+- *mon__uj__o* – portmonetka, portfel
 - *cindr__uj__o* – popielniczka
+- *pomo* – jabłko → *pom__uj__o* – jabłoń
 - *Franc__uj__o* – Francja
 - *Aŭstr__uj__o* – Austria
-- *pomo*   – apple
-	- *pom__uj__o*   – jabłoń

--- a/enhavo/tradukenda/pl/gramatiko/11.md
+++ b/enhavo/tradukenda/pl/gramatiko/11.md
@@ -1,8 +1,10 @@
-# Przyrostek *-il*
+# Przyrostek *__-il__*
 
-narzędzie:
+oznacza narzędzie lub środek do wykonania czynności:
 
-- *tranĉ__il__o*    – nóż
-- *manĝ__il__o*      – sztuciec
-- *ŝlos__il__o*     – klucz
-- *fot__il__o*    – aparat fotograficzny
+- *tranĉ__il__o* – nóż (czym się tnie)
+- *manĝ__il__o* – sztuciec (czym się je)
+- *ŝlos__il__o* – klucz (czym się zamyka)
+- *fot__il__o* – aparat fotograficzny (czym się fotografuje)
+
+**💡 Wskazówka:** *-il* to „narzędzie do…". Weź czasownik i dodaj *-ilo*: *tranĉi* (ciąć) → *tranĉ__il__o* (nóż), *kombi* (czesać) → *komb__il__o* (grzebień).

--- a/enhavo/tradukenda/pl/gramatiko/12.md
+++ b/enhavo/tradukenda/pl/gramatiko/12.md
@@ -1,32 +1,35 @@
-# *Ju … des*
+# *ju … des*
 
-im ... tym
-- *Ju pli longe, des pli bone.* – Im dłużej, tym lepiej.
- 
+konstrukcja „im … tym":
 
-# *Ajn*
--kolwiek, przysłówek najczęściej używany z zaimkami korelatywnymi,
+- *__Ju__ pli longe, __des__ pli bone.* – Im dłużej, tym lepiej.
 
-- *kiu ajn*, *iu ajn*– ktokolwiek
+**💡 Wskazówka:** to dokładnie nasze „im … tym". *ju* = „im", *des* = „tym": *ju pli … des pli* = „im bardziej … tym bardziej".
+
+# *ajn*
+
+*__ajn__* znaczy „-kolwiek" i najczęściej towarzyszy korelatywom (zob. [tabelę korelatywów](/pl/tabelvortoj/)):
+
+- *kiu ajn*, *iu ajn* – ktokolwiek
 - *ie ajn* – gdziekolwiek
 - *kiam ajn*, *iam ajn* – kiedykolwiek
 
+# Przedrostek *__dis-__*
 
-# Przyrostek *dis-*
-
-roz-; rozdzielenie:
+oznacza rozdzielenie, rozproszenie (polskie „roz-"):
 
 - *__dis__ĵeti* – rozrzucać
 - *__dis__doni* – rozdawać
 - *__dis__tranĉi* – rozciąć
 - *__dis__bati* – rozbić
 
-# Przyrostek *-on*
+# Przyrostek *__-on__*
 
-ułamek, okreśolna część:
+tworzy ułamki (określoną część):
 
-- *du__on__o*   – połowa
-- *tri__on__o*  – jedna trzecia
+- *du__on__o* – połowa
+- *tri__on__o* – jedna trzecia
 - *kvar__on__o* – ćwierć
-- *ses__on__o*  – jedna szósta
- 
+- *ses__on__o* – jedna szósta
+
+**💡 Wskazówka:** *-on* robi z liczby ułamek: *du* (2) → *du__on__o* (połowa), *kvar* (4) → *kvar__on__o* (ćwierć).

--- a/enhavo/tradukenda/pl/vortaro/novaj.yml
+++ b/enhavo/tradukenda/pl/vortaro/novaj.yml
@@ -3,7 +3,7 @@ divers: różne
 ekzempl: przykład
 glas: szklanka
 infan: dziecko
-inform: informacja
+inform: informować
 kant: śpiewać
 kien: dokąd
 konsent: zgadzać się
@@ -21,7 +21,7 @@ pluv:
 poŝ: kieszeń
 poŝt: poczta
 proksimum: około
-publik: publicznie
+publik: publiczny
 punkt: punkt
 pur: czysty
 rakont: opowiadać
@@ -30,7 +30,7 @@ seĝ: krzesło
 sia: swój
 simpl: prosty
 suk: sok
-terur: przerażenie
+terur: straszny
 tut: cały
 universal: uniwersalny
 rilat: 
@@ -44,6 +44,6 @@ ag:
 aper:
 - pojawiać się
 - ukazać się
-- pokazać się;
+- pokazać się
 sent: czuć
 kred: wierzyć

--- a/enhavo/tradukenda/pl/vortaro/participo.yml
+++ b/enhavo/tradukenda/pl/vortaro/participo.yml
@@ -1,8 +1,8 @@
-ant: teraźniejszy czynna
-int: przeszły czynna
-ont: przyszły czynna
-unt: przypuszczający czynna
-at:  teraźniejszy bierna
-it:  przeszły bierna
-ot:  przyszły bierna
-ut:  przypuszczający bierna
+ant: teraźniejszy czynny
+int: przeszły czynny
+ont: przyszły czynny
+unt: przypuszczający czynny
+at:  teraźniejszy bierny
+it:  przeszły bierny
+ot:  przyszły bierny
+ut:  przypuszczający bierny

--- a/enhavo/tradukenda/pl/vortaro/partikulo.yml
+++ b/enhavo/tradukenda/pl/vortaro/partikulo.yml
@@ -1,6 +1,4 @@
-ajn:
-- wcale
-- '-kolwiek'
+ajn: '-kolwiek'
 des: tym (więcej, mniej)
 jen: oto
 ju: im (więcej, mneij)

--- a/enhavo/tradukenda/pl/vortaro/prepozicio.yml
+++ b/enhavo/tradukenda/pl/vortaro/prepozicio.yml
@@ -14,11 +14,10 @@ dum: podczas
 ekde: 
 - od
 - odkąd
-ekster: 
-- oprócz
+ekster:
 - poza
+- na zewnątrz
 el:
-- od
 - z
 - ze
 en: w
@@ -54,7 +53,9 @@ super:
 - powyżej
 sur: na
 tra: przez
-trans: poprzez
+trans:
+- na drugą stronę
+- po drugiej stronie
 ĉe: 
 - u
 - przy

--- a/enhavo/tradukenda/pl/vortaro/sufikso.yml
+++ b/enhavo/tradukenda/pl/vortaro/sufikso.yml
@@ -29,7 +29,7 @@ il:
 - narzędzie
 - środek (np. transportu) 
 in: 
-- żenski 
+- żeński
 ind: 
 - godny
 - godzien

--- a/enhavo/tradukenda/pl/vortaro/tabelvorto-klarigo.yml
+++ b/enhavo/tradukenda/pl/vortaro/tabelvorto-klarigo.yml
@@ -2,7 +2,7 @@
 'ti-': wskazanie 
 'i-': nieokreślony 
 'ĉi-': uniwersalny 
-'neni-': negative 
+'neni-': przeczący
 '-o': rzecz
 '-u': osoba
 '-e': miejsce

--- a/enhavo/tradukenda/pl/vortaro/vorto.yml
+++ b/enhavo/tradukenda/pl/vortaro/vorto.yml
@@ -52,7 +52,7 @@ eniri:
 - wchodzić
 - wejść
 eniris: wszedł
-eniru: wchodż! 
+eniru: wchodź!
 facilmovaj: łatwe do ruszenia
 faligi:
 - przewracać
@@ -62,7 +62,7 @@ familianoj: członkowie rodziny
 fermita: zamknięty 
 fine: w końcu
 foresti: być nieobecnym
-foriro: będzie nieobecny
+foriros: odejdzie
 fratino: siostra
 fuŝparolis: powiedział mylnie
 geamikoj: przyjaciele
@@ -72,7 +72,7 @@ gepatroj: rodzice
 gondolisto: gondolier 
 gondolistoj: gondolierzy
 grafino: hrabina
-grafinon: krabinę
+grafinon: hrabinę
 grandula: olbrzymi
 gravuloj: ważni ludzie
 haltigis: zatrzymał


### PR DESCRIPTION
## Resumo

Plibonigo de la pola traduko laŭ `ai/plibonigi-tradukon.md`: vortaro, ekzercoj **kaj** plena pedagogia rekonstruo de la gramatiko (kiel ĉe en/fr/ru).

## Vortaro
- `tabelvorto-klarigo`: `neni- «negative»` (angla) → przeczący
- `sufikso`: `in «żenski»` → żeński (tajperaro)
- `participo`: genra akordo `czynna/bierna` → czynny/bierny
- `prepozicio`: `ekster «oprócz»` (= *krom*!) → poza/na zewnątrz; `trans «poprzez»` → na drugą stronę / po drugiej stronie; `el` forigis misan «od»
- `partikulo`: `ajn` forigis «wcale» (restas «-kolwiek»)
- `novaj`: inform→informować, publik→publiczny, terur→straszny, vaganta «;»
- `vorto`: `grafinon «krabinę»`→hrabinę, `eniru «wchodż»`→wchodź, ŝlosil-eraro `foriro`→`foriros`

## Ekzercoj
- **traduku**: trilingva «trójęzyczny»→trójjęzyczny; espereble «prawpdopodobnie» (malĝusta signifo)→miejmy nadzieję/oby; nomiĝi «nazwyać»→nazywać; elkuri «nie mieć już» (malĝusta)→wybiec/wybiegać; ĉevalaĉo «koń»→szkapa/chabeta
- **traduku-kaj-respondu**: «piosenę»→piosenkę (03), «Patyża»→Paryża (09), «bedzięsz … zrobiło się»→będziesz … zrobi się (11)

## Gramatiko (01–12) — pedagogia rekonstruo
Konservante la temojn kaj la Esperanto-ekzemplojn, plibonigita prezento laŭ la modelo de en/fr/ru:
- **Memorhelpiloj 💡 kaj avertoj ⚠️ specifaj por poloj**: akcento sur antaŭlasta silabo (= pole); prononco *ĉ/ĝ/ĵ/ŝ/ŭ = cz/dż/ż/sz/ł*; *-as* sen persona fleksio; biernik/akuzativo; *per* = narzędnik; *sia* = swój; **manko de duobla neado** (la plej granda stumblilo por poloj); *-us* = *-by*; *ju…des* = *im…tym*; *da* = dopełniacz; *-ec* = *-ość*; *-in* = *-yni*.
- **Krucreferencoj kiel ligiloj** al [lekcji 5](/pl/05/gramatiko/), [tabela korelatywów](/pl/tabelvortoj/) ktp.
- **Riparitaj eraroj**: anglaj restaĵoj (Addition, Examples, The Suffix, apple, „to sing"), tajperaroj (przyszedem, czowiek, Idż, ktopić, srib, IUwierzyłbym, okreśolna), duobligoj, fuŝa markado `*libr_ego_*`, rompita titolo `#jes/ne`, x-skribo cxambro/mangxi, misaj etikedoj Przyrostek→Przedrostek (re-, dis-).

`make check` sukcesas; la pola HTML konstruiĝas senerare; bildigon de la kestoj, ligiloj kaj titoloj kontrolita.

**Rekomendo:** la nova pola formulado de la gramatiko meritas trapason de denaskulo, sed ĝi ne enkondukas elpensitajn faktojn — nur klarigojn kaj kontrastojn kun la pola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)