### PR TITLE
Kompletigu la tokiponan tradukon

### DIFF
--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/01.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/01.yml
@@ -1,57 +1,56 @@
-- 
-  demando: Who is your female friend?
+-
+  demando: jan pona meli sina li seme?
   rektatraduko:
-    - Kiu: Who
-    - estas: is
-    - via: your
-    - amikino: female friend
+    - Kiu: seme
+    - estas: li
+    - via: sina
+    - amikino: jan pona meli
     - '?'
-- 
-  demando: Is your friend Anna now writing in the room?
+-
+  demando: jan pona meli sina Ana li sitelen lon tomo lon tenpo ni, anu seme?
   rektatraduko:
-    - Ĉu: Whether
-    - via: your
-    - amikino: female friend
-    - Anna: Anna
-    - skribas: writes
-    - nun: now
-    - en: in
-    - la: the 
-    - ĉambro: room
+    - Ĉu: anu seme
+    - via: sina
+    - amikino: jan pona meli
+    - Anna: Ana
+    - skribas: sitelen
+    - nun: lon tenpo ni
+    - en: lon
+    - la: (ni)
+    - ĉambro: tomo
     - '?'
-- 
-  demando: Does the friend of your father work in a hotel?
+-
+  demando: jan pona pi mama mije sina li pali lon tomo lape, anu seme?
   rektatraduko:
-    - Ĉu: Whether
-    - la: the
-    - amiko: friend
-    - de: of
-    - via: your
-    - patro: father
-    - laboras: works
-    - en: in
-    - hotelo: hotel
+    - Ĉu: anu seme
+    - la: (ni)
+    - amiko: jan pona
+    - de: pi
+    - via: sina
+    - patro: mama mije
+    - laboras: pali
+    - en: lon
+    - hotelo: tomo lape
     - '?'
-- 
-  demando: What is on the work-bench in our room?
+-
+  demando: ijo seme li lon supa pali lon tomo mi mute?
   rektatraduko:
-    - Kio: What 
-    - estas: is
-    - sur: 'on'
-    - la: the
-    - labortablo: work-bench
-    - en: in
-    - nia: our
-    - ĉambro: room
+    - Kio: ijo seme
+    - estas: li lon
+    - sur: lon sewi
+    - la: (ni)
+    - labortablo: supa pali
+    - en: lon
+    - nia: pi mi mute
+    - ĉambro: tomo
     - '?'
-- 
-  demando: Is there an Esperanto textbook on your table?
+-
+  demando: lipu sona pi toki Epelanto li lon supa sina, anu seme?
   rektatraduko:
-    - Ĉu: Whether
-    - Esperanto-lernolibro: Esperanto-textbook
-    - estas: is
-    - sur: 'on'
-    - via: your 
-    - tablo: table
+    - Ĉu: anu seme
+    - Esperanto-lernolibro: lipu sona pi toki Epelanto
+    - estas: li lon
+    - sur: lon sewi
+    - via: sina
+    - tablo: supa
     - '?'
-

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/02.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/02.yml
@@ -1,70 +1,70 @@
-- 
-  demando: What was your old home like?
-  rektatraduko: 
-    - Kia: What like
-    - estis: was
-    - via: your
-    - malnova: old
-    - hejmo: home 
-    - '?'
-- 
-  demando: Which books did you read, and were they good?
-  rektatraduko: 
-    - Kiujn: Which 
-    - librojn: books
-    - vi: you
-    - legis: did read
-    - kaj: and
-    - ĉu: whether
-    - ili: they
-    - estas: are
-    - bonaj: good 
-    - '?'
-- 
-  demando: "What did Anna and Mark do in Marks little room?"
+-
+  demando: tomo pi tenpo pini sina li seme?
   rektatraduko:
-    - Kion: What
-    - faris: did do
-    - Anna: Anna
-    - kaj: and
-    - Marko: Mark
-    - en: in 
-    - la: the
-    - malgranda: little
-    - ĉambro: room
-    - de: of
-    - Marko: Mark
+    - Kia: seme
+    - estis: li, tenpo pini
+    - via: sina
+    - malnova: pi tenpo pini
+    - hejmo: tomo
     - '?'
-- 
-  demando: Do you like reading books about love?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - ŝatas: like
-    - legi: to read
-    - librojn: books
-    - pri: about
-    - amo: love
+-
+  demando: sina lukin e lipu seme, ona li pona anu seme?
+  rektatraduko:
+    - Kiujn: ijo seme
+    - librojn: lipu
+    - vi: sina
+    - legis: lukin e lipu, tenpo pini
+    - kaj: en
+    - ĉu: anu seme
+    - ili: ona mute
+    - estas: li
+    - bonaj: pona
     - '?'
-- 
-  demando: Who will go with you to your home?
-  rektatraduko: 
-    - Kiu: Who
-    - iros: will go
-    - kun: with
-    - vi: you
-    - al: to 
-    - via: your
-    - hejmo: home
+-
+  demando: "jan Ana en jan Mako li pali e seme lon tomo lili Mako?"
+  rektatraduko:
+    - Kion: ijo seme
+    - faris: pali, tenpo pini
+    - Anna: jan Ana
+    - kaj: en
+    - Marko: jan Mako
+    - en: lon
+    - la: (ni)
+    - malgranda: lili
+    - ĉambro: tomo
+    - de: pi
+    - Marko: jan Mako
     - '?'
-- 
-  demando: "What are your girl-friend's eyes like?"
-  rektatraduko: 
-    - Kiaj: What like
-    - estas: are
-    - la: the
-    - okuloj: eyes
-    - de: of
-    - via: your
-    - amikino: girl-friend
+-
+  demando: sina pilin pona tawa lukin e lipu pi olin, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - ŝatas: pilin pona tawa
+    - legi: lukin e lipu
+    - librojn: lipu
+    - pri: pi
+    - amo: olin
+    - '?'
+-
+  demando: jan seme li tawa tomo sina, poka sina?
+  rektatraduko:
+    - Kiu: jan seme
+    - iros: tawa, tenpo kama
+    - kun: poka
+    - vi: sina
+    - al: tawa
+    - via: sina
+    - hejmo: tomo
+    - '?'
+-
+  demando: oko pi jan pona meli sina li seme?
+  rektatraduko:
+    - Kiaj: seme
+    - estas: li
+    - la: (ni)
+    - okuloj: oko
+    - de: pi
+    - via: sina
+    - amikino: jan pona meli
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/03.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/03.yml
@@ -1,77 +1,77 @@
 -
-  demando: Do waiters in large hotels understand a lot of languages? 
-  rektatraduko:  
-    - Ĉu: Whether 
-    - kelneroj: waiters
-    - en: in
-    - grandaj: big
-    - hoteloj: hotels
-    - komprenas: understand
-    - multajn: many
-    - lingvojn: languages
+  demando: jan pi pana moku lon tomo lape suli li sona e toki mute, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - kelneroj: jan pi pana moku
+    - en: lon
+    - grandaj: suli
+    - hoteloj: tomo lape
+    - komprenas: sona
+    - multajn: mute
+    - lingvojn: toki
     - '?'
 -
-  demando: Do you know that Anna likes a new song about a poor man and a beautiful girl?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - scias: know
+  demando: jan Ana li pilin pona tawa kalama musi sin pi jan pi mani lili en meli pona. sina sona ala sona e ni?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - scias: sona
     - ','
-    - ĉu: whether
-    - Anna: Anna 
-    - ŝatas: likes
-    - la: the
-    - novan: new
-    - kanton: song
-    - pri: about
-    - malriĉulo: a poor man
-    - kaj: and
-    - belulino: a beautiful girl
+    - ĉu: anu seme
+    - Anna: jan Ana
+    - ŝatas: pilin pona tawa
+    - la: (ni)
+    - novan: sin
+    - kanton: kalama musi
+    - pri: pi
+    - malriĉulo: jan pi mani lili
+    - kaj: en
+    - belulino: meli pona
     - '?'
 -
-  demando: Where did you see an old man and a young man who were carrying a large table?
-  rektatraduko: 
-    - Kie: Where
-    - vi: you
-    - vidis: did see
-    - la: the
-    - maljunulon: old man
-    - kaj: and
-    - la: the
-    - junulon: young man
+  demando: sina lukin e mije pi tenpo pini en mije lili lon ma seme? ona li jo e supa suli.
+  rektatraduko:
+    - Kie: ma seme
+    - vi: sina
+    - vidis: lukin, tenpo pini
+    - la: (ni)
+    - maljunulon: mije pi tenpo pini
+    - kaj: en
+    - la: (ni)
+    - junulon: mije lili
     - ','
-    - kiuj: who
-    - portis: were carrying
-    - grandan: big
-    - tablon: table
+    - kiuj: ona
+    - portis: jo, tenpo pini
+    - grandan: suli
+    - tablon: supa
     - '?'
 -
-  demando: How did it happen that you again came to us without brothers-and-sisters?
-  rektatraduko: 
-    - Kiel: How
-    - okazis: did it happen
+  demando: sina kama sin tawa mi mute. jan sama sina li lon ala. ni li kama lon nasin seme?
+  rektatraduko:
+    - Kiel: nasin seme
+    - okazis: kama lon, tenpo pini
     - ','
-    - ke: that
-    - vi: you
-    - denove: again
-    - venis: came
-    - al: to 
-    - ni: us
-    - sen: without
-    - gefratoj: brothers-and-sisters
+    - ke: ni
+    - vi: sina
+    - denove: sin
+    - venis: kama, tenpo pini
+    - al: tawa
+    - ni: mi mute
+    - sen: weka pi
+    - gefratoj: jan sama
     - '?'
 -
-  demando: Can you learn Esperanto quite quickly with-the-help-of the new textbook?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - povas: can
-    - per: with-the-help-of
-    - la: the 
-    - nova: new
-    - lernolibro: textbook
-    - sufiĉe: quite
-    - rapide: quickly
-    - lerni: learn
-    - Esperanton: Esperanto
+  demando: sina ken kama sona pona e toki Epelanto kepeken lipu sona sin, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - povas: ken
+    - per: kepeken
+    - la: (ni)
+    - nova: sin
+    - lernolibro: lipu sona
+    - sufiĉe: mute pona
+    - rapide: kepeken tenpo lili
+    - lerni: kama sona
+    - Esperanton: toki Epelanto
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/04.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/04.yml
@@ -1,73 +1,73 @@
 -
-  demando: When am I going to see you again?
-  rektatraduko: 
-    - Kiam: When
-    - mi: I  
-    - revidos: am going to see again
-    - vin: you
+  demando: mi lukin sin e sina lon tenpo seme?
+  rektatraduko:
+    - Kiam: tenpo seme
+    - mi: mi
+    - revidos: lukin sin, tenpo kama
+    - vin: sina
     - '?'
 -
-  demando: How long have you been learning the international language?
-  rektatraduko: 
-    - Kiel: How
-    - longe: long
-    - vi: you
-    - lernas: learn
-    - la: the 
-    - Internacian: international
-    - Lingvon: language
+  demando: sina kama sona e toki pi ma ale lon tenpo pi suli seme?
+  rektatraduko:
+    - Kiel: nasin seme
+    - longe: tenpo suli
+    - vi: sina
+    - lernas: kama sona
+    - la: (ni)
+    - Internacian: pi ma ale
+    - Lingvon: toki
     - '?'
 -
-  demando: Where is my new book with photographs?
-  rektatraduko: 
-    - Kie: Where
-    - estas: is
-    - mia: my
-    - nova: new
-    - libro: book
-    - kun: with
-    - fotoj: photographs
+  demando: lipu sin mi pi sitelen li lon ma seme?
+  rektatraduko:
+    - Kie: ma seme
+    - estas: li lon
+    - mia: mi
+    - nova: sin
+    - libro: lipu
+    - kun: poka
+    - fotoj: sitelen
     - '?'
 -
-  demando: Where (where-to) will you go after lunch?
-  rektatraduko: 
-    - Kien: Where-to
-    - vi: you
-    - iros: will go
-    - post: after
-    - la: the
-    - tagmanĝo: lunch
+  demando: sina tawa ma seme lon tenpo pi pini moku suno?
+  rektatraduko:
+    - Kien: tawa ma seme
+    - vi: sina
+    - iros: tawa, tenpo kama
+    - post: lon tenpo kama pi
+    - la: (ni)
+    - tagmanĝo: moku pi tenpo suno
     - '?'
 -
-  demando: Can one close the door of the room when it is cold?
-  rektatraduko: 
-    - Ĉu: Whether
-    - oni: one
-    - povas: can 
-    - fermi: close
-    - la: the
-    - pordon: door
-    - de: of 
-    - la: the
-    - ĉambro: room
+  demando: tenpo li lete la, jan li ken pini e lupa tomo, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - oni: jan
+    - povas: ken
+    - fermi: open ala e
+    - la: (ni)
+    - pordon: lupa tomo
+    - de: pi
+    - la: (ni)
+    - ĉambro: tomo
     - ','
-    - kiam: when
-    - estas: is
-    - malvarme: cold
+    - kiam: tenpo
+    - estas: li
+    - malvarme: lete
     - '?'
 -
-  demando: How long are you angry for if people take a lot of money from you?
-  rektatraduko: 
-    - Kiel: How
-    - longe: long
-    - vi: you
-    - koleras: are angry
+  demando: jan li kama jo e mani mute tan sina la, sina pilin utala lon tenpo pi suli seme?
+  rektatraduko:
+    - Kiel: nasin seme
+    - longe: tenpo suli
+    - vi: sina
+    - koleras: pilin utala
     - ','
-    - se: if
-    - oni: one
-    - forprenas: takes away
-    - de: from
-    - vi: you
-    - multan: a lot of
-    - monon: money
+    - se: la
+    - oni: jan
+    - forprenas: kama jo, weka
+    - de: tan
+    - vi: sina
+    - multan: mute
+    - monon: mani
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/05.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/05.yml
@@ -1,64 +1,64 @@
 -
-  demando: Can you learn calmly when someone is singing joyfully?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - povas: can
-    - trankvile: calmly
-    - lerni: learn
+  demando: jan li kalama musi kepeken pilin pona la, sina ken kama sona kepeken pilin awen, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - povas: ken
+    - trankvile: kepeken pilin awen
+    - lerni: kama sona
     - ','
-    - dum: while
-    - iu: someone
-    - ĝoje: joyfully
-    - kantas: sings
+    - dum: lon tenpo pi
+    - iu: jan
+    - ĝoje: kepeken pilin pona
+    - kantas: kalama musi
     - '?'
 -
-  demando: Who knows when and where we will see each other again?
-  rektatraduko: 
-    - Kiu: Who
-    - scias: knows
+  demando: jan seme li sona e tenpo en ma pi lukin sin pi mi mute?
+  rektatraduko:
+    - Kiu: jan seme
+    - scias: sona
     - ','
-    - kiam: when 
-    - kaj: and
-    - kie: where
-    - ni: we
-    - revidos: will see again
-    - nin: each other
+    - kiam: tenpo seme
+    - kaj: en
+    - kie: ma seme
+    - ni: mi mute
+    - revidos: lukin sin, tenpo kama
+    - nin: mi mute
     - '?'
 -
-  demando: What time is it now?
-  rektatraduko: 
-    - Kioma: How many'eth
-    - horo: hour
-    - estas: is 
-    - nun: now
+  demando: tenpo li seme lon tenpo ni?
+  rektatraduko:
+    - Kioma: nanpa seme
+    - horo: tenpo
+    - estas: li
+    - nun: lon tenpo ni
     - '?'
 -
-  demando: Did someone help you open the door of the old house?
-  rektatraduko: 
-    - Ĉu: Whether
-    - iu: someone 
-    - helpis: did help 
-    - al: to 
-    - vi: you 
-    - malfermi: open 
-    - la: the 
-    - pordon: door 
-    - de: of
-    - la: the
-    - malnova: old
-    - domo: house
+  demando: jan li pana e pona tawa sina, tawa open pi lupa tomo pi tenpo pini, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - iu: jan
+    - helpis: pana e pona, tenpo pini
+    - al: tawa
+    - vi: sina
+    - malfermi: open e
+    - la: (ni)
+    - pordon: lupa tomo
+    - de: pi
+    - la: (ni)
+    - malnova: pi tenpo pini
+    - domo: tomo
     - '?'
 -
-  demando: Why do you not have time to listen to me longer?
-  rektatraduko: 
-    - Kial: Why
-    - vi: you
-    - ne: not
-    - havas: have
-    - tempon: time
-    - aŭskulti: to listen
-    - min: me
-    - pli: more
-    - longe: long
+  demando: sina jo ala e tenpo pi kute e mi lon tenpo suli, tan seme?
+  rektatraduko:
+    - Kial: tan seme
+    - vi: sina
+    - ne: ala
+    - havas: jo
+    - tempon: tenpo
+    - aŭskulti: kute e
+    - min: mi
+    - pli: mute
+    - longe: tenpo suli
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/06.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/06.yml
@@ -1,72 +1,72 @@
-- 
-  demando: Do you want me to show you my newest book?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - deziras: wish
-    - ',' 
-    - ke: that 
-    - mi: I
-    - montru: show
-    - al: to
-    - vi: you
-    - mian: my
-    - plej: most
-    - novan: new
-    - libron: book
+-
+  demando: sina wile e ni anu seme — mi pana e lipu sin mi tawa sina?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - deziras: wile
+    - ','
+    - ke: ni
+    - mi: mi
+    - montru: pana lon lukin
+    - al: tawa
+    - vi: sina
+    - mian: mi
+    - plej: nanpa wan
+    - novan: sin
+    - libron: lipu
     - '?'
-- 
-  demando: What do you want for breakfast tomorrow?
-  rektatraduko: 
-    - Kion: What
-    - vi: you
-    - volas: want
-    - morgaŭ: tomorrow
-    - matenmanĝi: eat breakfast
+-
+  demando: sina wile moku e seme lon open pi tenpo suno kama?
+  rektatraduko:
+    - Kion: ijo seme
+    - vi: sina
+    - volas: wile
+    - morgaŭ: lon tenpo suno kama
+    - matenmanĝi: moku pi open suno
     - '?'
-- 
-  demando: "When will Mark arrive, at five or at eight o'clock?"
-  rektatraduko: 
-    - Kiam: When
-    - Marko: Mark
-    - alvenos: will arrive
-    - ',' 
-    - je: at
-    - la: the
-    - kvina: fifth
-    - aŭ: or
-    - je: at
-    - la: the
-    - oka: eighth
-    - horo: hour
+-
+  demando: jan Mako li kama lon tenpo seme — lon nanpa 5 anu lon nanpa 8?
+  rektatraduko:
+    - Kiam: tenpo seme
+    - Marko: jan Mako
+    - alvenos: kama, tenpo kama
+    - ','
+    - je: lon
+    - la: (ni)
+    - kvina: nanpa 5
+    - aŭ: anu
+    - je: lon
+    - la: (ni)
+    - oka: nanpa 8
+    - horo: tenpo
     - '?'
-- 
-  demando: When did you notice that the whole family calls me benefactor?
-  rektatraduko: 
-    - Kiam: When
-    - vi: you
-    - rimarkis: did notice
-    - ','  
-    - ke: that
-    - la: the
-    - tuta: whole
-    - familio: family
-    - nomas: calls
-    - min: me
-    - bonfarulo: benefactor
+-
+  demando: kulupu mama ale li nimi e mi, jan pi pali pona. sina kama sona e ni lon tenpo seme?
+  rektatraduko:
+    - Kiam: tenpo seme
+    - vi: sina
+    - rimarkis: kama sona, tenpo pini
+    - ','
+    - ke: ni
+    - la: (ni)
+    - tuta: ale
+    - familio: kulupu mama
+    - nomas: nimi e
+    - min: mi
+    - bonfarulo: jan pi pali pona
     - '?'
-- 
-  demando: Was the booklet which I sent you useful to you?
-  rektatraduko: 
-    - Ĉu: Whether
-    - la: the 
-    - libreto: booklet
-    - estis: was
-    - utila: useful
-    - al: to
-    - vi: you
-    - ',' 
-    - kiun: which
-    - mi: I 
-    - sendis: sent
+-
+  demando: lipu lili pi pana mi tawa sina li pona tawa pali sina, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - la: (ni)
+    - libreto: lipu lili
+    - estis: li, tenpo pini
+    - utila: pona tawa pali
+    - al: tawa
+    - vi: sina
+    - ','
+    - kiun: ona
+    - mi: mi
+    - sendis: pana tawa weka, tenpo pini
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/07.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/07.yml
@@ -1,77 +1,77 @@
-- 
-  demando: Who had the book that you were waiting for for more than 2 years?
-  rektatraduko: 
-    - Kiu: Who
-    - havis: had
-    - la: the
-    - libron: book
-    - ',' 
-    - kiun: that
-    - vi: you
-    - atendis: were waiting
-    - pli: more
-    - ol: than
-    - du: two
-    - jarojn: years
-    - '?'
-- 
-  demando: Do you want me to show you the photo which is dearest to me?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - volas: want
+-
+  demando: jan seme li jo e lipu? sina awen e ona lon tenpo sike suno tu mute.
+  rektatraduko:
+    - Kiu: jan seme
+    - havis: jo, tenpo pini
+    - la: (ni)
+    - libron: lipu
     - ','
-    - ke: that
-    - mi: I
-    - montru: show
-    - al: to 
-    - vi: you
-    - mian: my
-    - plej: most
-    - karan: dear
-    - foton: photo
+    - kiun: ona
+    - vi: sina
+    - atendis: awen, tenpo pini
+    - pli: mute
+    - ol: tawa
+    - du: tu
+    - jarojn: tenpo sike suno
     - '?'
-- 
-  demando: Where did you buy that garment?
-  rektatraduko: 
-    - Kie: Where
-    - vi: you
-    - aĉetis: did buy
-    - tiun: that
-    - vestaĵon: garment
+-
+  demando: sina wile e ni anu seme — mi pana e sitelen pi suli mute tawa pilin mi, tawa sina?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - volas: wile
+    - ','
+    - ke: ni
+    - mi: mi
+    - montru: pana lon lukin
+    - al: tawa
+    - vi: sina
+    - mian: mi
+    - plej: nanpa wan
+    - karan: suli tawa pilin
+    - foton: sitelen
     - '?'
-- 
-  demando: Where will you go on Sunday if it is a sunny day?
-  rektatraduko: 
-    - Kien: Where
-    - vi: you
-    - iros: will go
-    - dimanĉe: on Sunday
-    - ',' 
-    - se: if
-    - estos: will be
-    - suna: sunny
-    - tago: day
+-
+  demando: sina esun e len ni lon ma seme?
+  rektatraduko:
+    - Kie: ma seme
+    - vi: sina
+    - aĉetis: esun, tenpo pini
+    - tiun: ni
+    - vestaĵon: len
     - '?'
-- 
-  demando: Did your brother already leave?
-  rektatraduko: 
-    - Ĉu: Whether
-    - via: your
-    - frato: brother
-    - jam: already
-    - ekiris: did leave
+-
+  demando: tenpo suno nanpa 7 li suno la, sina tawa ma seme?
+  rektatraduko:
+    - Kien: tawa ma seme
+    - vi: sina
+    - iros: tawa, tenpo kama
+    - dimanĉe: lon tenpo suno nanpa 7
+    - ','
+    - se: la
+    - estos: li, tenpo kama
+    - suna: suno
+    - tago: tenpo suno
     - '?'
-- 
-  demando: Where is the water which you have brought yourself?
-  rektatraduko: 
-    - Kie: Where
-    - estas: is
-    - la: the
-    - akvo: water
-    - ',' 
-    - kiun: which
-    - vi: you
-    - mem: yourself
-    - kunportis: have brought
+-
+  demando: jan sama mije sina li tawa weka, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - via: sina
+    - frato: jan sama mije
+    - jam: pini la
+    - ekiris: open tawa, tenpo pini
+    - '?'
+-
+  demando: telo pi jo sina sama li lon ma seme?
+  rektatraduko:
+    - Kie: ma seme
+    - estas: li lon
+    - la: (ni)
+    - akvo: telo
+    - ','
+    - kiun: ona
+    - vi: sina
+    - mem: sina sama
+    - kunportis: jo, tenpo pini
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/08.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/08.yml
@@ -1,86 +1,86 @@
-- 
-  demando: Who is going to clean the kitchen after lunch?
-  rektatraduko: 
-    - Kiu: Who
-    - purigos: is going to clean
-    - la: the
-    - kuirejon: kitchen
-    - post: after
-    - la: the
-    - tagmanĝo: lunch
+-
+  demando: jan seme li weka e jaki tan tomo moku, lon tenpo pi pini moku suno?
+  rektatraduko:
+    - Kiu: jan seme
+    - purigos: weka e jaki, tenpo kama
+    - la: (ni)
+    - kuirejon: tomo moku
+    - post: lon tenpo kama pi
+    - la: (ni)
+    - tagmanĝo: moku pi tenpo suno
     - '?'
-- 
-  demando: "What do you want to drink: tea, some coffee or do you not want anything?"
-  rektatraduko: 
-    - Kion: What
-    - vi: you
-    - volas: want
-    - trinki: to drink
-    - ':' 
-    - teon: tea
-    - ',' 
-    - iom: some
-    - da: of
-    - kafo: coffee
-    - aŭ: or
-    - ĉu: whether
-    - vi: you
-    - volas: want
-    - nenion: nothing
+-
+  demando: sina wile moku e seme? telo kasi anu telo wawa lili anu sina wile ala e ijo?
+  rektatraduko:
+    - Kion: ijo seme
+    - vi: sina
+    - volas: wile
+    - trinki: moku e telo
+    - ':'
+    - teon: telo kasi
+    - ','
+    - iom: lili
+    - da: pi
+    - kafo: telo wawa
+    - aŭ: anu
+    - ĉu: anu seme
+    - vi: sina
+    - volas: wile
+    - nenion: ijo ala
     - '?'
-- 
-  demando: Why did you so suddenly decide to renovate your small room?
-  rektatraduko: 
-    - Kial: Why
-    - vi: you
-    - tiel: so
-    - subite: suddenly
-    - decidis: did decide
-    - renovigi: to renovate
-    - vian: your
-    - ĉambreton: small room
+-
+  demando: sina kama wile kepeken tenpo lili, tawa kama sin e tomo lili sina, tan seme?
+  rektatraduko:
+    - Kial: tan seme
+    - vi: sina
+    - tiel: ni la
+    - subite: kepeken tenpo lili
+    - decidis: kama wile, tenpo pini
+    - renovigi: kama sin e
+    - vian: sina
+    - ĉambreton: tomo lili
     - '?'
-- 
-  demando: To whom did you give the clean wine glasses?
-  rektatraduko: 
-    - Al: To
-    - kiu: whom
-    - vi: you
-    - donis: did give
-    - la: the
-    - purajn: clean
-    - glasojn: glasses
-    - por: for 
-    - la: the
-    - vino: wine
+-
+  demando: sina pana e poki pi telo nasa, pi jaki ala, tawa jan seme?
+  rektatraduko:
+    - Al: tawa
+    - kiu: jan seme
+    - vi: sina
+    - donis: pana, tenpo pini
+    - la: (ni)
+    - purajn: jaki ala
+    - glasojn: poki telo
+    - por: tawa
+    - la: (ni)
+    - vino: telo nasa
     - '?'
-- 
-  demando: Against whom did your sports club play two weeks ago?
-  rektatraduko: 
-    - Kontraŭ: Against
-    - kiu: whom
-    - ludis: did play
-    - via: your
-    - sportklubo: sports club
-    - antaŭ: before
-    - du: two
-    - semajnoj: weeks
+-
+  demando: kulupu pi musi sijelo sina li musi utala tawa jan seme, lon tenpo pini?
+  rektatraduko:
+    - Kontraŭ: utala tawa
+    - kiu: jan seme
+    - ludis: musi, tenpo pini
+    - via: sina
+    - sportklubo: kulupu pi musi sijelo
+    - antaŭ: lon tenpo pini pi
+    - du: tu
+    - semajnoj: tenpo pi suno mute
     - '?'
-- 
-  demando: Do you often see the policeman who is living in the apartment above you?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - ofte: often
-    - vidas: see
-    - la: the
-    - policiston: policeman
-    - ',' 
-    - kiu: who
-    - loĝas: lives
-    - en: in 
-    - la: the
-    - loĝejo: apartment
-    - super: above
-    - vi: you
+-
+  demando: sina lukin e jan pi awen lawa lon tenpo mute, anu seme? ona li lon tomo sewi sina.
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - ofte: lon tenpo mute
+    - vidas: lukin
+    - la: (ni)
+    - policiston: jan pi awen lawa
+    - ','
+    - kiu: ona
+    - loĝas: lon tomo
+    - en: lon
+    - la: (ni)
+    - loĝejo: tomo
+    - super: lon sewi
+    - vi: sina
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/09.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/09.yml
@@ -1,75 +1,75 @@
-- 
-  demando: What could delight your parents most of all?
-  rektatraduko: 
-    - Kio: What
-    - povus: could
-    - plej: most
-    - ĝojigi: delight
-    - viajn: your
-    - gepatrojn: parents
+-
+  demando: ijo seme li ken pana e pilin pona mute tawa mama sina?
+  rektatraduko:
+    - Kio: ijo seme
+    - povus: ken
+    - plej: nanpa wan
+    - ĝojigi: pana e pilin pona
+    - viajn: sina
+    - gepatrojn: mama mute
     - '?'
-- 
-  demando: If only you wanted to go to the city center after school!
-  rektatraduko: 
-    - Se: If
-    - almenaŭ: at least (if only)
-    - vi: you
-    - post: after
-    - la: the 
-    - lernado: learning
-    - irus: would go
-    - kun: with
-    - mi: me
-    - en: into
-    - la: the 
-    - urbocentron: city center
+-
+  demando: sina wile tawa insa pi ma tomo lon tenpo pi pini sona la, pona a!
+  rektatraduko:
+    - Se: la
+    - almenaŭ: taso
+    - vi: sina
+    - post: lon tenpo kama pi
+    - la: (ni)
+    - lernado: kama sona
+    - irus: tawa, ken
+    - kun: poka
+    - mi: mi
+    - en: tawa
+    - la: (ni)
+    - urbocentron: insa pi ma tomo
     - '!'
-- 
-  demando: Where would you like to travel to if you had enough money and time?
-  rektatraduko: 
-    - Kien: Where to
-    - vi: you
-    - dezirus: would wish
-    - vojaĝi: to travel
-    - ',' 
-    - se: if
-    - vi: you
-    - havus: would have
-    - sufiĉe: enough
-    - da: of
-    - mono: money
-    - kaj: and
-    - tempo: time
+-
+  demando: sina jo e mani pona en tenpo pona la, sina wile tawa ma seme?
+  rektatraduko:
+    - Kien: tawa ma seme
+    - vi: sina
+    - dezirus: wile, ken
+    - vojaĝi: tawa ma weka
+    - ','
+    - se: la
+    - vi: sina
+    - havus: jo, ken
+    - sufiĉe: mute pona
+    - da: pi
+    - mono: mani
+    - kaj: en
+    - tempo: tenpo
     - '?'
-- 
-  demando: Are you planning to travel to Paris by car or does it not seem much better by train?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - planas: plan
-    - veturi: to travel
-    - al: to
-    - Parizo: Paris
-    - per: by
-    - aŭto: car
-    - aŭ: or
-    - ĉu: whether
-    - ne: not
-    - ŝajnas: seem
-    - multe: much
-    - pli: more
-    - bone: good
-    - per: by
-    - vagonaro: train
+-
+  demando: sina wile tawa ma Pali kepeken tomo tawa, anu ni li pona mute — tomo tawa linja?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - planas: wile
+    - veturi: tawa
+    - al: tawa
+    - Parizo: ma Pali
+    - per: kepeken
+    - aŭto: tomo tawa
+    - aŭ: anu
+    - ĉu: anu seme
+    - ne: ala
+    - ŝajnas: lukin sama
+    - multe: mute
+    - pli: mute
+    - bone: pona
+    - per: kepeken
+    - vagonaro: tomo tawa linja
     - '?'
-- 
-  demando: Why do different people explain identical ideas differently?
-  rektatraduko: 
-    - Kial: Why
-    - diversaj: different
-    - homoj: people
-    - klarigas: explain
-    - samajn: identical
-    - ideojn: ideas
-    - diversmaniere: differently 
+-
+  demando: jan ante mute li pana e sona pi pilin sama, kepeken nasin ante, tan seme?
+  rektatraduko:
+    - Kial: tan seme
+    - diversaj: ante mute
+    - homoj: jan
+    - klarigas: pana e sona
+    - samajn: sama
+    - ideojn: pilin
+    - diversmaniere: kepeken nasin ante
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/10.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/10.yml
@@ -1,51 +1,51 @@
-- 
-  demando: Does friendship make you more happy than love does?
-  rektatraduko: 
-    - Ĉu: Whether
-    - amikeco: friendship
-    - pli: more
-    - feliĉigas: makes happy
-    - vin: you
-    - ol: than
-    - la: the
-    - amo: love
+-
+  demando: nasin pi jan pona li pana e pilin pona tawa sina, mute tawa olin, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - amikeco: nasin pi jan pona
+    - pli: mute
+    - feliĉigas: pana e pilin pona
+    - vin: sina
+    - ol: tawa
+    - la: (ni)
+    - amo: olin
     - '?'
-- 
-  demando: How often do you write letters to your girlfriends in Italy?
-  rektatraduko: 
-    - Kiel: How
-    - ofte: often
-    - vi: you
-    - skribas: write
-    - leterojn: letters
-    - al: to
-    - viaj: your
-    - amikinoj: friends
-    - en: in
-    - Italio: Italy
+-
+  demando: sina sitelen e lipu toki tawa jan pona meli sina lon ma Italija, lon tenpo pi mute seme?
+  rektatraduko:
+    - Kiel: nasin seme
+    - ofte: lon tenpo mute
+    - vi: sina
+    - skribas: sitelen
+    - leterojn: lipu toki
+    - al: tawa
+    - viaj: sina
+    - amikinoj: jan pona meli
+    - en: lon
+    - Italio: ma Italija
     - '?'
-- 
-  demando: Has the relationship between you and your teacher changed?
-  rektatraduko: 
-    - Ĉu: Whether
-    - la: the
-    - rilato: relationship
-    - inter: between
-    - vi: you
-    - kaj: and
-    - via: your
-    - instruisto: teacher
-    - ŝanĝiĝis: changed
+-
+  demando: nasin poka pi sina en jan pi pana sona sina li kama ante, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - la: (ni)
+    - rilato: nasin poka
+    - inter: lon insa pi
+    - vi: sina
+    - kaj: en
+    - via: sina
+    - instruisto: jan pi pana sona
+    - ŝanĝiĝis: kama ante, tenpo pini
     - '?'
-- 
-  demando: Do you now already know Esperanto well enough?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - nun: now
-    - jam: already
-    - scias: know
-    - Esperanton: Esperanto
-    - sufiĉe: enough
-    - bone: well
+-
+  demando: sina sona pona e toki Epelanto lon tenpo ni, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - nun: lon tenpo ni
+    - jam: pini la
+    - scias: sona
+    - Esperanton: toki Epelanto
+    - sufiĉe: mute pona
+    - bone: pona
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/11.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/11.yml
@@ -1,54 +1,54 @@
-- 
-  demando: Can you bring along my sister's medicine?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - povas: can
-    - kunporti: bring along
-    - la: the
-    - sanigilon: medicine
-    - de: of
-    - mia: my
-    - fratino: sister
+-
+  demando: sina ken jo e ijo pi pona sijelo pi jan sama meli mi, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - povas: ken
+    - kunporti: jo poka
+    - la: (ni)
+    - sanigilon: ijo pi pona sijelo
+    - de: pi
+    - mia: mi
+    - fratino: jan sama meli
     - '?'
-- 
-  demando: When did you buy that musical instrument?
-  rektatraduko: 
-    - Kiam: When
-    - vi: you
-    - aĉetis: did buy
-    - tiun: that
-    - muzikilon: musical instrument
+-
+  demando: sina esun e ilo kalama musi ni lon tenpo seme?
+  rektatraduko:
+    - Kiam: tenpo seme
+    - vi: sina
+    - aĉetis: esun, tenpo pini
+    - tiun: ni
+    - muzikilon: ilo kalama musi
     - '?'
-- 
-  demando: Who used my key the last time?
-  rektatraduko: 
-    - Kiu: Who
-    - laste: last time
-    - uzis: used
-    - mian: my
-    - ŝlosilon: key
+-
+  demando: jan seme li kepeken e ilo open mi lon tenpo pini?
+  rektatraduko:
+    - Kiu: jan seme
+    - laste: lon tenpo pini
+    - uzis: kepeken, tenpo pini
+    - mian: mi
+    - ŝlosilon: ilo open
     - '?'
-- 
-  demando: Did you travel in Venice also by gondola?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - en: in
-    - Venecio: Venice
-    - veturis: did travel
-    - ankaŭ: also
-    - per: by
-    - gondolo: gondola
+-
+  demando: sina tawa lon ma Wenesija kepeken tomo tawa telo kin, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - en: lon
+    - Venecio: ma Wenesija
+    - veturis: tawa, tenpo pini
+    - ankaŭ: kin
+    - per: kepeken
+    - gondolo: tomo tawa telo
     - '?'
-- 
-  demando: Will you be able to fall asleep when it becomes quiet?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - povos: will be able
-    - ekdormi: to fall asleep
-    - ',' 
-    - kiam: when 
-    - silentiĝis: became quiet
+-
+  demando: tenpo li kama kalama ala la, sina ken kama lape, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - povos: ken, tenpo kama
+    - ekdormi: kama lape
+    - ','
+    - kiam: tenpo
+    - silentiĝis: kama kalama ala
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/12.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku-kaj-respondu/12.yml
@@ -1,68 +1,68 @@
-- 
-  demando: Will we see each other again, no matter where or when?
-  rektatraduko: 
-    - Ĉu: Whether
-    - ni: we
-    - revidos: will see again
-    - nin: each other
-    - ',' 
-    - kie: where
-    - ajn: -ever
-    - kaj: and
-    - kiam: when
-    - ajn: -ever
+-
+  demando: mi mute li lukin sin e mi mute, lon ma ale en lon tenpo ale, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - ni: mi mute
+    - revidos: lukin sin, tenpo kama
+    - nin: mi mute
+    - ','
+    - kie: ma
+    - ajn: ale
+    - kaj: en
+    - kiam: tenpo
+    - ajn: ale
     - '?'
-- 
-  demando: When will I get back the other half of the books?
-  rektatraduko: 
-    - Kiam: When
-    - mi: I 
-    - rericevos: will get back
-    - la: the
-    - alian: other
-    - duonon: half
-    - de: of
-    - la: the
-    - libroj: books
+-
+  demando: mi kama jo sin e kipisi ante pi lipu lon tenpo seme?
+  rektatraduko:
+    - Kiam: tenpo seme
+    - mi: mi
+    - rericevos: kama jo sin, tenpo kama
+    - la: (ni)
+    - alian: ante
+    - duonon: kipisi tu
+    - de: pi
+    - la: (ni)
+    - libroj: lipu
     - '?'
-- 
-  demando: Will you need more than a quarter of the year for those jobs?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - bezonos: will need
-    - pli: more
-    - ol: than
-    - kvaronan: quarter
-    - jaron: year
-    - por: for
-    - tiuj: those
-    - laboroj: jobs
+-
+  demando: sina wile e tenpo, pi mute tawa kipisi pi tenpo sike suno, tawa pali ni, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - bezonos: wile, tenpo kama
+    - pli: mute
+    - ol: tawa
+    - kvaronan: kipisi tu tu pi
+    - jaron: tenpo sike suno
+    - por: tawa
+    - tiuj: ni
+    - laboroj: pali
     - '?'
-- 
-  demando: Why is it that the colder it is, the longer we wait?
-  rektatraduko: 
-    - Kial: Why
-    - estas: is
-    - des: the
-    - pli: more
-    - malvarma: cold
-    - ',' 
-    - ju: the
-    - pli: more
-    - longe: long
-    - ni: we
-    - atendas: wait
+-
+  demando: tenpo li lete mute la, mi mute li awen lon tenpo suli, tan seme?
+  rektatraduko:
+    - Kial: tan seme
+    - estas: li
+    - des: ni la mute kin
+    - pli: mute
+    - malvarma: lete
+    - ','
+    - ju: mute la
+    - pli: mute
+    - longe: tenpo suli
+    - ni: mi mute
+    - atendas: awen
     - '?'
-- 
-  demando: Would you be happy with any man?
-  rektatraduko: 
-    - Ĉu: Whether
-    - vi: you
-    - estus: would be
-    - kontenta: happy
-    - kun: with
-    - iu: any
-    - ajn: ever
-    - viro: man
+-
+  demando: sina ken pilin pona poka mije ale, anu seme?
+  rektatraduko:
+    - Ĉu: anu seme
+    - vi: sina
+    - estus: li, ken
+    - kontenta: pilin pona
+    - kun: poka
+    - iu: ale
+    - ajn: ale
+    - viro: mije
     - '?'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/03.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/03.yml
@@ -1,22 +1,20 @@
 - antaŭĉambro:
-  - anteroom
-  - chamber
-  - antechamber
-  - waiting room
-- malamiko: enemy
-- malantaŭ: behind
-- antaŭvidi: to foresee
-- malrapida: slow
-- trarigardi: to look through
-- junulo: teenager
-- malmulte: less
-- finfine: eventually
-- malriĉulo: poor
-- tagmanĝo: lunch
-- tralegi: 
-  - to read through
-  - to skim
-- malnova: old
-- laborejo: workplace
-- travidebla: transparent
-- trinkebla: drinkable
+  - tomo open
+  - tomo lili pi sinpin
+- malamiko: jan utala
+- malantaŭ: lon monsi
+- antaŭvidi: lukin e tenpo kama
+- malrapida: tawa lili
+- trarigardi: lukin insa
+- junulo: jan lili
+- malmulte: mute lili
+- finfine: lon pini la
+- malriĉulo: jan pi mani lili
+- tagmanĝo: moku pi tenpo suno
+- tralegi:
+  - lukin e lipu ale
+  - lukin e lipu kepeken tenpo lili
+- malnova: pi tenpo pini
+- laborejo: tomo pali
+- travidebla: ken lukin insa
+- trinkebla: ken moku

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/04.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/04.yml
@@ -1,17 +1,17 @@
-﻿- enfali: to fall into
-- ellabori: to work on 
-- scivola: curious
-- trilingva: trilingual
-- reiri: to go back
-- enmeti: to put inside
-- dektaga: ten days
-- elpreni: to take out
+- enfali: tawa anpa lon insa
+- ellabori: pali pona e
+- scivola: wile sona
+- trilingva: pi toki tu wan
+- reiri: tawa sin
+- enmeti: pana lon insa
+- dektaga: pi tenpo suno 10
+- elpreni: kama jo tan insa
 - malfermi: open
-- eldoni: to give out
-- eldonisto: editor
+- eldoni: pana tawa jan mute
+- eldonisto: jan pi pana lipu
 - okdek ses: '86'
-- revidi:  to see again
-- reveni: to come back
-- internacia: international
-- piediri: to go by foot
+- revidi: lukin sin
+- reveni: kama sin
+- internacia: pi ma mute
+- piediri: tawa noka
 - dumil tri: '2003'

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/05.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/05.yml
@@ -1,24 +1,19 @@
-﻿- sinjorino:
-  - lady
-  - Mrs
-  - Mrs.
-- malmultekosta: cheap
-- ĉiutaga: everyday
-- intertempe: in the meantime
-- plenplena: 
-  - packed
-  - crowded
-  - full
-- nuntempe: 
-  - currently
-  - nowadays
-  - these days
-- malhelpi: to hinder
-- vendejo: store
-- edzino: wife
-- ĉiujare: every year
-- jarcento: century
-- kvarmonate: every four months
-- alveturi: to travel to
-- pli multekosta: more expensive
-- la plej juna: the youngest
+- sinjorino:
+  - jan meli
+  - meli
+- malmultekosta: mani lili
+- ĉiutaga: pi tenpo suno ale
+- intertempe: lon tenpo insa
+- plenplena:
+  - jo e ijo mute
+  - pi jan mute
+- nuntempe: lon tenpo ni
+- malhelpi: ike tawa
+- vendejo: tomo esun
+- edzino: meli olin
+- ĉiujare: lon tenpo sike suno ale
+- jarcento: tenpo pi sike suno mute
+- kvarmonate: lon tenpo mun tu tu
+- alveturi: kama kepeken tomo tawa
+- pli multekosta: pi mani mute
+- la plej juna: pi lili nanpa wan

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/06.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/06.yml
@@ -1,21 +1,17 @@
-﻿- leterportisto: postman
-- hejmlando: homeland
-- iomete: a little
-- bonege: great
-- vespermanĝo: supper
-- prizorgi: take care of
-- espereble: hopefully
-- altkvalita: high quality
-- pripensi: to think over
-- depreni: to take away
-- loĝejo: flat
-- dufoje: twice
-- multfoje: multiple times
-- nomiĝi: to be called
-- ruĝiĝi: 
-  - blush
-  - redden
-- libreto: 
-  - a little book
-  - booklet
-- varmega: hot
+- leterportisto: jan pi tawa lipu toki
+- hejmlando: ma mama
+- iomete: lili
+- bonege: pona mute
+- vespermanĝo: moku pi tenpo pimeja
+- prizorgi: lukin pona e
+- espereble: ken la pona
+- altkvalita: pi pona mute
+- pripensi: pilin e ijo
+- depreni: weka e
+- loĝejo: tomo
+- dufoje: tenpo tu
+- multfoje: tenpo mute
+- nomiĝi: jo e nimi
+- ruĝiĝi: kama loje
+- libreto: lipu lili
+- varmega: seli mute

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/07.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/07.yml
@@ -1,18 +1,16 @@
-﻿- rideti: to smile
-- tranokto: overnight stay
-- foriri: to go away
-- forlasi: to leave
-- ekde: since
-- formanĝi: to eat up
-- forpreni: to take away
-- laŭeble: 
-  - if possible
-  - when possible 
-- saĝulo: wise
-- ekstari: to stand up
-- poŝtkarto: postcard
-- diableto: little devil
-- senutila: useless
-- elkuri: to run out of
-- ekami: to fall in love
-- ĝisnuna: until now
+- rideti: uta pona
+- tranokto: lape lon tomo ante
+- foriri: tawa weka
+- forlasi: weka tan
+- ekde: tan tenpo
+- formanĝi: moku e ale
+- forpreni: weka e ijo
+- laŭeble: ken la
+- saĝulo: jan pi sona mute
+- ekstari: kama sewi
+- poŝtkarto: lipu sitelen
+- diableto: kon ike lili
+- senutila: pona ala
+- elkuri: tawa wawa tan insa
+- ekami: kama olin
+- ĝisnuna: tawa tenpo ni

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/08.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/08.yml
@@ -1,20 +1,20 @@
-﻿- subteni: to support
-- malaperigi: to let disappear
-- elteni: to endure
-- utiligi: to use
-- deteni sin: to abstain
-- alivorte: in other words
-- sinteno: behaviour
-- loĝigi: accommodate
-- memorigi: to remember
-- plifortigi: to make something stronger
-- renovigo: renewal
-- utiligebla: useful
-- aperigi: to display
-- forigi: to take away
-- purigi: to clean
-- senmorta: immortal
-- malplenigi: to empty 
-- kelkfoje: sometimes
-- transdoni: to hand over
-- superrigardo: overview
+- subteni: pana e wawa
+- malaperigi: weka e ijo
+- elteni: awen lon ike
+- utiligi: kepeken
+- deteni sin: awen e ona sama
+- alivorte: kepeken nimi ante
+- sinteno: nasin pali
+- loĝigi: pana e tomo
+- memorigi: kama e sona
+- plifortigi: wawa e ijo
+- renovigo: kama sin
+- utiligebla: ken kepeken
+- aperigi: pana lon lukin
+- forigi: weka e
+- purigi: weka e jaki
+- senmorta: pi moli ala
+- malplenigi: weka e ijo lon poki
+- kelkfoje: tenpo lili la
+- transdoni: pana tawa jan ante
+- superrigardo: lukin pi ale

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/09.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/09.yml
@@ -1,16 +1,16 @@
-﻿- nekredebla: unbelievable
-- organizado: organisation
-- informado: information
-- libervole: voluntarily
-- parolado: speech
-- survoje: on the way
-- homaro: mankind
-- kredeble: credible
-- kunvojaĝi: to travel with
-- manĝaĵo: food
-- novaĵo: news
-- vagonaro: train
-- ĉirkaŭaĵo: surroundings
-- parolrajto: right to speak
-- domaĉo: ruin
-- tiuokaze: this time
+- nekredebla: pi pilin lon ala
+- organizado: nasin pi kulupu
+- informado: sona
+- libervole: tan wile ona sama
+- parolado: toki tawa jan mute
+- survoje: lon nasin
+- homaro: jan ale
+- kredeble: ken la lon
+- kunvojaĝi: tawa poka
+- manĝaĵo: moku
+- novaĵo: sona sin
+- vagonaro: tomo tawa linja
+- ĉirkaŭaĵo: ma poka
+- parolrajto: ken toki
+- domaĉo: tomo pakala
+- tiuokaze: ni la

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/10.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/10.yml
@@ -1,16 +1,13 @@
-﻿- verŝajne: probably
-- tutsimple: simply
-- neŭtraleco: neutrality
-- tiurilate: in this regard
-- universaleco: universality
-- ebleco: possibility
-- partopreni: to take part
-- plejparte: 
-  - mostly
-  - mainly
-  - for the most part
-- samtempe: at the same time
-- anstataŭigi: to replace
-- elĵeti: to throw out
-- finiĝi: to end
-- informiĝi: to inform oneself
+- verŝajne: ken la
+- tutsimple: kepeken nasin pona
+- neŭtraleco: nasin pi poka ala
+- tiurilate: lon nasin ni
+- universaleco: nasin pi ale
+- ebleco: ken
+- partopreni: kama lon kulupu
+- plejparte: mute la
+- samtempe: lon tenpo sama
+- anstataŭigi: ante e ijo
+- elĵeti: tawa e ijo weka
+- finiĝi: kama pini
+- informiĝi: kama sona

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/11.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/11.yml
@@ -1,13 +1,13 @@
-- estraro: board
-- tagmeze: middays
-- posttagmeze: in the afternoon
-- malsata: hungry
-- interkonsenti: to agree
-- manĝilaro: cutlery
-- vidpunkto: point of view
-- malfermilo: opener
-- noktomezo: midnight
-- publikigi: to publish
-- pagigi: to let pay
-- duflanka: bilateral
-- aliflanke: on the other hand
+- estraro: kulupu lawa
+- tagmeze: lon insa pi tenpo suno
+- posttagmeze: lon tenpo suno pini
+- malsata: wile moku
+- interkonsenti: kama wile sama
+- manĝilaro: kulupu pi ilo moku
+- vidpunkto: nasin lukin
+- malfermilo: ilo open
+- noktomezo: insa pi tenpo pimeja
+- publikigi: pana tawa jan ale
+- pagigi: kama jo e mani tan jan
+- duflanka: pi poka tu
+- aliflanke: lon poka ante

--- a/enhavo/tradukenda/tok/ekzercoj/traduku/12.yml
+++ b/enhavo/tradukenda/tok/ekzercoj/traduku/12.yml
@@ -1,14 +1,12 @@
-- prezentaĵo: presentation
-- skribaĉi: 
-  - to scrawl
-  - to scribble
-- klarigi: to clarify
-- pretigi: to make ready
-- ĉevalaĉo: horse
-- disdoni: to distribute
-- dekono: tenth
-- duonigi: to cut in half
-- virinaĉo: bitch
-- ĉiumomente: every moment
-- renkontiĝo: meeting
-- retrovi: to find again
+- prezentaĵo: pana lukin
+- skribaĉi: sitelen ike
+- klarigi: pana e sona
+- pretigi: pali e ken open
+- ĉevalaĉo: soweli ike
+- disdoni: pana tawa jan mute
+- dekono: kipisi pi nanpa 10
+- duonigi: kipisi e ijo tawa tu
+- virinaĉo: meli ike
+- ĉiumomente: lon tenpo ale
+- renkontiĝo: kama poka pi jan mute
+- retrovi: kama lukin sin e

--- a/enhavo/tradukenda/tok/fasado/ekzercoj.yml
+++ b/enhavo/tradukenda/tok/fasado/ekzercoj.yml
@@ -1,7 +1,7 @@
 Alklaku la vortojn por vidi ilian tradukon.: o luka e nimi o lukin e kon ona.
 Forigu: o weka e ante
 Kompletigu la frazojn: o pana e toki weka
-Por la Esperantaj literoj vi ankaŭ rajtas skribi cx, gx, hx, jx, sx kaj ux.: 'sitelen pi toki Epelanto la sina ken sitelen sama ni: cx, gx, hx, jx, sx and ux.'
+Por la Esperantaj literoj vi ankaŭ rajtas skribi cx, gx, hx, jx, sx kaj ux.: 'sitelen pi toki Epelanto la sina ken sitelen sama ni: cx, gx, hx, jx, sx en ux.'
 Solvu: o sona e pana pona
 Traduku: o toki Epelanto
 Traduku kaj respondu: o toki Epelanto o pana e sona wile

--- a/enhavo/tradukenda/tok/gramatiko/01.md
+++ b/enhavo/tradukenda/tok/gramatiko/01.md
@@ -4,8 +4,9 @@ toki Epelanto la sitelen ni li lon: a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ
 
 open toki la sitelen li suli (_"Vi estas mia amiko."_ li pona, _"vi estas mia amiko."_ li ike).
 
-> [!NOTE]
-> Mi ankoraŭ traduku tiun ĉi parton.
+sitelen ale li jo e kalama wan taso, li ante ala. sina sona e sitelen la, sina ken toki e nimi ale.
+
+sitelen pi nena sewi (*ĉ, ĝ, ĥ, ĵ, ŝ, ŭ*) li jo e kalama ona sama, ante tan sitelen pi nena ala.
 
 # kalama
 

--- a/enhavo/tradukenda/tok/gramatiko/03.md
+++ b/enhavo/tradukenda/tok/gramatiko/03.md
@@ -31,7 +31,7 @@ pini nimi li *-e* la ona li toki e nasin pali.
 - *poste* – pini la.
 
 
-# The Preposition *Malantaŭ*
+# nimi poki *malantaŭ*
 
 *malantaŭ* - lon monsi
 

--- a/enhavo/tradukenda/tok/gramatiko/06.md
+++ b/enhavo/tradukenda/tok/gramatiko/06.md
@@ -26,7 +26,7 @@ pini ni li lili e ijo.
 
 pini ni li suli e ijo.
 
-- *libr_ego_*    – lipu suli
+- *libr__eg__o*  – lipu suli
 - *varm__eg__a*  – seli suli
 - *bel__eg__a*   – pona lukin suli
 - *bon__eg__a*   – pona suli

--- a/enhavo/tradukenda/tok/gramatiko/07.md
+++ b/enhavo/tradukenda/tok/gramatiko/07.md
@@ -1,52 +1,44 @@
-# Negation
+# nimi pi ala
 
-The rules for negation are much as in English.
+toki Epelanto la, sina kepeken nimi pi ala wan taso lon toki wan. sina kepeken ala e nimi pi ala tu.
 
-
-- *__Nek__ li __nek__ ŝi respondis.*   – Neither he or she answered.
-- *Vi __nek__ sidas __nek__ rigardas.* – You are neither sitting nor looking.
-
-- *Mi __neniam__ diros al iu.* – I shall never tell anyone. (*Mi neniam diros al neniu* is wrong in Esperanto just as "I shan't never tell no-one" is in English.)
-
+- *__Nek__ li __nek__ ŝi respondis.* – ona mije li toki ala. ona meli li toki ala kin.
+- *Vi __nek__ sidas __nek__ rigardas.* – sina lon supa ala. sina lukin ala.
+- *Mi __neniam__ diros al iu.* – mi toki ala tawa jan, lon tenpo ale.
 
 # *Mem*
 
-*Mem* means "self" (myself, yourself, himself etc.) and is used to emphasize the noun or pronoun it follows. (Compare *si*, reflexive, lesson 4.)
+nimi *mem* li toki e ni: jan li pali e ijo, ona sama. (o lukin e nimi *si* lon lipu sona nanpa 4.)
 
-- *Mi __mem__ faris tion.*  – I myself did that, I did that myself.
+- *Mi __mem__ faris tion.* – mi sama li pali e ni.
 
-# Bye…
+# o tawa pona
 
-There are various ways of saying "goodbye" in Esperanto, but the most usual is 
+toki Epelanto la, nasin mute li lon, tawa toki pi "tawa pona". nasin nanpa wan li ni:
 
-- *ĝis la revido* – literally  "until the re-seeing" (Compare English "see you", French "au revoir".)
+- *ĝis la revido* – kalama li sama "tawa tenpo pi lukin sin"
 
-Alternatively it may be said without the article:
+sina ken weka e nimi *la* kin:
 
-- *ĝis revido*.
+- *ĝis revido*
 
+# open *ek-*
 
-# The Prefix *ek-*
+open ni li toki e ni:
 
-shows
+1. pali li open, anu
+2. pali li lon kepeken tenpo lili.
 
-1. the beginning of an action, or
-2. a sudden momentary action.
+- *__ek__paroli* – open toki
+- *__ek__silenti* – kama kalama ala
+- *__ek__sidi* – kama lon supa
+- *__ek__ridi* – open mu musi
 
-Examples:
+# pini *-aĵ*
 
-- *__ek__paroli*  – to start speaking
-- *__ek__silenti* – to fall silent
-- *__ek__sidi*    – to sit down, to take a seat
-- *__ek__ridi*    – to burst out laughing
- 
+pini ni li toki e ijo pi sijelo lon:
 
-# The Suffix *-aĵ*
-
-means "thing", a concrete object:
-
-- *manĝ__aĵ__o*  – food
-- *trink__aĵ__o* – drink, beverage
-- *bel__aĵ__o*   – something beautiful
-- *send__aĵ__o*  – something sent, a missive
- 
+- *manĝ__aĵ__o* – moku
+- *trink__aĵ__o* – telo moku
+- *bel__aĵ__o* – ijo pona lukin
+- *send__aĵ__o* – ijo pi pana tawa weka

--- a/enhavo/tradukenda/tok/gramatiko/08.md
+++ b/enhavo/tradukenda/tok/gramatiko/08.md
@@ -1,25 +1,24 @@
-# The Preposition *Da*
+# nimi poki *da*
 
-is a preposition used in expressions of weight, measure or quantity:
+nimi *da* li lon poka pi nimi pi mute, pi suli, pi pana:
 
-- *kilogramo __da__ sukero* – a kilo of sugar
-- *glaso __da__ akvo* – a glass of water 
-- *multe __da__ ideoj* – a lot of ideas 
+- *kilogramo __da__ sukero* – ko suwi mute
+- *glaso __da__ akvo* – telo lon poki
+- *multe __da__ ideoj* – sona mute
 
-# The Suffix *-ig*
+# pini *-ig*
 
-This "causative" suffix means "to make, cause to be":
+pini ni li toki e ni: jan li pali e ijo, ijo li kama ante.
 
-- *bel__ig__i* – to beautify
-- *malplen__ig__i* – to empty
-- *san__ig__i* – to cure, to heal
-- *mort__ig__i* – to kill 
+- *bel__ig__i* – pona lukin e ijo
+- *malplen__ig__i* – weka e ijo lon poki
+- *san__ig__i* – pona e sijelo
+- *mort__ig__i* – moli e
 
-# The Suffix *-aĉ*
+# pini *-aĉ*
 
-shows the speaker has a low opinion of the thing in question:
+pini ni li toki e ni: jan li pilin ike tawa ijo.
 
-- *hund__aĉ__o* – cur
-- *knab__aĉ__o* – brat
-- *skrib__aĉ__i* – to scribble
- 
+- *hund__aĉ__o* – soweli ike
+- *knab__aĉ__o* – jan lili ike
+- *skrib__aĉ__i* – sitelen ike

--- a/enhavo/tradukenda/tok/gramatiko/09.md
+++ b/enhavo/tradukenda/tok/gramatiko/09.md
@@ -1,60 +1,48 @@
-# The Conditional Mood
+# nasin *-us*
 
-is expressed by the verb ending *-us*:
+nimi pali pini *-us* li toki e ni: ijo li ken lon, taso li lon ala.
 
-- *mi kred__us__* – I would believe, I should think
-- *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – If I were (was) well I would (should) be very happy.
+- *mi kred__us__* – mi pilin lon, ken la
+- *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – mi jo e sijelo pona la, mi pilin pona mute (taso ni li lon ala).
 
 # *Kvazaŭ*
 
-is used as a conjunction, normally followed by the conditional:
+nimi *kvazaŭ* li sama nimi "sama". nimi pali pi poka ona li kepeken *-us*:
 
-- *Vi sidas tie __kvazaŭ__ vi estus riĉulo.* – You are sitting there as if you were a wealthy man.
+- *Vi sidas tie __kvazaŭ__ vi estus riĉulo.* – sina lon supa sama jan pi mani mute.
+- *Vi sidas tie __kvazaŭ__ riĉulo.* – sina lon supa sama jan pi mani mute.
 
-It can also by used elliptically:
+# pini *-ad*
 
-- *Vi sidas tie __kvazaŭ__ riĉulo.* – You are sitting there as if rich.
- 
-# The Suffix *-ad*
+pini ni li ante e nimi pali tawa nimi ijo:
 
-is used to make a verb form a noun:
+- *kanti* – kalama musi
+  - *kant__ad__o* – kalama musi (ijo)
 
-- *kanti* – to sing
-  - *kant__ad__o* – (the act of) singing
-- *suferi* – to suffer
-	- *sufer__ad__o* – suffering
+ona li toki kin e pali awen anu pali pi tenpo mute:
 
-It also conveys the idea of continued or repeated action:
+- *rigardi* – lukin
+  - *rigard__ad__i* – lukin awen
+- *demandi* – wile sona
+  - *demand__ad__i* – wile sona lon tenpo mute
 
-- *rigardi* – to look
-  - *rigard__ad__i* – to go on looking, to gaze
-- *demandi* – to ask a question
-	- *demand__ad__i* – to keep asking questions
-- *informo* – information
-	- *inform__ad__o* – publicity
+# pini *-ar*
 
+pini ni li toki e kulupu ijo:
 
-# The Suffix *-ar*
+- *arbo* – kasi suli
+  - *arb__ar__o* – ma kasi
+- *vagono* – tomo tawa
+  - *vagon__ar__o* – tomo tawa linja
+- *vorto* – nimi
+  - *vort__ar__o* – lipu nimi
 
-indicates a collection of objects viewed as a whole:
+# pini *-um*
 
-- *arbo* – tree
-	- *arb__ar__o* – wood, forest
-- *vagono* – coach
-	- *vagon__ar__o* – train
-- *vorto* – word
-	- *vort__ar__o* – dictionary
- 
+pini *-um* li pini pi kon sona ala. kon ona li ante tan nimi tawa nimi:
 
-# The Suffix *-um*
-
-is a joker suffix, with no fixed meaning:
-
-- *plena* – full
-  -  *plen__um__i* – to fulfil
-- *proksima* – close
-  -  *proksim__um__e* – approximately
-- *suno* – sun 
-	- *sun__um__i* – to sunbath 
-- *malvarm__um__i* – to catch a cold
- 
+- *plena* – pi ijo mute
+  - *plen__um__i* – pali e wile
+- *suno* – suno
+  - *sun__um__i* – kama jo e suno lon sijelo
+- *malvarm__um__i* – kama pi sijelo ike, tan lete

--- a/enhavo/tradukenda/tok/gramatiko/10.md
+++ b/enhavo/tradukenda/tok/gramatiko/10.md
@@ -1,29 +1,27 @@
-# The Suffix *-an*
+# pini *-an*
 
-member of, somebody belonging to:
+pini ni li toki e jan pi kulupu:
 
-- *klub__an__o*    – club member
-- *amerik__an__o*  – American
-- *samland__an__o* – fellow-countryman
-- *samide__an__o*  – fellow-supporter (of an idea: in particular, a fellow Esperantist)
- 
+- *klub__an__o* – jan pi kulupu musi
+- *amerik__an__o* – jan pi ma Mewika
+- *samland__an__o* – jan pi ma sama
+- *samide__an__o* – jan pi pilin sama (jan pi toki Epelanto)
 
-# The Suffix *-ec*
+# pini *-ec*
 
-makes an abstract noun, indicating a state of quality:
+pini ni li pali e nimi ijo tan nimi kule. ona li toki e nasin pi ijo:
 
-- *bel__ec__o*   – beauty
-- *varm__ec__o*  – warmth
-- *simpl__ec__o* – simplicity
- 
+- *bel__ec__o* – pona lukin
+- *varm__ec__o* – seli
+- *simpl__ec__o* – nasin pona
 
-# The Suffix *-uj*
+# pini *-uj*
 
-forms the name of a container, country or plant:
+pini ni li toki e poki, anu ma, anu kasi:
 
-- *manĝ__uj__o*  – manger, food-trough
-- *cindr__uj__o* – ashtray
-- *Franc__uj__o* – France
-- *Aŭstr__uj__o* – Austria
-- *pomo*   – apple
-	- *pom__uj__o*   – apple tree
+- *manĝ__uj__o* – poki moku
+- *cindr__uj__o* – poki pi ko pimeja
+- *Franc__uj__o* – ma Panse
+- *Aŭstr__uj__o* – ma Osi
+- *pomo* – kili
+  - *pom__uj__o* – kasi pi kili

--- a/enhavo/tradukenda/tok/gramatiko/11.md
+++ b/enhavo/tradukenda/tok/gramatiko/11.md
@@ -1,4 +1,4 @@
-# The Suffix *-il*
+# pini *-il*
 
 pini ni li toki e ni: ijo li ilo li ken e ijo nimi.
 

--- a/enhavo/tradukenda/tok/gramatiko/12.md
+++ b/enhavo/tradukenda/tok/gramatiko/12.md
@@ -1,27 +1,23 @@
-# *Ju … des*
+# *ju … des*
 
-- *Ju pli longe, des pli bone.* – the longer the better
- 
+- *Ju pli longe, des pli bone.* – tenpo li suli la, ijo li pona kin.
 
 # *Ajn*
 
-- *kiom ajn* – however much
- 
+- *kiom ajn* – mute ale la
 
-# The Prefix *dis-*
+# open *dis-*
 
-denotes separation, dispersal:
+open ni li toki e ni: ijo li tawa nasin mute, li kipisi.
 
-- *__dis__ĵeti* – to scatter
-- *__dis__sendi* – to broadcast
- 
+- *__dis__ĵeti* – tawa e ijo tawa nasin mute
+- *__dis__sendi* – pana e sona tawa jan mute
 
-# The Suffix *-on*
+# pini *-on*
 
-denotes a fraction:
+pini ni li toki e kipisi nanpa:
 
-- *du__on__o*   – half
-- *tri__on__o*  – third
-- *kvar__on__o* – quarter
-- *ses__on__o*  – sixth
- 
+- *du__on__o* – kipisi tu (wan pi tu)
+- *tri__on__o* – wan pi tu wan
+- *kvar__on__o* – wan pi tu tu
+- *ses__on__o* – wan pi luka wan

--- a/enhavo/tradukenda/tok/vortaro/adverbo.yml
+++ b/enhavo/tradukenda/tok/vortaro/adverbo.yml
@@ -9,7 +9,7 @@ hieraŭ: suno pini poka la
 hodiaŭ: suno ni la
 jam: (pali li lon li pini)
 jes: ni li lon
-kvazaŭ: sama ni:
+kvazaŭ: "sama ni:"
 morgaŭ: suno kama poka la
 nun: tenpo ni la
 nur: (ijo) taso

--- a/enhavo/tradukenda/tok/vortaro/grava_esprimo.yml
+++ b/enhavo/tradukenda/tok/vortaro/grava_esprimo.yml
@@ -1,13 +1,12 @@
-'ĉu ne': isn't it
-'iom post iom': little by little
-'pli-malpli': more or less
-'mem kompreneble': obviously
-'temas pri': it is about
-'iomete': 
-- a little
-'rilate al': relating to
-'ni diru': let's say
-'verŝajne': probably
-'eble': 
-- maybe
-- perhaps
+'ĉu ne': anu seme?
+'iom post iom': lili lili
+'pli-malpli': mute anu lili
+'mem kompreneble': sona la
+'temas pri': ona li toki e
+'iomete': lili
+'rilate al': pi ijo ni
+'ni diru': o toki e ni
+'verŝajne': ken la
+'eble':
+- ken
+- ken la

--- a/enhavo/tradukenda/tok/vortaro/konjunkcio.yml
+++ b/enhavo/tradukenda/tok/vortaro/konjunkcio.yml
@@ -1,9 +1,9 @@
 aŭ: anu
 kaj: en/li/e (nanpa mute)
-ke: ni: 
+ke: "ni:"
 kvankam: taso ...
 nek: ... ala (anu ... ala)
 ol: tawa (sina toki e ante pi ijo tu)
 se: la
 sed: taso ...
-ĉar: tan ni:
+ĉar: "tan ni:"

--- a/enhavo/tradukenda/tok/vortaro/novaj.yml
+++ b/enhavo/tradukenda/tok/vortaro/novaj.yml
@@ -1,54 +1,40 @@
-aŭskult: to listen
-divers: diverse
-ekzempl: example
-glas: glass
-infan: child
-inform: to inform
-kant: to sing
-kien: where to
-konsent: to consent
-las: to let
-lingv: language
-loĝ:
-- to live
-- to inhabit
-- to reside
-manier: manner
-monat: month
-mond: world
-naci: nation
-organiz: to organize
-plor:
-- to weep
-- to cry
-pluv: to rain
-poŝ: pocket
-poŝt: post
-proksimum: approximate
-publik: public
-punkt: point
-pur:
-- clean
-- pure
-rakont: to tell
-rimark: to notice
-seĝ: chair
-sia: 
-- his own
-- her own
-- its own
-- one's own, 
-- their own
-simpl: simple
-suk: juice
-terur: terrible
-tut: whole
-universal: universal
-rilat: to relate
-sat:
-- to be full
-- sated
-ag: to act
-aper: to appear
-sent: to feel
-kred: to believe
+aŭskult: kute
+divers: ante mute
+ekzempl: ijo sama
+glas: poki telo
+infan: jan lili
+inform: pana e sona
+kant: kalama musi
+kien: tawa ma seme
+konsent: wile sama
+las: ken e
+lingv: toki
+loĝ: lon tomo
+manier: nasin
+monat: tenpo mun
+mond: ma ale
+naci: kulupu pi ma wan
+organiz: pona e nasin
+plor: pana e telo oko
+pluv: telo tan sewi
+poŝ: poki len
+poŝt: nasin pi lipu toki
+proksimum: lon poka
+publik: pi jan ale
+punkt: ijo lili
+pur: jaki ala
+rakont: toki e ijo
+rimark: kama lukin
+seĝ: supa pi lon
+sia: ona sama
+simpl: pona
+suk: telo kili
+terur: ike a
+tut: ale
+universal: pi ale
+rilat: nasin poka
+sat: pini moku
+ag: pali
+aper: kama lon
+sent: pilin
+kred: pilin lon

--- a/enhavo/tradukenda/tok/vortaro/participo.yml
+++ b/enhavo/tradukenda/tok/vortaro/participo.yml
@@ -1,8 +1,8 @@
-ant: present active
-int: past active
-ont: future active
-unt: conditional active
-at:  present passive
-it:  past passive
-ot:  future passive
-ut:  conditional passive
+ant: pali lon tenpo ni
+int: pali lon tenpo pini
+ont: pali lon tenpo kama
+unt: pali ken
+at: kama pali lon tenpo ni
+it: kama pali lon tenpo pini
+ot: kama pali lon tenpo kama
+ut: kama pali ken

--- a/enhavo/tradukenda/tok/vortaro/partikulo.yml
+++ b/enhavo/tradukenda/tok/vortaro/partikulo.yml
@@ -1,13 +1,8 @@
-ajn:
-- any
-- at all
-- '-ever'
-des: the (more, less)
-jen: here is
-ju: the (more, less)
-mem: self
-ne:
-- 'no'
-- not
-ĉi: this
-ĉu: whether (starts questions)
+ajn: ale (ijo ale)
+des: ni la mute kin
+jen: o lukin e ni
+ju: mute la
+mem: ona sama
+ne: ala
+ĉi: ni
+ĉu: anu seme (open pi wile sona)

--- a/enhavo/tradukenda/tok/vortaro/prefikso.yml
+++ b/enhavo/tradukenda/tok/vortaro/prefikso.yml
@@ -1,16 +1,12 @@
 dis:
-- dispersal
-- breaking up
-ek: 
-- beginning of action
-- suddenness 
-for:
-- away
-- 'off'
-ge:
-- pertaining of both sexes 
-mal:
-- opposite 
-re: 
-- again
-- re- 
+- tawa nasin mute
+- kipisi
+ek:
+- open pali
+- kepeken tenpo lili
+for: weka
+ge: mije en meli
+mal: ante (sama ala)
+re:
+- sin
+- lon tenpo sin

--- a/enhavo/tradukenda/tok/vortaro/prepozicio.yml
+++ b/enhavo/tradukenda/tok/vortaro/prepozicio.yml
@@ -1,58 +1,43 @@
-al: 
-- to
-- in the direction of
-anstataŭ: instead of
+al: tawa
+anstataŭ: ni li lon, ijo ante li lon ala
 antaŭ:
-- before
-- in front of
-apud: next to
-da: of
+- lon sinpin
+- lon tenpo pini
+apud: lon poka
+da: pi
 de:
-- of
-- from
-dum: during
-ekde: since
-ekster: outside of
-el:
-- from
-- out of
-en: in
-inter: 
-- between
-- among
-je:
-- of
-- with
-- in
-kontraŭ: 
-- against
-krom: 
-- besides
-- in addition to
-kun: 
-- with
-laŭ: 
-- according to
-- along
-per: 
-- by means of
-- with
-por: for
-post: after
-pri:
-- about
-- concerning
-pro: because of
-sen: without
-sub:
-- under
-- beneath
-super: 
-- over
-- above
-sur: 'on'
-tra: through
-trans: across
-ĉe: at
-ĉirkaŭ: around
-ĝis: until
+- pi
+- tan
+dum: lon tenpo ni
+ekde: tan tenpo
+ekster: lon selo
+el: tan insa
+en: lon
+inter:
+- lon insa
+- lon kulupu
+je: lon
+kontraŭ: utala
+krom:
+- kin
+- weka pi
+kun: poka
+laŭ:
+- lon nasin
+- kepeken nasin
+per: kepeken
+por: tawa
+post:
+- lon monsi
+- lon tenpo kama
+pri: pi
+pro: tan
+sen: jo ala e
+sub: lon anpa
+super: lon sewi
+sur: lon sewi
+tra: lon insa
+trans: tawa poka ante
+ĉe: lon
+ĉirkaŭ: lon poka ale
+ĝis: tawa tenpo pini

--- a/enhavo/tradukenda/tok/vortaro/pronomo.yml
+++ b/enhavo/tradukenda/tok/vortaro/pronomo.yml
@@ -1,10 +1,10 @@
-ili: they
-li: he
-lia: his
-mi: I
-mia: my
-ni: we
-oni: one (indefinite pronoun)
-vi: you (can be both singular and plural)
-ĝi: it
-ŝi: she
+ili: ona mute
+li: ona (mije)
+lia: ona (mije)
+mi: mi
+mia: mi
+ni: mi mute
+oni: jan
+vi: sina
+ĝi: ona (ijo)
+ŝi: ona (meli)

--- a/enhavo/tradukenda/tok/vortaro/radiko.yml
+++ b/enhavo/tradukenda/tok/vortaro/radiko.yml
@@ -1,316 +1,300 @@
-afer: matter
-agrabl: pleasant
-akcept: to accept
-akv: water
-ali: another
-alt: high
-am: to love
-amik: friend
-arb: tree
+afer: ijo
+agrabl: pona
+akcept: kama jo
+akv: telo
+ali: ante
+alt: sewi
+am: olin
+amik: jan pona
+arb: kasi suli
 aspekt:
-- to look
-- to seem
-atend: to wait
-atent: to pay attention
-aĉet: to buy
-aŭd: to hear
-aŭt: car
-aŭtoritat: authority
-bedaŭr: to regret
-bel: beautiful
-best: animal
-bezon: to need
-bien:
-- estate
-- land
-bon: good
-branĉ: branch
-bru: noise
-buŝ: mouth
-cert: certain
-dank: to thank
-daŭr: to continue
-decid: to decide
-demand: to ask
-dev: to must
-dezir: to wish
-diabl: devil
-dik:
-- thick
-- fat
-dimanĉ: Sunday
-dir: to say
-direkt: direction
-doktor: doctor
-dolar: dollar
+- lukin
+- kama lukin sama
+atend: awen
+atent: kute pona
+aĉet: esun
+aŭd: kute
+aŭt: tomo tawa
+aŭtoritat: wawa lawa
+bedaŭr: pilin ike
+bel: pona lukin
+best: soweli
+bezon: wile
+bien: ma
+bon: pona
+branĉ: palisa kasi
+bru: kalama
+buŝ: uta
+cert: sona
+dank: toki pona tawa
+daŭr: awen
+decid: kama wile
+demand: wile sona
+dev: wile
+dezir: wile
+diabl: kon ike
+dik: suli
+dimanĉ: tenpo suno nanpa 7
+dir: toki
+direkt: nasin
+doktor: jan pi pona sijelo
+dolar: mani
 dolor:
-- to hurt
-- pain
-dolĉ: sweet
-dom: house
-don: to give
-dorm: to sleep
-doĝ: doge
-edz: husband
-efektiv: actually
-ekskurs: excursion
-esper: to hope
-est: to be
-facil: easy
-fakt: fact
-fal: to fall
-famili: family
-far: to do
-fart:
-- to feel
-- to be
-feliĉ: happy
-ferm: to close 
-fin: to end
-flank: side
-foj:
-- occasion
-- time
-forges: to forget
-form: form
-fort: strong
-fot: photo
-frat: brother
-fru: early
-fuŝ: to mess up
-gondol: gondola
-graf:
-- earl
-- count
-grand:
-- big
-- great
-grav: important
-halt: to stop
-hav: to have
-hejm: home
-help: to help
-hom: human
-hor: hour
-hotel: hotel
-ide: idea
-industri: industry 
-instru: to teach
-interes: to interest
-invit: to invite
-ir: to go
-itali: Italy
-jar: year
-jun: young
-kaf: coffee
-kalv: bald
-kap: head
-kapabl: capable
-kapt: to catch
-kar: dear
-kastel: castle
-kav: cave
-kelk: some
-kelner: waiter
-klar: clear
-klub: club
-knab: boy
-koler: anger
-kolor: color
-komenc: to begin
-kompren: to understand
-kon: to know
-kontent: satisfied
-kontrol: to check
-kor: heart
-korp: body
-kost: to cost
-kri: to scream
-kuir: to cook
-kuk: cake 
-kur: to run
-labor: to work
-lakt: milk
-lamp: lamp
-land: land
-larĝ: wide
-last: last
-laŭt: loud
-lecion: lesson
-leg: to read
-lern: to learn
-leter: letter
-liber: free
-libr: book
-lok: place
-long: long
-lud: to play
-lum: light
-man: hand
-mank: be lacking
-manĝ: to eat
-mar: sea
-maten: morning
-memor: to remember
-met: to put
-mez: middle
-milit: war
-minut: minute
-mir: to wonder
-moment: moment
-mon: money
-mont: mountain
-montr: to show
-mort: to die
-mov: to move
-mult: many
-muzik: music
-nask: to give birth
-natur: nature
-neces: necessary
-nokt: night
-nom: name
-not: note
-nov: new
-odor: smell
-oft: often
-okaz: to happen
-okul: eye
-onkl: uncle
+- pilin ike
+- pakala
+dolĉ: suwi
+dom: tomo
+don: pana
+dorm: lape
+doĝ: jan lawa
+edz: mije olin
+efektiv: lon la
+ekskurs: tawa musi
+esper: wile pona
+est: lon
+facil: pali lili
+fakt: ijo lon
+fal: tawa anpa
+famili: kulupu mama
+far: pali
+fart: pilin
+feliĉ: pilin pona
+ferm: open ala
+fin: pini
+flank: poka
+foj: tenpo
+forges: weka e sona
+form: sijelo
+fort: wawa
+fot: sitelen
+frat: jan sama (mije)
+fru: lon tenpo open
+fuŝ: pakala
+gondol: tomo tawa telo
+graf: jan lawa
+grand: suli
+grav: suli tawa pilin
+halt: kama awen
+hav: jo
+hejm: tomo
+help: pana e pona
+hom: jan
+hor: tenpo
+hotel: tomo lape
+ide: sona sin
+industri: kulupu pali
+instru: pana e sona
+interes: pilin wile
+invit: toki e ni, o kama
+ir: tawa
+itali: ma Italija
+jar: tenpo pi sike suno
+jun: lili
+kaf: telo wawa
+kalv: lawa pi linja ala
+kap: lawa
+kapabl: ken
+kapt: alasa
+kar: suli tawa pilin
+kastel: tomo lawa suli
+kav: lupa ma
+kelk: mute lili
+kelner: jan pi pana moku
+klar: sona pona
+klub: kulupu
+knab: jan lili (mije)
+koler: pilin utala
+kolor: kule
+komenc: open
+kompren: kama sona
+kon: sona
+kontent: pilin pona
+kontrol: lukin pona
+kor: insa pilin
+korp: sijelo
+kost: wile mani
+kri: kalama wawa
+kuir: seli e moku
+kuk: pan suwi
+kur: tawa wawa
+labor: pali
+lakt: telo mama
+lamp: ilo suno
+land: ma
+larĝ: suli lon poka
+last: nanpa pini
+laŭt: kalama suli
+lecion: lipu sona
+leg: lukin e lipu
+lern: kama sona
+leter: lipu toki
+liber: ken pi pali ale
+libr: lipu
+lok: ma
+long: linja suli
+lud: musi
+lum: suno
+man: luka
+mank: jo ala
+manĝ: moku
+mar: telo suli
+maten: tenpo pi open suno
+memor: awen e sona
+met: pana lon
+mez: insa
+milit: utala suli
+minut: tenpo lili
+mir: pilin nasa
+moment: tenpo lili
+mon: mani
+mont: nena suli
+montr: pana e lukin
+mort: moli
+mov: tawa
+mult: mute
+muzik: kalama musi
+nask: kama mama
+natur: ma pi pali jan ala
+neces: wile suli
+nokt: tenpo pimeja
+nom: nimi
+not: sitelen lili
+nov: sin
+odor: kon
+oft: tenpo mute la
+okaz: kama lon
+okul: oko
+onkl: mije pi kulupu mama
 opini:
-- to opinionate
-- to think
-ord: to order
-orel: ear
-pac: peace
-pag: to pay
-pan: bread
-paper: paper
-pardon: to forgive
-parol: to speak
-part: part
-pas: to pass
-patr: father
-paŝ: step
-pens: to think
-perd: to loose
-person: person
-pet: to request
-pez: heavy
-pied: foot
-plac: place
-plan: to plan
-plaĉ: to be pleasing
-plen: full
-polic: police
-pord: door
-port: to carry
-pov: can
-pren: to take 
-pret: ready
-prezent: to present
-problem: problem
-proksim: near
-promen: to stroll
-propon: to propose
-prov: to try
-rajt: to be allowed to
-rapid: fast
-raport: report
-real: real
-rekt: direct
-renkont: to meet
-respekt: to respect
-respond: to answer
-rest: to remain
-ricev: to receive
-rid: to laugh
-rigard: to look at
-riĉ: rich
-rol: role
-ruĝ: red
-salt: to jump
-salut: hello
-sam: same
-san: healthy
-saĝ: wise
-sci: to know
-sek: dry
-sekret: secret
-sekv: to follow
-semajn: week
-send: to send
-serĉ: to search
-si: reflexive pronoun
-sid: to sit
-silent: silent
-simil: similar
-sinjor:
-- gentleman
-- Mr.
-situaci: situation
-skrib: to write
-sol: alone
-son: to sound
-sovaĝ: wild
-sport: sport
-star: to stand
-strat: street
-subit: suddenly
-sufiĉ: sufficient
-sukces: success
-sun: sun
-supr: above
-tabl: table 
-tag: day
-te: tea
-telefon: phone
-temp: time
-temperatur: temperature
-ten: to hold
-teror: terror
-tim: to fear
-ton: tone
-trankvil: calm
-trink: to drink
-trov: to find
-turk: Turkish
-tuŝ: to touch
-urb: city
-util: useful
-uz: to use
-vagon: coach
-varm: warm
-ven: come
-vend: to sell
-Veneci: Venice
-ver: 'true'
-vesper: evening
-vest: to dress
-vetur: to ride
-vid: to see
-vin: wine
-vir: man
-viv: to live
-vizaĝ: face
-vizit: to visit
-voj: way
-vojaĝ: to travel
-vok: to call
-vol: to want
-vort: word
-voĉ: voice
-zorg: to care
-ĉambr: room
-ĉef: boss
-ĝen:
-- to distrub
-- to bother
-ĝeneral: general
-ĝoj: glad
-ĝust: correct
-ĵet: to throw
-ŝajn: seem
-ŝanĝ: to change
-ŝat: to like
-ŝip: ship
+- pilin
+- toki e pilin
+ord: lawa
+orel: ilo kute
+pac: utala ala
+pag: pana e mani
+pan: pan
+paper: lipu
+pardon: weka e pilin ike
+parol: toki
+part: kipisi
+pas: tawa weka
+patr: mama (mije)
+paŝ: tawa noka
+pens: pilin
+perd: weka e
+person: jan
+pet: toki e wile
+pez: suli
+pied: noka
+plac: ma pi jan mute
+plan: nasin pi tenpo kama
+plaĉ: pona tawa pilin
+plen: jo e ijo mute
+polic: jan pi awen lawa
+pord: lupa tomo
+port: jo lon tawa
+pov: ken
+pren: kama jo
+pret: ken open
+prezent: pana lon lukin
+problem: ijo ike
+proksim: poka
+promen: tawa noka musi
+propon: pana e nasin
+prov: alasa pali
+rajt: ken tan lawa
+rapid: tawa wawa
+raport: toki sona
+real: lon
+rekt: nasin linja
+renkont: kama poka
+respekt: pilin suli tawa
+respond: toki tawa wile sona
+rest: awen
+ricev: kama jo
+rid: mu musi
+rigard: lukin
+riĉ: jo mani mute
+rol: nasin pali
+ruĝ: loje
+salt: tawa sewi
+salut: toki!
+sam: sama
+san: sijelo pona
+saĝ: sona mute
+sci: sona
+sek: telo ala
+sekret: sona len
+sekv: tawa lon monsi
+semajn: tenpo pi suno mute
+send: pana tawa weka
+serĉ: alasa
+si: ona sama
+sid: lon supa
+silent: kalama ala
+simil: sama lili
+sinjor: jan mije
+situaci: ijo pi tenpo ni
+skrib: sitelen
+sol: wan taso
+son: kalama
+sovaĝ: pi ma
+sport: musi sijelo
+star: awen lon noka
+strat: nasin
+subit: kepeken tenpo lili
+sufiĉ: mute pona
+sukces: pini pona
+sun: suno
+supr: sewi
+tabl: supa
+tag: tenpo suno
+te: telo kasi
+telefon: ilo toki
+temp: tenpo
+temperatur: seli anu lete
+ten: jo kepeken luka
+teror: monsuta
+tim: pilin monsuta
+ton: nasin kalama
+trankvil: pilin awen
+trink: moku e telo
+trov: kama lukin e
+turk: pi ma Tuki
+tuŝ: luka e
+urb: ma tomo
+util: pona tawa pali
+uz: kepeken
+vagon: tomo tawa
+varm: seli
+ven: kama
+vend: esun pana
+Veneci: ma tomo Wenesija
+ver: lon
+vesper: tenpo pi pini suno
+vest: len e sijelo
+vetur: tawa kepeken tomo tawa
+vid: lukin
+vin: telo nasa
+vir: mije
+viv: lon (moli ala)
+vizaĝ: sinpin lawa
+vizit: kama lon tomo ante
+voj: nasin
+vojaĝ: tawa ma weka
+vok: toki tawa jan
+vol: wile
+vort: nimi
+voĉ: kalama uta
+zorg: lukin pona e
+ĉambr: tomo lili
+ĉef: jan lawa
+ĝen: ike tawa
+ĝeneral: pi ale
+ĝoj: pilin pona
+ĝust: pona lon
+ĵet: tawa e ijo weka
+ŝajn: lukin sama
+ŝanĝ: ante
+ŝat: pilin pona tawa
+ŝip: tomo tawa telo

--- a/enhavo/tradukenda/tok/vortaro/sufikso.yml
+++ b/enhavo/tradukenda/tok/vortaro/sufikso.yml
@@ -1,44 +1,26 @@
-ad:  continuous action
-an:  member of a group
-ar:  group, collection
-aĉ:  indicates undesirable quality
-aĵ:  
-- thing
-- concrete manifestation
-ebl: possibility
-ec:  abstract quality
-eg:
-- big
-- augmentative
-ej:  place
+ad: pali awen
+an: jan pi kulupu
+ar: kulupu
+aĉ: ike
+aĵ: ijo
+ebl: ken
+ec: kule (ijo pi sijelo ala)
+eg: suli
+ej: ma
 er:
-- fragment, small piece
-- particle
-estr:
-- chief
-- head
-et:  
-- small
-- diminutive
-ig:  
-- cause something
-il: 
-- tool
-- means 
-in: 
-- female 
-ind: 
-- worthy of
-ist: 
-- profession
-- habitual association
-iĝ: 
-- become 
-uj:  
-- container
-- tree
-- country
-ul: 
-- person 
-um:  
-- indefinite meaning
+- ijo lili
+- kipisi lili
+estr: jan lawa
+et: lili
+ig: pali e ijo
+il: ilo
+in: meli
+ind: pona tawa
+ist: jan pali
+iĝ: kama
+uj:
+- poki
+- kasi
+- ma
+ul: jan
+um: kon pi nimi li sona ala

--- a/enhavo/tradukenda/tok/vortaro/vorto.yml
+++ b/enhavo/tradukenda/tok/vortaro/vorto.yml
@@ -1,264 +1,246 @@
-Esperanto: Esperanto
-akcepteblan: acceptable
-alilandaj: foreign
-alporti: to bring over
-alportis: brought over 
-alvenigas: leads here
-alvenis: came here
-alvenos: will come here
-amikino: girl-friend
-amikinon: girl-friend
-amletero: love letter
-antaŭeniris: went ahead
-arbaro: wood
-arbetoj: bushes
-arboplena: full of trees
-aĉetumos: will go shopping
-aĉodora: bad smelling 
-aŭdiĝis: was being heard
-bedaŭrinde: unfortunately
-belaĵoj: beautiful things
-beleta: cute
-bestetoj: little animals
-bonega: very good
-bonvolu: please
-bonvolus: would you be so kind
-centoj: hundreds
-dankon: thank you
-daŭrigis: continued
-denove: again
-devojiĝis: to go astray
-dikiĝi: to become fat
-doloriga: pain causing
-dolorige: pain causing
-domegon: villa
-dumnokte: at night
-dumtage: at day
-ekkriis: started screaming
-ekmire: wondrously
-ekparolis: started speaking
-ekridis: started laughing
-ekrigardis: started looking
-eksaltis: started jumping
-ekscii: to find out
-eksidis: sat down
-ekstervoje: on the way out
-ekveturas: start riding
-ekvidis: started seeing
-elstaraj: outstanding
-eniri: to go in
-eniris: went in 
-eniru: go in! 
-facilmovaj: easy-to-move
-faligi:
-- to cause falling
-- to run over
-faligis: ran over
-familianoj: family members
-fermita: closed 
-fine: at the end
-foresti: to be away
-foriros: will go away
-fratino: sister
-fuŝparolis: spoke wrongly
-geamikoj: friends
-gefratoj: siblings
-gelernantojn:
-- learners
-- students
-gepatroj: parents
-gondolisto: gondolist 
-gondolistoj: gondolists
-grafino: countess
-grafinon: countess
-grandula: giant
-gravuloj: important people
-haltigis: stopped
-havigi: to obtain
-havindan: worth having
-homformo: form of a person
-hommulton: crowd
-ideoriĉan: imaginative
-industriisto: industrialist
-instruistino: female teacher 
-instruiston: teacher
-intervidiĝas: see each other
-iron: walk
-junulino: female youngster
-junulinoj: female youngsters
-junulinon: female youngster
-junuloj: youngsters
-kafejo: café
-kafejon: café
-karulino: darling
-karulo: darling
-klarigis: explained
-klarigon: explanation 
-klubanoj: club members
-kompreneble: 
-- understandably
-- of course
-korpoforton: physical strength
-kunmanĝos: will eat together
-kunporti: to bring along
-kunulino: female companion
-kunvenas: come together
-laboristo: worker
-lampeto: little lamp
-lernanto:
-- learner
-- student
-lernejo: school
-lernejon: school 
-lernolibroj: schoolbooks
-leteroj: letters
-libertempo:
-- free time
-- spare time
-libroj: books
-lumigis:
-- lightened up
-- flashed up
-malagrabla: unpleasant
-malbela: ugly
-malbonaj: bad
-malbonajn: bad
-malbonan: bad
-malbono: bad 
-malfacilan: difficult
-malfacile: difficult
-malfeliĉo: misfortune
-malforta: weak
-malforte: weak 
-malfruas: is late 
-malfrue: late
-malfrui: to be late 
-malgranda:
-- little
--  small
-malhelpis: hindered
-malinterese: uninteresting
-malkontentigi: to annoy
-mallaŭte: quiet
-malliberejon: prison
-mallumo: darkness
-malmulte: few
-malmultekosta: cheap 
-malmulton: few
-malnova: old
-malnovaj: old
-malofte: rarely 
-malplaĉa: uncomfortable
-malplaĉan: uncomfortable 
-malproksime: far away
-malsaniĝis: got sick
-malsaĝa: unwise
-malsekajn: wet
-malsukcesa: unsuccessful
-maltrankvila: anxious
-malvarman: cold
-malĝoja: sad
-malŝatas: doesn't like
-malŝatis: didn't like
-manĝaĵo: food
-manĝegi: to devour
-maristo: seaman
-maristoj: seamen
-mariston: seaman
-miaj: my 
-militistoj: soldiers
-monerojn: coins
-monujo: purse
-morgaŭan: tomorrow's
-mortigo: murder
-moviĝis: moved
-multekosta: expensive
-multpiedaj: many-footed
-naskiĝtaga: birthday
-naskiĝtago: birthday 
-naturaĵojn: natural things
-nehoma: non-human
-neinteresaj: uninteresting
-nokta: nightly
-novaĵoj: news
-opinion: opinion
-ordigi: to order 
-paperoj: papers
-paperojn:  papers
-paperujon: wastebasket
-pasigos: will spend
-patrino: mother
-perdigis: withdrew
-plenigadis: filled
-plenumis: fulfilled
-plibeligis: beautified
-plimulto: majority
-policano: policeman
-promenejo: promenade
-promeno: walk
-rapidege: very quickly
-realigi: to realize
-redonu: give back
-rekapti: to get back
-repaciĝon: reliberation
-revenis: came back
-revidi: to see again
-revido: goodbye
-ridetis: smiled
-rideto: smile
-riĉeco:
-- richness
-- wealth
-riĉulo: rich man
-salton: jump
-saluton: hello
-samklubanoj: co-members of the club
-sekretajn: secret
-sekreton: secret
-senbrue: silently
-seninterese: disinterested
-senkolora: colorless
-sensukcese: without success
-sentimulo: fearless man
-senvorte: wordlessly
-sinjorinoj: ladies
-sinjorinon: lady
-skribotablo: desk
-soleca: lonely
-sovaĝejo: wilderness
-sportisto: sportsman
-subakvigis: to sink
-subakviĝis: to sink
-subite: suddenly
-supren: upward
-surhavas: wear
-surlokan: at this place
-teroristoj: terrorists
-tiuokaze: in that case
-travivaĵo: adventure
-tridekjara: 30-year-old
-troviĝis: was situated
-unuaj: first
-urbomezo: city center
-vagonaro: train
-vendejo: shop
-vendejon: shop
-vendisto: clerk 
-vestaĵo: clothes 
-vestaĵoj: clothes
-vestaĵojn: clothes 
-vestaĵon: clothes
-veturado:
-- drive
-- tour
-veturigus: would drive 
-viaj: your
-virino: woman
-vojaĝantoj: travellers
-ĉambristoj: chambermaids
-ĉeesto: presence
-ĉirkaŭaĵo: surrounding
-ĝenon: disturbance
-ĝustatempe: at the right time
-ŝiaj: her 
-ŝipkuron: ship race
+Esperanto: toki Epelanto
+akcepteblan: ken pona
+alilandaj: pi ma ante
+alporti: jo tawa ni
+alportis: jo tawa ni, tenpo pini
+alvenigas: kama e ijo tawa ni
+alvenis: kama, tenpo pini
+alvenos: kama, tenpo kama
+amikino: jan pona (meli)
+amikinon: jan pona (meli)
+amletero: lipu olin
+antaŭeniris: tawa sinpin, tenpo pini
+arbaro: ma kasi
+arbetoj: kasi lili
+arboplena: pi kasi mute
+aĉetumos: esun, tenpo kama
+aĉodora: kon ike
+aŭdiĝis: kama kute, tenpo pini
+bedaŭrinde: ike la
+belaĵoj: ijo pona lukin
+beleta: suwi
+bestetoj: soweli lili
+bonega: pona mute
+bonvolu: o pona
+bonvolus: sina pona la, o
+centoj: mute mute
+dankon: pona!
+daŭrigis: awen e, tenpo pini
+denove: sin
+devojiĝis: tawa weka tan nasin
+dikiĝi: kama suli
+doloriga: pana e pilin ike
+dolorige: pi pilin ike
+domegon: tomo suli
+dumnokte: lon tenpo pimeja
+dumtage: lon tenpo suno
+ekkriis: open kalama wawa
+ekmire: pi pilin nasa
+ekparolis: open toki
+ekridis: open mu musi
+ekrigardis: open lukin
+eksaltis: open tawa sewi
+ekscii: kama sona
+eksidis: kama lon supa
+ekstervoje: lon weka pi nasin
+ekveturas: open tawa kepeken tomo tawa
+ekvidis: kama lukin
+elstaraj: pona nanpa wan
+eniri: tawa insa
+eniris: tawa insa, tenpo pini
+eniru: o tawa insa!
+facilmovaj: ken tawa pona
+faligi: tawa anpa e ijo
+faligis: tawa anpa e ijo, tenpo pini
+familianoj: jan pi kulupu mama
+fermita: open ala
+fine: lon pini
+foresti: lon weka
+foriros: tawa weka, tenpo kama
+fratino: jan sama (meli)
+fuŝparolis: toki pakala
+geamikoj: jan pona mute
+gefratoj: jan sama mute
+gelernantojn: jan pi kama sona
+gepatroj: mama mute
+gondolisto: jan pi tomo tawa telo
+gondolistoj: jan pi tomo tawa telo
+grafino: jan lawa (meli)
+grafinon: jan lawa (meli)
+grandula: jan suli
+gravuloj: jan suli mute
+haltigis: awen e ijo, tenpo pini
+havigi: kama jo
+havindan: pona tawa jo
+homformo: sijelo jan
+hommulton: kulupu jan
+ideoriĉan: pi sona sin mute
+industriisto: jan lawa pi kulupu pali
+instruistino: jan pi pana sona (meli)
+instruiston: jan pi pana sona
+intervidiĝas: lukin e jan ante
+iron: tawa noka
+junulino: jan lili (meli)
+junulinoj: jan lili (meli)
+junulinon: jan lili (meli)
+junuloj: jan lili mute
+kafejo: tomo pi telo wawa
+kafejon: tomo pi telo wawa
+karulino: jan olin (meli)
+karulo: jan olin
+klarigis: toki e sona, tenpo pini
+klarigon: toki pi sona
+klubanoj: jan pi kulupu
+kompreneble: sona la
+korpoforton: wawa sijelo
+kunmanĝos: moku poka, tenpo kama
+kunporti: jo poka
+kunulino: jan poka (meli)
+kunvenas: kama kulupu
+laboristo: jan pali
+lampeto: ilo suno lili
+lernanto: jan pi kama sona
+lernejo: tomo sona
+lernejon: tomo sona
+lernolibroj: lipu sona mute
+leteroj: lipu toki mute
+libertempo: tenpo pi pali ala
+libroj: lipu mute
+lumigis: pana e suno, tenpo pini
+malagrabla: ike
+malbela: ike lukin
+malbonaj: ike
+malbonajn: ike
+malbonan: ike
+malbono: ijo ike
+malfacilan: pali suli
+malfacile: kepeken pali suli
+malfeliĉo: ijo ike
+malforta: wawa ala
+malforte: kepeken wawa ala
+malfruas: lon tenpo pini
+malfrue: lon tenpo pini
+malfrui: kama lon tenpo pini
+malgranda: lili
+malhelpis: ike tawa, tenpo pini
+malinterese: pi wile sona ala
+malkontentigi: pana e pilin ike
+mallaŭte: kalama lili
+malliberejon: tomo pi tawa ken ala
+mallumo: pimeja
+malmulte: mute lili
+malmultekosta: mani lili
+malmulton: mute lili
+malnova: pi tenpo pini
+malnovaj: pi tenpo pini
+malofte: tenpo lili la
+malplaĉa: ike tawa pilin
+malplaĉan: ike tawa pilin
+malproksime: lon weka
+malsaniĝis: kama pi sijelo ike
+malsaĝa: sona ala
+malsekajn: pi telo
+malsukcesa: pini ike
+maltrankvila: pilin pi awen ala
+malvarman: lete
+malĝoja: pilin ike
+malŝatas: pilin ike tawa
+malŝatis: pilin ike tawa, tenpo pini
+manĝaĵo: moku
+manĝegi: moku wawa
+maristo: jan pi telo suli
+maristoj: jan pi telo suli
+mariston: jan pi telo suli
+miaj: mi
+militistoj: jan utala
+monerojn: mani kiwen
+monujo: poki mani
+morgaŭan: pi tenpo suno kama
+mortigo: moli e jan
+moviĝis: tawa, tenpo pini
+multekosta: mani mute
+multpiedaj: pi noka mute
+naskiĝtaga: pi tenpo suno pi kama lon
+naskiĝtago: tenpo suno pi kama lon
+naturaĵojn: ijo pi pali jan ala
+nehoma: pi jan ala
+neinteresaj: pi wile sona ala
+nokta: pi tenpo pimeja
+novaĵoj: sona sin
+opinion: pilin
+ordigi: pona e nasin
+paperoj: lipu mute
+paperojn: lipu mute
+paperujon: poki jaki
+pasigos: kepeken tenpo, tenpo kama
+patrino: mama (meli)
+perdigis: weka e ijo, tenpo pini
+plenigadis: pana e ijo lon insa, tenpo pini
+plenumis: pali e wile, tenpo pini
+plibeligis: pona e lukin, tenpo pini
+plimulto: kulupu pi mute suli
+policano: jan pi awen lawa
+promenejo: nasin pi tawa musi
+promeno: tawa noka
+rapidege: tawa wawa mute
+realigi: kama lon e ijo
+redonu: o pana sin
+rekapti: kama jo sin
+repaciĝon: kama pona sin
+revenis: kama sin, tenpo pini
+revidi: lukin sin
+revido: tawa pona!
+ridetis: uta pona, tenpo pini
+rideto: uta pona
+riĉeco: mani mute
+riĉulo: jan pi mani mute
+salton: tawa sewi
+saluton: toki!
+samklubanoj: jan pi kulupu sama
+sekretajn: sona len
+sekreton: sona len
+senbrue: kepeken kalama ala
+seninterese: pi wile sona ala
+senkolora: pi kule ala
+sensukcese: kepeken pini ike
+sentimulo: jan pi pilin monsuta ala
+senvorte: kepeken nimi ala
+sinjorinoj: jan meli mute
+sinjorinon: jan meli
+skribotablo: supa sitelen
+soleca: pilin wan taso
+sovaĝejo: ma pi jan ala
+sportisto: jan pi musi sijelo
+subakvigis: anpa e ijo lon telo
+subakviĝis: kama anpa lon telo
+subite: kepeken tenpo lili
+supren: tawa sewi
+surhavas: jo e len
+surlokan: pi ma ni
+teroristoj: jan pi pana monsuta
+tiuokaze: ni la
+travivaĵo: ijo pi tawa musi
+tridekjara: pi tenpo sike suno 30
+troviĝis: lon ma, tenpo pini
+unuaj: nanpa wan
+urbomezo: insa pi ma tomo
+vagonaro: tomo tawa linja
+vendejo: tomo esun
+vendejon: tomo esun
+vendisto: jan esun
+vestaĵo: len
+vestaĵoj: len
+vestaĵojn: len
+vestaĵon: len
+veturado: tawa kepeken tomo tawa
+veturigus: lawa e tomo tawa (ken)
+viaj: sina
+virino: meli
+vojaĝantoj: jan tawa
+ĉambristoj: jan pi pali tomo
+ĉeesto: lon
+ĉirkaŭaĵo: ma poka
+ĝenon: ike tawa pilin
+ĝustatempe: lon tenpo pona
+ŝiaj: ona (meli)
+ŝipkuron: utala tawa pi tomo tawa telo


### PR DESCRIPTION
## Resumo

Plenigo de la **toki-pona** traduko de la kurso. Antaŭe granda parto de la enhavo restis en la angla (netradukita) kaj la toki-pona retejo eĉ **ne konstruiĝis** pro nevalida YAML.

## Riparoj de konstruo
- Nevalida YAML (dupunktoj en valoroj `ke: ni:`, `ĉar: tan ni:`, `kvazaŭ: sama ni:`) — nun cititaj. La tok-konstruo (`make html LINGVO=tok`) denove sukcesas.
- Forigita la Esperanta TODO-noto en `gramatiko/01` (anstataŭigita per toki-pona klarigo pri la alfabeto).
- Riparita fuŝa Markdown `*libr_ego_*` → `*libr__eg__o*` (gramatiko/06).

## Tradukita el la angla al toki pona
- **vortaro**: `radiko` (293 radikoj), `vorto` (246 vortoj), `novaj`, `pronomo`, `partikulo`, `prefikso`, `sufikso`, `prepozicio`, `participo`, `grava_esprimo`.
- **ekzercoj**: `traduku` 03–12 (ekz. 1) kaj ĉiuj 12 `traduku-kaj-respondu` (ekz. 3) — demandoj + vort-post-vortaj glosoj.
- **gramatiko**: anglaj titoloj en 03/11, kaj plena prozo de 07, 08, 09, 10, 12.

## Rimarkoj
Toki pona havas nur ~120 vortojn, do multaj Esperantaj konceptoj (ekz. *doĝ, dolaro, aŭtoritato, doktoro*) ricevis **proksimumajn** tradukojn (ekz. *dolaro* → `mani`). Tio estas **plej bona provo** kaj meritas trapason de denaska toki-pona parolanto antaŭ definitiva publikigo, sed ĝi enkondukas neniujn elpensitajn faktojn kaj ne ŝanĝas la kursan strukturon.

`make check` sukcesas; la toki-pona HTML konstruiĝas senerare; restas neniuj anglaj glosoj en la eligo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)