### PR TITLE
Aldonu multlingvajn llms-dosierojn

### DIFF
--- a/fonto/md/ekzerco1.md
+++ b/fonto/md/ekzerco1.md
@@ -2,7 +2,7 @@
 
 {% for vico in leciono.ekzercoj['Traduku'] %}
   {% for esperante, fontlingve in vico.items() %}
-- {{ esperante }}: `\hrulefill`{=latex}
+- {{ esperante }}: {% if llms %}____{% else %}`\hrulefill`{=latex}{% endif %}
 
   {% endfor %}
 {% endfor %}

--- a/fonto/md/ekzerco3.md
+++ b/fonto/md/ekzerco3.md
@@ -8,7 +8,7 @@
 
   {%- if paro is mapping -%}
     {% for esperante, fontlingve in paro.items() %}
-- {{ fontlingve }}: `\hrulefill`{=latex}
+- {{ fontlingve }}: {% if llms %}____{% else %}`\hrulefill`{=latex}{% endif %}
     {% endfor %}
   {% endif %}
 

--- a/fonto/md/leciono.md
+++ b/fonto/md/leciono.md
@@ -37,7 +37,9 @@
 
 ### {{ enhavo.fasado['Solvoj'] or 'Solvoj' }}
 
+{% if not llms %}
 `\begin{multicols}{2}`{=latex}
+{% endif %}
 
 
 
@@ -56,7 +58,9 @@
 {%- endif %}
 
 
+{% if not llms %}
 `\end{multicols}`{=latex}
+{% endif %}
 
 
 {% endif %}

--- a/fonto/md/llms-full.md
+++ b/fonto/md/llms-full.md
@@ -1,0 +1,11 @@
+# {{ enhavo.fasado.get('Lerni Esperanton') or enhavo.fasado.get('Lerni Esperanton en 12 lecionoj') or 'Lerni Esperanton' }}
+
+{{enhavo.enkonduko}}
+
+# {{ enhavo.fasado.get('Lecionoj') or 'Lecionoj' }}
+
+{% for leciono in enhavo.lecionoj %}
+  {% if loop.index in printendaj.lecionoj %}
+    {% include 'leciono.md' %}
+  {% endif %}
+{% endfor %}

--- a/fonto/md/vortoj.md
+++ b/fonto/md/vortoj.md
@@ -1,7 +1,9 @@
 ### {{ enhavo.fasado['Novaj vortoj'] }}
 
 
+{% if not llms %}
 `\begin{multicols}{2}`{=latex}
+{% endif %}
 
 
 #### {{ enhavo.fasado['En la teksto'] or '' }}
@@ -18,5 +20,6 @@
 {% endfor %}
 
 
+{% if not llms %}
 `\end{multicols}`{=latex}
-
+{% endif %}

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -346,9 +346,7 @@ def render_lingva_llms(enhavo, enkonduko):
         '',
         '> ' + priskribo,
         '',
-        'Esperanto12.net provides this free Esperanto basics course using the Zagreb method.',
-        '',
-        '## Course',
+        '## ' + fasada_etikedo(enhavo, 'Lecionoj'),
         markdown_link(
             fasada_etikedo(enhavo, 'Lerni Esperanton en 12 lecionoj'),
             absoluta_url(lingva_vojo(lingvo)),
@@ -384,18 +382,16 @@ def render_lingva_llms(enhavo, enkonduko):
             absoluta_url(lingva_vojo(lingvo, 'post/')),
         ),
         '',
-        '## Full Context',
+        '## llms-full.txt',
         markdown_link(
             'llms-full.txt',
             lingva_dosiero_url(lingvo, 'llms-full.txt'),
-            'Complete Markdown course context for this language.',
         ),
         '',
         '## Optional',
         markdown_link(
             'Sitemap',
             absoluta_url('/sitemap.xml'),
-            'XML sitemap for indexable pages.',
         ),
         '',
     ]

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -14,6 +14,7 @@ from markupsafe import Markup
 import mistune
 
 from .ankroj import forigu_html, unika_ankro
+from . import md as md_generilo
 from . import pwa
 
 
@@ -26,6 +27,20 @@ GITHUB_CONTENT_BASE = 'https://github.com/Esperanto/kurso-zagreba-metodo'
 SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 ALDONAJ_PAGXOJ = ('tabelvortoj', 'prepozicioj', 'konjunkcioj', 'afiksoj', 'diversajxoj', 'auxtoroj', 'post')
 LECIONAJ_TAB_VOJOJ = ('', 'vortoj/', 'gramatiko/', 'ekzerco1/', 'ekzerco2/', 'ekzerco3/')
+LLMS_FULL_PRINTENDAJ = {
+    'partoj': (
+        'teksto',
+        'vortoj',
+        'gramatiko',
+        'ekzerco1',
+        'ekzerco2',
+        'ekzerco3',
+        'solvo1',
+        'solvo2',
+        'solvo3',
+    ),
+    'lecionoj': tuple(range(1, 13)),
+}
 
 ET.register_namespace('', SITEMAP_NS)
 
@@ -86,6 +101,14 @@ def render_markdown(text):
 
 def normaligu_spacojn(text):
     return re.sub(r'\s+', ' ', text).strip()
+
+
+def markdown_link(label, url, description=None):
+    label = str(label).replace('[', '\\[').replace(']', '\\]')
+    line = f'- [{label}]({url})'
+    if description:
+        line += ': ' + normaligu_spacojn(str(description))
+    return line
 
 
 def meta_description_from_markdown(text):
@@ -169,6 +192,10 @@ def normaligu_relativan_vojon(relativa_vojo):
 def lingva_vojo(lingvo, relativa_vojo=''):
     relativa_vojo = normaligu_relativan_vojon(relativa_vojo)
     return '/' + lingvo + '/' + relativa_vojo
+
+
+def lingva_dosiero_url(lingvo, relativa_vojo):
+    return absoluta_url('/' + lingvo + '/' + relativa_vojo.lstrip('/'))
 
 
 def alternaj_ligiloj(lingvoj, relativa_vojo, inkluzivu_x_default=True):
@@ -268,6 +295,121 @@ def generate_seo_files(lingvoj, generitaj_lingvoj):
     write_file(
         OUTPUT_DIR / 'sitemap.xml',
         render_sitemap(lingvoj, generitaj_lingvoj),
+    )
+
+
+def kursa_titolo(enhavo):
+    return (
+        enhavo['fasado'].get('Lerni Esperanton')
+        or enhavo['fasado'].get('Lerni Esperanton en 12 lecionoj')
+        or 'Lerni Esperanton'
+    )
+
+
+def fasada_etikedo(enhavo, klavo):
+    return enhavo['fasado'].get(klavo) or klavo
+
+
+def render_llms_index(hejmaj_lingvoj, meta_description):
+    lines = [
+        '# Esperanto12.net',
+        '',
+        '> Esperanto12.net is a free Esperanto basics course using the Zagreb method. '
+        + normaligu_spacojn(meta_description),
+        '',
+        '## Languages',
+    ]
+    for lingvo in hejmaj_lingvoj:
+        lines.append(markdown_link(
+            lingvo['nomo'],
+            lingva_dosiero_url(lingvo['kodo'], 'llms.txt'),
+            lingvo['titolo'],
+        ))
+    lines.extend([
+        '',
+        '## Resources',
+        markdown_link(
+            'Sitemap',
+            absoluta_url('/sitemap.xml'),
+            'XML sitemap for indexable pages.',
+        ),
+        '',
+    ])
+    return '\n'.join(lines)
+
+
+def render_lingva_llms(enhavo, enkonduko):
+    lingvo = enhavo['lingvo']
+    priskribo = meta_description_from_markdown(enkonduko)
+    lines = [
+        '# ' + kursa_titolo(enhavo),
+        '',
+        '> ' + priskribo,
+        '',
+        'Esperanto12.net provides this free Esperanto basics course using the Zagreb method.',
+        '',
+        '## Course',
+        markdown_link(
+            fasada_etikedo(enhavo, 'Lerni Esperanton en 12 lecionoj'),
+            absoluta_url(lingva_vojo(lingvo)),
+            priskribo,
+        ),
+        markdown_link(
+            '01. ' + enhavo['lecionoj'][0]['teksto']['titolo_string'],
+            absoluta_url(lingva_vojo(lingvo, '01/')),
+            fasada_etikedo(enhavo, 'Teksto'),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Tabelvortoj'),
+            absoluta_url(lingva_vojo(lingvo, 'tabelvortoj/')),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Prepozicioj'),
+            absoluta_url(lingva_vojo(lingvo, 'prepozicioj/')),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Konjunkcioj'),
+            absoluta_url(lingva_vojo(lingvo, 'konjunkcioj/')),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Afiksoj'),
+            absoluta_url(lingva_vojo(lingvo, 'afiksoj/')),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Diversaĵoj'),
+            absoluta_url(lingva_vojo(lingvo, 'diversajxoj/')),
+        ),
+        markdown_link(
+            fasada_etikedo(enhavo, 'Trovu Esperanto-parolantojn'),
+            absoluta_url(lingva_vojo(lingvo, 'post/')),
+        ),
+        '',
+        '## Full Context',
+        markdown_link(
+            'llms-full.txt',
+            lingva_dosiero_url(lingvo, 'llms-full.txt'),
+            'Complete Markdown course context for this language.',
+        ),
+        '',
+        '## Optional',
+        markdown_link(
+            'Sitemap',
+            absoluta_url('/sitemap.xml'),
+            'XML sitemap for indexable pages.',
+        ),
+        '',
+    ]
+    return '\n'.join(lines)
+
+
+def render_lingva_llms_full(enhavo, enkonduko):
+    enhavo_md = dict(enhavo)
+    enhavo_md['enkonduko'] = enkonduko
+    return md_generilo.rendu_md(
+        enhavo_md,
+        LLMS_FULL_PRINTENDAJ,
+        template='llms-full.md',
+        llms=True,
     )
 
 
@@ -550,6 +692,10 @@ def copy_static_files(versio, meta_description, hejmaj_lingvoj):
         str(OUTPUT_DIR / 'index.html'),
         render_hejmo(versio, meta_description, hejmaj_lingvoj),
     )
+    write_file(
+        str(OUTPUT_DIR / 'llms.txt'),
+        render_llms_index(hejmaj_lingvoj, meta_description),
+    )
     shutil.copy2(FONTO_DIR / 'bildoj' / 'logo' / 'favicon.ico', OUTPUT_DIR / 'favicon.ico')
     shutil.copy2(FONTO_DIR / 'bildoj' / 'logo' / 'apple-touch-icon.png', OUTPUT_DIR / 'apple-touch-icon.png')
     pwa.copy_static_assets(OUTPUT_DIR)
@@ -633,10 +779,16 @@ def generate_html(
         'anki': 'https://apps.ankiweb.net/',
         'kartaro': vojprefikso + 'eksporto/' + lingvo + '.apkg',
     }
+    llms_url = {
+        'anki': 'https://apps.ankiweb.net/',
+        'kartaro': lingva_dosiero_url(lingvo, 'eksporto/' + lingvo + '.apkg'),
+    }
+    enkonduko = env.from_string(enhavo['enkonduko']).render(url=url)
+    llms_enkonduko = env.from_string(enhavo['enkonduko']).render(url=llms_url)
 
     rendered = env.get_template('index.html').render(
         enhavo=enhavo,
-        enkonduko=env.from_string(enhavo['enkonduko']).render(url=url),
+        enkonduko=enkonduko,
         pretaj_lingvoj=[
             (kodo, lingvo)
             for kodo, lingvo in sorted(enhavo['lingvoj'].items())
@@ -650,6 +802,9 @@ def generate_html(
     )
 
     eligo[output_path / 'index.html'] = rendered
+    if enhavo['lingvoj'][lingvo].get('stato') == 'preta':
+        eligo[output_path / 'llms.txt'] = render_lingva_llms(enhavo, llms_enkonduko)
+        eligo[output_path / 'llms-full.txt'] = render_lingva_llms_full(enhavo, llms_enkonduko)
 
     # vortaro.js
     rendered = env.get_template('vortlisto.js').render(

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -31,6 +31,16 @@ HREFLANG_DE_PATTERN = re.compile(r'<link rel="alternate" hreflang="de" href="htt
 HREFLANG_X_DEFAULT_PATTERN = re.compile(r'<link rel="alternate" hreflang="x-default" href="https://esperanto12\.net/" />')
 ROBOTS_SITEMAP_PATTERN = re.compile(r'Sitemap: https://esperanto12\.net/sitemap\.xml')
 SITEMAP_EN_PATTERN = re.compile(r'<loc>https://esperanto12\.net/en/01/</loc>')
+LLMS_ROOT_TITLE_PATTERN = re.compile(r'^# Esperanto12\.net$', re.M)
+LLMS_ROOT_EN_PATTERN = re.compile(r'https://esperanto12\.net/en/llms\.txt\)')
+LLMS_ROOT_DE_PATTERN = re.compile(r'https://esperanto12\.net/de/llms\.txt\)')
+LLMS_ROOT_BE_PATTERN = re.compile(r'https://esperanto12\.net/be/llms\.txt\)')
+LLMS_EN_FULL_PATTERN = re.compile(r'https://esperanto12\.net/en/llms-full\.txt\)')
+LLMS_EN_LESSON_PATTERN = re.compile(r'https://esperanto12\.net/en/01/')
+LLMS_EN_TABELVORTOJ_PATTERN = re.compile(r'https://esperanto12\.net/en/tabelvortoj/')
+LLMS_FULL_LESSON_1_PATTERN = re.compile(r'Amiko\s+Marko')
+LLMS_FULL_LESSON_12_PATTERN = re.compile(r'Nokta\s+promeno')
+RAW_TEMPLATE_PATTERN = re.compile(r'\{\{[^}]+\}\}')
 
 
 def fail(message):
@@ -57,6 +67,16 @@ def require_pattern(path, pattern):
         fail('ne eblas legi kiel UTF-8 ' + str(path) + ': ' + str(error))
     if not pattern.search(text):
         fail('mankas atendita enhavo en ' + str(path))
+
+
+def forbid_pattern(path, pattern):
+    require_nonempty_file(path)
+    try:
+        text = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError as error:
+        fail('ne eblas legi kiel UTF-8 ' + str(path) + ': ' + str(error))
+    if pattern.search(text):
+        fail('trovis neatenditan enhavon en ' + str(path))
 
 
 def require_apkg(path):
@@ -111,7 +131,10 @@ def main():
         output_dir / 'apple-touch-icon.png',
         output_dir / 'robots.txt',
         output_dir / 'sitemap.xml',
+        output_dir / 'llms.txt',
         lingvo_dir / 'index.html',
+        lingvo_dir / 'llms.txt',
+        lingvo_dir / 'llms-full.txt',
         output_dir / 'assets' / 'css' / 'main.css',
         output_dir / 'assets' / 'js' / 'hejmo.js',
         output_dir / 'assets' / 'js' / 'main.js',
@@ -133,6 +156,16 @@ def main():
     require_pattern(output_dir / 'sw.js', PWA_SERVICE_WORKER_PATTERN)
     require_pattern(output_dir / 'robots.txt', ROBOTS_SITEMAP_PATTERN)
     require_pattern(output_dir / 'sitemap.xml', SITEMAP_EN_PATTERN)
+    require_pattern(output_dir / 'llms.txt', LLMS_ROOT_TITLE_PATTERN)
+    require_pattern(output_dir / 'llms.txt', LLMS_ROOT_EN_PATTERN)
+    require_pattern(output_dir / 'llms.txt', LLMS_ROOT_DE_PATTERN)
+    forbid_pattern(output_dir / 'llms.txt', LLMS_ROOT_BE_PATTERN)
+    require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_FULL_PATTERN)
+    require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_LESSON_PATTERN)
+    require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_TABELVORTOJ_PATTERN)
+    require_pattern(lingvo_dir / 'llms-full.txt', LLMS_FULL_LESSON_1_PATTERN)
+    require_pattern(lingvo_dir / 'llms-full.txt', LLMS_FULL_LESSON_12_PATTERN)
+    forbid_pattern(lingvo_dir / 'llms-full.txt', RAW_TEMPLATE_PATTERN)
     require_pattern(lingvo_dir / 'index.html', HTML_LANG_PATTERN)
     require_pattern(lingvo_dir / 'index.html', TITLE_ROOT_PATTERN)
     require_pattern(lingvo_dir / 'index.html', META_DESCRIPTION_PATTERN)

--- a/fonto/py/md.py
+++ b/fonto/py/md.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from copy import deepcopy
 from pathlib import Path
 
 import jinja2
@@ -11,7 +12,15 @@ from markupsafe import Markup
 FONTO_DIR = Path(__file__).resolve().parents[1]
 
 
-def kreu_md(enhavo, printendaj):
+def preparu_enhavon(enhavo):
+    enhavo = deepcopy(enhavo)
+    # Ŝanĝu __ al **, ĉar nur tio Pandoc ŝajne komprenas.
+    for leciono in enhavo['lecionoj']:
+        leciono['gramatiko']['teksto'] = leciono['gramatiko']['teksto'].replace('__', '**')
+    return enhavo
+
+
+def rendu_md(enhavo, printendaj, template='arangxo.md', **context):
     md = mistune.create_markdown()
 
     env = jinja2.Environment(auto_reload=False)
@@ -20,9 +29,13 @@ def kreu_md(enhavo, printendaj):
     env.lstrip_blocks = True
     env.loader = jinja2.FileSystemLoader(str(FONTO_DIR / 'md'))
 
-    # Ŝanĝu __ al **, ĉar nur tio Pandoc ŝajne komprenas.
-    for leciono in enhavo['lecionoj']:
-        leciono['gramatiko']['teksto'] = leciono['gramatiko']['teksto'].replace('__', '**')
+    rendered = env.get_template(template).render(
+        enhavo=preparu_enhavon(enhavo),
+        printendaj=printendaj,
+        **context,
+    )
+    return rendered
 
-    rendered = env.get_template('arangxo.md').render(enhavo=enhavo, printendaj=printendaj)
-    print(rendered)
+
+def kreu_md(enhavo, printendaj):
+    print(rendu_md(enhavo, printendaj))


### PR DESCRIPTION
Resumo: Aldonas root-llms.txt kiel kompakta indekso por pretaj lingvoj, generas po-lingvajn llms.txt kaj llms-full.txt nur por stato preta, kaj reuzas purigitan Markdown-eligon por la plena LLM-kunteksto. Testaj lingvoj restas ekster la LLM-dosieroj. Kontroloj: make check; make html-all; make check-pwa.