### PR TITLE
Simpligu radikan lingvan plusendon

### DIFF
--- a/fonto/html/hejmo.html
+++ b/fonto/html/hejmo.html
@@ -4,10 +4,9 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>
-      {{ fasado['Lerni Esperanton'] }} | {{ fasado['La plej rapida kurso por la bazoj'] }}
-    </title>
+    <meta http-equiv="refresh" content="2; url=/en/" />
+    <meta name="description" content="{{meta_description|e}}" />
+    <title>Learn Esperanto | The Fastest Basics Course</title>
 
     <link href="/vendor/fira-sans/400.css" rel="stylesheet" />
     <link href="/vendor/fira-sans/700.css" rel="stylesheet" />
@@ -28,79 +27,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link href="assets/css/main.css?versio={{versio}}" rel="stylesheet" />
   </head>
-  <body class="hejmo-korpo">
-    <nav class="navbar navbar-dark bg-dark">
-      <div class="container navbar-enhavo">
-        <a class="navbar-brand" href="/">
-          <span class="navbar-retejo">Esperanto12.net</span>
-        </a>
-      </div>
-    </nav>
-
-    <main class="container">
-      <div class="row">
-        <div class="col-sm-12">
-          <div class="hejmo">
-            <h1 class="hejmo-titolo">Learn Esperanto</h1>
-            <div id="hejmo-lingvoj" class="hejmo-lingvoj">
-              {% for lingvo in hejmaj_lingvoj %}
-              <a
-                class="btn btn-outline-primary"
-                href="/{{lingvo.kodo}}/"
-                lang="{{lingvo.kodo}}"
-                dir="{{lingvo.tekstodirekto}}"
-                >{{lingvo.nomo}}</a
-              >
-              {% endfor %}
-            </div>
-            <script id="hejmo-lingvodatenoj" type="application/json">
-              {{hejmaj_lingvoj|tojson}}
-            </script>
-          </div>
-        </div>
-      </div>
-    </main>
-
-    <footer class="footer">
-      <div class="container footer-kolumnoj">
-        <div class="footer-listo">
-          <a
-            href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/PERMESILO.md"
-            target="_blank"
-            rel="noopener"
-            >Krea komunaĵo</a
-          >
-          <span>
-            Surbaze de la
-            <a href="https://eo.wikipedia.org/wiki/Zagreba_metodo"
-              target="_blank"
-              rel="noopener"
-              >Zagreba metodo</a
-            >
-          </span>
-        </div>
-        <div class="footer-listo">
-          <a
-            href="https://github.com/Esperanto/kurso-zagreba-metodo/blob/master/AUTHORS.md"
-            target="_blank"
-            rel="noopener"
-            >Kontribuantoj</a
-          >
-          <a
-            href="https://github.com/Esperanto/kurso-zagreba-metodo/tree/master/KONTRIBUADO.md"
-            target="_blank"
-            rel="noopener"
-            >Kontribuu</a
-          >
-        </div>
-        <div class="footer-listo">
-          <a href="https://jaehnig.org/impressum/" target="_blank" rel="noopener">Kontakto</a>
-          <a href="https://jaehnig.org/privacy" target="_blank" rel="noopener">Privateco</a>
-          <span class="versio">⏱︎ Versio: {{versio}}</span>
-        </div>
-      </div>
-    </footer>
-
+  <body>
+    <script id="hejmo-lingvodatenoj" type="application/json">
+      {{hejmaj_lingvoj|tojson}}
+    </script>
     <script src="assets/js/hejmo.js?versio={{versio}}"></script>
 
     <!-- 100% privacy-first analytics -->

--- a/fonto/py/generu.py
+++ b/fonto/py/generu.py
@@ -355,7 +355,6 @@ def hejmaj_lingvoj(lingvoj):
 
 def generu_html_por_lingvoj(args, lingvoj):
     por_generi = args.lingvoj or [args.lingvo]
-    hejma_fasado = legi_cxefpagxan_fasadon('en')
     hejmaj_lingvoj_datenoj = hejmaj_lingvoj(lingvoj)
     for index, lingvo in enumerate(por_generi):
         if args.lingvoj:
@@ -366,7 +365,6 @@ def generu_html_por_lingvoj(args, lingvoj):
             enhavo,
             args,
             kopiu_statikan=(index == 0),
-            hejma_fasado=hejma_fasado,
             hejmaj_lingvoj=hejmaj_lingvoj_datenoj,
         )
     html_generilo.generate_pwa()

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -3,6 +3,7 @@
 
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 
@@ -74,6 +75,15 @@ def render_markdown(text):
         plugins=[morfema_emfazo],
     )
     return Markup(md(text))
+
+
+def meta_description_from_markdown(text):
+    text = re.sub(r'\{\{\s*url\.[^}]+\s*\}\}', '', text)
+    text = re.sub(r'\[([^\]]+)\]\([^)]*\)', r'\1', text)
+    text = re.sub(r'[*_`#>]', '', text)
+    text = re.sub(r'^\s*[-+]\s+', '', text, flags=re.MULTILINE)
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip()
 
 
 def render_page(name, enhavo, vojprefikso, env, redaktaj_ligiloj=None):
@@ -307,17 +317,17 @@ def create_anki(enhavo):
     return deck
 
 
-def render_hejmo(versio, fasado, hejmaj_lingvoj):
+def render_hejmo(versio, meta_description, hejmaj_lingvoj):
     env = jinja2.Environment(auto_reload=False)
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'html'))
     return env.get_template('hejmo.html').render(
-        fasado=fasado,
         hejmaj_lingvoj=hejmaj_lingvoj,
+        meta_description=meta_description,
         versio=versio,
     )
 
 
-def copy_static_files(versio, hejma_fasado, hejmaj_lingvoj):
+def copy_static_files(versio, meta_description, hejmaj_lingvoj):
     static_dirs = [
         (FONTO_DIR / 'css', OUTPUT_DIR / 'assets' / 'css'),
         (FONTO_DIR / 'js', OUTPUT_DIR / 'assets' / 'js'),
@@ -350,7 +360,7 @@ def copy_static_files(versio, hejma_fasado, hejmaj_lingvoj):
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     write_file(
         str(OUTPUT_DIR / 'index.html'),
-        render_hejmo(versio, hejma_fasado, hejmaj_lingvoj),
+        render_hejmo(versio, meta_description, hejmaj_lingvoj),
     )
     shutil.copy2(FONTO_DIR / 'bildoj' / 'logo' / 'favicon.ico', OUTPUT_DIR / 'favicon.ico')
     shutil.copy2(FONTO_DIR / 'bildoj' / 'logo' / 'apple-touch-icon.png', OUTPUT_DIR / 'apple-touch-icon.png')
@@ -392,16 +402,18 @@ def generate_html(
     enhavo,
     args,
     kopiu_statikan=True,
-    hejma_fasado=None,
     hejmaj_lingvoj=None,
 ):
     eligo = {}
     versio = get_version_hash()
     enhavo['versio'] = versio
     if kopiu_statikan:
+        angla_enkonduko = (ROOT_DIR / 'enhavo' / 'tradukenda' / 'en' / 'enkonduko.md').read_text(
+            encoding='utf-8',
+        )
         copy_static_files(
             versio,
-            hejma_fasado or enhavo['fasado'],
+            meta_description_from_markdown(angla_enkonduko),
             hejmaj_lingvoj or [],
         )
 


### PR DESCRIPTION
## Resumo
- simpligas la radikan paĝon al blanka lingva plusendo
- aldonas SEO-titolon, meta-priskribon kaj HTML-fallbackon al /en/
- limigas aŭtomatan plusendon al lingvoj kun stato: preta

## Kontroloj
- make check
- make html-all
- git diff --check
- statika kontrolo de eligo/retejo/index.html