### PR TITLE
Anstataŭigu la Gitter-babilejan insignon per Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # La esperanto-kurso laŭ la Zagreba metodo
 
-[![Aliĝu la babililon https://gitter.im/Esperanto/kurso-zagreba-metodo](https://badges.gitter.im/Esperanto/kurso-zagreba-metodo.svg)](https://gitter.im/Esperanto/kurso-zagreba-metodo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Aliĝu al la babilejo en Telegram](https://img.shields.io/badge/babilejo-Telegram-26A5E4?logo=telegram&logoColor=white)](https://zagreba.telegramo.org/)
 
 Tiu deponejo enhavas la Esperanto-kurson laŭ la [Zagreba metodo](https://eo.wikipedia.org/wiki/Zagreba_metodo) en strukturita datumaranĝo. Do, la kompleta enhavo estas konservita per [YAML](https://en.wikipedia.org/wiki/YAML)-dosieroj, facile legeblaj per diversaj komputilaj programlingvoj – kaj ankaŭ por homoj.
 


### PR DESCRIPTION
## Resumo

La babileja insigno en `README.md` ligis al **Gitter**, kiu ne plu aktivas. Ĝi nun ligas al la **Telegram**-babilejo.

## Ŝanĝo

Anstataŭ la Gitter-insigno:

```markdown
[![Aliĝu al la babilejo en Telegram](https://img.shields.io/badge/babilejo-Telegram-26A5E4?logo=telegram&logoColor=white)](https://zagreba.telegramo.org/)
```

- Statika **shields.io**-insigno kun la Telegram-emblemo kaj la marka koloro (`#26A5E4`).
- Ligas al `https://zagreba.telegramo.org/`.

## Pri la elekto

La proponita ilo [chatman-media/telegram-badge](https://github.com/chatman-media/telegram-badge) generas **dinamikan** insignon (membronombro) per ekstera *runkit*-servo. Tio postulas `t.me`-invitligilon kaj dependas de tria-parta servo, kiu povas malfunkcii. Por README-insigno la **statika** shields.io-insigno estas pli fidinda kaj sen-bezona je prizorgado — sed se vi preferas montri la membronombron, eblas anstataŭe uzi tiun ilon.

Kontrolite: la insigno-bildo redonas validan SVG (HTTP 200) kaj la Telegram-ligilo respondas (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)