### PR TITLE
Aldonu insignojn al README (CI, permesilo, lingvoj, demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Pages](https://github.com/Esperanto/kurso-zagreba-metodo/actions/workflows/pages.yml/badge.svg)](https://github.com/Esperanto/kurso-zagreba-metodo/actions/workflows/pages.yml)
 [![Permesilo: CC BY 4.0](https://img.shields.io/badge/permesilo-CC%20BY%204.0-lightgrey)](PERMESILO.md)
 [![Lingvoj: 32](https://img.shields.io/badge/lingvoj-32-blue)](agordoj/lingvoj.yml)
-[![Demo: esperanto12.net](https://img.shields.io/badge/demo-esperanto12.net-brightgreen)](https://esperanto12.net/)
+[![Live: esperanto12.net](https://img.shields.io/badge/live-esperanto12.net-brightgreen)](https://esperanto12.net/)
 [![Aliĝu al la babilejo en Telegram](https://img.shields.io/badge/babilejo-Telegram-26A5E4?logo=telegram&logoColor=white)](https://zagreba.telegramo.org/)
 
 Tiu deponejo enhavas la Esperanto-kurson laŭ la [Zagreba metodo](https://eo.wikipedia.org/wiki/Zagreba_metodo) en strukturita datumaranĝo. Do, la kompleta enhavo estas konservita per [YAML](https://en.wikipedia.org/wiki/YAML)-dosieroj, facile legeblaj per diversaj komputilaj programlingvoj – kaj ankaŭ por homoj.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # La esperanto-kurso laŭ la Zagreba metodo
 
+[![Pages](https://github.com/Esperanto/kurso-zagreba-metodo/actions/workflows/pages.yml/badge.svg)](https://github.com/Esperanto/kurso-zagreba-metodo/actions/workflows/pages.yml)
+[![Permesilo: CC BY 4.0](https://img.shields.io/badge/permesilo-CC%20BY%204.0-lightgrey)](PERMESILO.md)
+[![Lingvoj: 32](https://img.shields.io/badge/lingvoj-32-blue)](agordoj/lingvoj.yml)
+[![Demo: esperanto12.net](https://img.shields.io/badge/demo-esperanto12.net-brightgreen)](https://esperanto12.net/)
 [![Aliĝu al la babilejo en Telegram](https://img.shields.io/badge/babilejo-Telegram-26A5E4?logo=telegram&logoColor=white)](https://zagreba.telegramo.org/)
 
 Tiu deponejo enhavas la Esperanto-kurson laŭ la [Zagreba metodo](https://eo.wikipedia.org/wiki/Zagreba_metodo) en strukturita datumaranĝo. Do, la kompleta enhavo estas konservita per [YAML](https://en.wikipedia.org/wiki/YAML)-dosieroj, facile legeblaj per diversaj komputilaj programlingvoj – kaj ankaŭ por homoj.


### PR DESCRIPTION
## Resumo

Aldonas kvar utilajn insignojn al `README.md`, apud la ekzistanta Telegram-babileja insigno.

## Insignoj

| Insigno | Celo |
|---|---|
| **Pages** (CI-stato) | Montras ĉu la GitHub-Actions-laborfluo `pages.yml` (make check + html-all + check-pwa + Pages-disponigo) sukcesas. Dinamika. |
| **Permesilo: CC BY 4.0** | Komunikas la permesilon; ligas al `PERMESILO.md`. |
| **Lingvoj: 32** | Reliefigas la kovron — 32 pretaj lingvoj (la 14 «testa»-lingvoj ne kalkuliĝas, same kiel sur la retejo). Statika. |
| **Demo: esperanto12.net** | Rekta ligilo al la viva kurso. |

```markdown
[![Pages](https://github.com/Esperanto/kurso-zagreba-metodo/actions/workflows/pages.yml/badge.svg)](…/actions/workflows/pages.yml)
[![Permesilo: CC BY 4.0](https://img.shields.io/badge/permesilo-CC%20BY%204.0-lightgrey)](PERMESILO.md)
[![Lingvoj: 32](https://img.shields.io/badge/lingvoj-32-blue)](agordoj/lingvoj.yml)
[![Demo: esperanto12.net](https://img.shields.io/badge/demo-esperanto12.net-brightgreen)](https://esperanto12.net/)
```

## Notoj

- La «Lingvoj»-nombro (32) egalas `stato: preta` en `agordoj/lingvoj.yml` — la sama nombro montrata sur la startpaĝo. Ĝi estas **statika**, do ĝi bezonos ĝisdatigon kiam aldoniĝos novaj pretaj lingvoj.
- Ĉiuj insigno-bildoj kontrolitaj (HTTP 200, valida SVG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)