### PR TITLE
Plibonigu la italan tradukon (gramatiko, vortaro, ekzercoj)

### DIFF
--- a/enhavo/tradukenda/it/ekzercoj/traduku-kaj-respondu/09.yml
+++ b/enhavo/tradukenda/it/ekzercoj/traduku-kaj-respondu/09.yml
@@ -42,7 +42,7 @@
     - tempo: tempo
     - '?'
 - 
-  demando: State programmado di andare in automobile a Parigi, non vi sembra molto meglio con il treno?
+  demando: State programmando di andare in automobile a Parigi, non vi sembra molto meglio con il treno?
   rektatraduko: 
     - Ĉu: (interrogativa)
     - vi: voi
@@ -63,13 +63,13 @@
     - vagonaro: treno
     - '?'
 - 
-  demando: Perché uomoni diversi spiegano le stesse idee in modo diverso?
+  demando: Perché uomini diversi spiegano le stesse idee in modo diverso?
   rektatraduko: 
     - Kial: Perché
     - diversaj: diversi
     - homoj: uomini
     - klarigas: spiegano
     - samajn: stesse
-    - ideojn: ideee
+    - ideojn: idee
     - diversmaniere: in modo diverso?
     - '?'

--- a/enhavo/tradukenda/it/gramatiko/01.md
+++ b/enhavo/tradukenda/it/gramatiko/01.md
@@ -1,156 +1,179 @@
 # Alfabeto
 
-L'alfabeto dell'esperanto si compone di 28 lettere: a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z.
+L'alfabeto dell'esperanto si compone di 28 lettere: *a, b, c, ĉ, d, e, f, g, ĝ, h, ĥ, i, j, ĵ, k, l, m, n, o, p, r, s, ŝ, t, u, ŭ, v, z*. Ogni lettera corrisponde sempre a un solo suono: chi conosce l'alfabeto sa leggere qualsiasi parola.
 
 Fai attenzione alle seguenti differenze con l'italiano:
 
-- __c__ come la z in "marzo"
-- __ĉ__ come la c in "celeste"
-- __g__ come la g in "gola"
-- __ĝ__ come la g in "genere"
-- __h__ si pronuncia con una leggera aspirazione
-- __ĥ__ si pronuncia con una forte aspirazione (gutturale)
-- __j__ come la i in "aia". __aj__, __ej__, __oj__, __uj__ sono dittonghi composti da a, e, o, u più una i breve. Ad esempio:
-	- aj come ai in "hai" 
-	- ej come ei in "sei"
-	- oj come oi in "poi"
-	- uj come ui in "cui"
-- __ĵ__ come la j francese o la g in "garage"
-- __k__ come la c in "caldo"
-- __s__ come s in "seme"
-- __ŝ__ come sci in "sciame"
-- __z__ come s in "rosa"
-- __ŭ__ come u in "uomo". __aŭ__, __eŭ__ sono dittongi composti da "a" o "e" più una u breve. Ad esempio:
-	- aŭ come au in "auto"
-	- eŭ come eu in "eutanasia"
+- *c* come la z in "marzo"
+- *ĉ* come la c in "celeste"
+- *g* come la g in "gola" (sempre dura)
+- *ĝ* come la g in "genere"
+- *h* aspirata leggera
+- *ĥ* aspirata forte (gutturale)
+- *j* come la i in "aia"; *aj, ej, oj, uj* sono dittonghi (a, e, o, u + una i breve):
+	- *aj* come ai in "hai"
+	- *ej* come ei in "sei"
+	- *oj* come oi in "poi"
+	- *uj* come ui in "cui"
+- *ĵ* come la j francese o la g in "garage"
+- *k* come la c in "caldo"
+- *s* come s in "seme"
+- *ŝ* come sci in "sciame"
+- *z* come s in "rosa"
+- *ŭ* come u in "uomo"; *aŭ, eŭ* sono dittonghi (a, e + una u breve):
+	- *aŭ* come au in "auto"
+	- *eŭ* come eu in "eutanasia"
 
+**💡 Suggerimento:** quasi tutti i suoni esistono già in italiano — *ĉ* è la c di *celeste*, *ĝ* la g di *genere*, *ŝ* lo sci di *sciame*, *z* la s di *rosa*.
+
+**⚠️ Attenzione:** tre lettere ingannano l'italiano. *c* è sempre "ts" (mai "k" né c dolce); *g* è sempre dura (la g dolce di *genere* è *ĝ*); *s* è sempre sorda (mai "z" come nella *rosa* italiana: quel suono è *z*).
 
 # Pronuncia
 
-Le parole si leggono così come sono scritte, applicando le regole suddette.
+Le parole si leggono esattamente come si scrivono, applicando le regole viste sopra:
+
+- *amiko* = a-MÍ-ko
+- *ĉambro* = CIÀM-bro
+- *ĝi* = gi (come in "giro")
 
 # Accento
 
-L'accento tonico cade sempre sulla penultima sillaba delle parole con più di una sillaba. Nelle parole monosillabiche l'accento cade sulla sillaba stessa.
+L'accento tonico cade sempre sulla penultima sillaba (nelle parole con più di una sillaba). Le parole monosillabiche si accentano sull'unica sillaba:
 
 - *te-le-FO-no*
 - *ra-DI-o*
-- *kaj*
-- a-MI-ko
-- ES-tas
-- NB: AN-kaŭ (perché kaŭ vale come sillaba singola).
+- *a-MI-ko*
+- *ES-tas*
+- *AN-kaŭ* (perché *kaŭ* è una sola sillaba)
 
-Bisogna prestare molta attenzione alle parole omofone all'italiano, ma con diverso accento, come: tele**fo**no, ra**di**o, histo**ri**o.
+**💡 Suggerimento:** è la stessa regola della maggior parte delle parole italiane (le parole piane). Ricorda solo che vocali vicine contano come sillabe separate: *radio* è ra-DI-o (tre sillabe).
+
+**⚠️ Attenzione:** occhio alle parole simili all'italiano ma con accento diverso — *telefono*, *radio*, *historio* diventano tele-FO-no, ra-DI-o, histo-RI-o (accento sulla penultima).
 
 # Articolo
 
-Esiste solo l'articolo determinativo "**la**". È invariabile (vale a dire, non cambia per genere e numero). Non esiste un articolo indeterminativo.
+Esiste solo l'articolo determinativo *__la__* (= il, lo, la, i, gli, le). È invariabile: non cambia mai per genere, numero o caso. Non esiste l'articolo indeterminativo:
 
 - *la amiko* – l'amico
   - *amiko* – un amico
 - *la laboro* – il lavoro
   - *laboro* – lavoro
-- *la tigro* - la tigre
-  - *tigro* - una tigre
+- *la tigro* – la tigre
+  - *tigro* – una tigre
+
+**⚠️ Attenzione:** non tradurre "un/uno/una" — l'esperanto lo omette. *Ĝi estas amiko.* = "È un amico."
+
+**💡 Suggerimento:** un solo *la*, invariabile — niente il/lo/la/i/gli/le da accordare.
 
 # Pronomi personali
 
 - *mi* – io
 - *vi* – tu, voi
-- *li* – lui/egli
-- *ŝi* – lei/ella
-- *ĝi* – esso
+- *li* – lui, egli
+- *ŝi* – lei, ella
+- *ĝi* – esso (cose e animali)
 - *ni* – noi
-- *ili* – loro/essi
+- *ili* – loro, essi
 
-Li si usa solo per persone di sesso maschile (genere naturale).
-Ŝi si usa solo per persone di sesso femminile.
-
+*Li* si usa solo per persone di sesso maschile, *ŝi* solo per persone di sesso femminile, *ĝi* per cose e animali.
 
 # Pronomi possessivi
 
-Si formano aggiungendo la desinenza __-a__ ai pronomi personali:
+Si formano in modo regolare, aggiungendo la desinenza *__-a__* ai pronomi personali:
 
-- *mia* – mio
-- *via* – tuo, vostro
-- *lia* – suo
-- *ŝia* – suo
-- *ĝia* – suo
-- *nia* – nostro
-- *ilia* – loro
+- *mi__a__* – mio
+- *vi__a__* – tuo, vostro
+- *li__a__* – suo (di lui)
+- *ŝi__a__* – suo (di lei)
+- *ĝi__a__* – suo (di esso)
+- *ni__a__* – nostro
+- *ili__a__* – loro
+
+**💡 Suggerimento:** pronome + *-a* e basta. La stessa desinenza *-a* forma anche gli aggettivi.
 
 # Sostantivi
 
-Tutti i sostantivi terminano in **-o**. Non esiste genere grammaticale. Se necessario, il femminile si può specificare con il suffisso **-in-**.
+Tutti i sostantivi terminano in *__-o__*. Non esiste genere grammaticale; se necessario, il femminile si indica con il suffisso *__-in__*:
 
 - *tabl__o__* – tavolo
 - *lernant__o__* – studente
-- *lernant__in__o* – studentessa
+- *patr__o__* – padre
+
+**💡 Suggerimento:** la desinenza *-o* rivela subito che la parola è un sostantivo.
 
 # Plurale
 
-La desinenza del plurale è __j__. Si appone sia a sostantivi che ad aggettivi.
+Il plurale si forma con la desinenza *__-j__*. La prendono sostantivi, aggettivi e pronomi possessivi:
 
 - *tablo__j__* – tavoli
 - *lernanto__j__* – studenti
 - *via__j__ lernanto__j__* – i tuoi studenti
 
+**⚠️ Attenzione:** il plurale è *-j* (si pronuncia come "i"); non si cambia la desinenza come in italiano (*-o → -i*, *-a → -e*). "Tavoli" è *tabloj*, mai *tabli*.
+
 # Verbi
 
-1. La desinenza dell'infinito è __-i__.
+La desinenza è **la stessa per tutte le persone** — niente coniugazione da imparare come in italiano.
+
+1. L'infinito termina in *__-i__*:
    - *lern__i__* – imparare
    - *labor__i__* – lavorare
    - *est__i__* – essere
-2. La desinenza del tempo presente indicativo è __-as__. È invariabile per tutti i soggetti singolari e plurali. Poiché esiste solo una desinenza si deve sempre nominare il soggetto o il pronome.
-   - *mi sid__as__* – io mi siedo.
-   - *vi sid__as__* – tu ti siedi.
-   - *ni sid__as__* – noi ci sediamo.
-   - *ili sid__as__* – essi si siedono.
+2. Il presente termina in *__-as__*, uguale per tutti i soggetti:
+   - *mi sid__as__* – io mi siedo
+   - *vi sid__as__* – tu ti siedi
+   - *ni sid__as__* – noi ci sediamo
+   - *ili sid__as__* – essi si siedono
+
+**💡 Suggerimento:** un'unica forma *-as* sostituisce tutta la coniugazione italiana (siedo, siedi, siede…).
+
+**⚠️ Attenzione:** poiché il verbo non mostra la persona, il pronome (*mi, vi, li*…) è obbligatorio. Non si dice *sidas* da solo per "mi siedo": sempre *mi sidas*.
 
 # *Ĉu?*
 
-Ĉu è una particella interrogativa che serve a introdurre le domande.
+*__ĉu__* trasforma un'affermazione in domanda sì/no. Si mette all'inizio e l'ordine delle parole non cambia:
 
 - *__Ĉu__ vi sidas?* – Sei seduto?
-- *__Ĉu__ vi skribas?* – Stai scrivendo? Scrivi?
+- *__Ĉu__ vi skribas?* – Scrivi? Stai scrivendo?
 
 # *Kiu?*
 
-Traduce il pronome interrogativo ("chi?"), ma anche l'aggettivo interrogativo ("quale?").
+Funziona come pronome ("chi?") e come aggettivo ("quale?"):
 
 - *__Kiu__ vi estas?* – Chi sei?
-- *__Kiu__ instruisto sidas?* – Quale insegnante sta seduto?
+- *__Kiu__ instruisto sidas?* – Quale insegnante è seduto?
 
+Vedrai altre parole di questo tipo (i correlativi) nella [lezione 5](/it/05/gramatiko/) e nella [tabella dei correlativi](/it/tabelvortoj/).
 
-# Il suffisso *-ist*
+# Il suffisso *__-ist__*
 
-Indica professione o appartenenza a qualche movimento.
+indica una professione o l'appartenenza a un movimento — come l'italiano "-ista":
 
 - *instru__ist__o* – insegnante
 - *hotel__ist__o* – albergatore
-- *esperant__ist__o* – Esperantista (appartiene al movimento esperantista)
+- *esperant__ist__o* – esperantista
 
+**💡 Suggerimento:** è lo stesso "-ista" di *art-ista*, *dent-ista*.
 
-# Il suffisso *-in*
+# Il suffisso *__-in__*
 
-Indica genere femminile.
+indica il genere femminile:
 
-- *patro* – padre
-    - *patr__in__o* – madre
-- *lernanto* – studente
-    - *lernant__in__o* – studentessa
-- *instruisto* – insegnante
-    - *instruist__in__o* – (donna) insegnante
+- *patro* – padre → *patr__in__o* – madre
+- *lernanto* – studente → *lernant__in__o* – studentessa
+- *instruisto* – insegnante → *instruist__in__o* – (donna) insegnante
+
+**💡 Suggerimento:** ricorda l'italiano "-essa" (studente → student-essa; dottore → dottor-essa) — segnale del femminile.
 
 # Avverbio affermativo
 
-*__jes__* corrisponde all'italiano "sì". Si pronuncia come l'inglese "yes".
+*__jes__* corrisponde all'italiano "sì":
 
-- *Ĉu vi estas en la ĉambro?* 
-  - *__Jes__, mi estas en la ĉambro.* 
+- *Ĉu vi estas en la ĉambro?*
+  - *__Jes__, mi estas en la ĉambro.*
 
-# Avverbo negativo
+# Avverbio negativo
 
-*__ne__* corrisponde all'italiano "no" e "non":
+*__ne__* corrisponde a "no" e "non":
 
-- *__Ne__, mi __ne__ estas en la ĉambro.* 
+- *__Ne__, mi __ne__ estas en la ĉambro.*

--- a/enhavo/tradukenda/it/gramatiko/02.md
+++ b/enhavo/tradukenda/it/gramatiko/02.md
@@ -1,90 +1,93 @@
 # Aggettivi
 
-Gli aggettivi hanno la desinenza *__-a__* e quando sono attributivi di norma precedono il sostantivo.
+Gli aggettivi hanno la desinenza *__-a__* e, quando sono attributivi, di norma precedono il sostantivo:
 
 - *bel__a__* – bello, bella
 - *grand__a__ frato* – un fratello grande
 - *malgrand__a__ fratino* – una sorella piccola
 
+**💡 Suggerimento:** *-o* per il sostantivo, *-a* per l'aggettivo. La desinenza rivela la classe della parola.
+
 # Casi
 
-In esperanto esistono solo due casi: nominativo ed accusativo. L'accusativo si forma con la desinenza *__-n__* e indica il complemento oggetto diretto.
+In esperanto esistono solo due casi: nominativo e accusativo. L'accusativo si forma con la desinenza *__-n__* e indica il complemento oggetto diretto:
 
 - *Kiu__n__ vi vidas?* – Chi vedi?
-- *Mi vidas amiko__n__* – Vedo un amico.
+- *Mi vidas amiko__n__.* – Vedo un amico.
 
-La -n dell'accusativo viene presa da tutti i sostantivi, aggettivi e pronomi, sia al singolare sia al plurale, quando si trovano in questo caso.
+La *-n* dell'accusativo la prendono tutti i sostantivi, aggettivi e pronomi, al singolare e al plurale:
 
-L'accusativo non va mai indicato dopo il verbo essere "esti" o equivalenti.
+- *Vi estas bon__a__ amik__o__.* – Tu sei un buon amico. (nominativo singolare)
+- *Vi estas bon__aj__ amik__oj__.* – Voi siete buoni amici. (nominativo plurale)
+- *Vi havas bon__an__ amik__on__.* – Tu hai un buon amico. (accusativo singolare)
+- *Vi havas bon__ajn__ amik__ojn__.* – Tu hai buoni amici. (accusativo plurale)
 
-- *Vi estas bon__a__ amik__o__* – Tu sei un buon amico. (nominativo singolare)
-- *Vi estas bon__aj__ amik__oj__* – Voi siete buoni amici. (nominativo plurale)
-- *Vi havas bon__an__ amik__on__* – Tu hai un buon amico. (accusativo singolare)
-- *Vi havas bon__ajn__ amik__ojn__* – Tu hai buoni amici. (accusativo plurale)
+**⚠️ Attenzione:** l'accusativo non si usa mai dopo il verbo *esti* (essere): *Vi estas bona amiko* (senza *-n*).
 
-Tutti gli altri casi si esprimono con l'aiuto delle preposizioni, come in italiano.
+Gli altri casi si esprimono con le preposizioni, come in italiano:
 
-- *La libroj __de__ mia frato.* – Il libro di mio fratello.
-- *Mi iras __al__ la teatro.* – Io vado al teatro.
-- *Mi iras __kun__ vi.* – Io vado con te.
+- *La libroj __de__ mia frato.* – I libri di mio fratello.
+- *Mi iras __al__ la teatro.* – Vado al teatro.
+- *Mi iras __kun__ vi.* – Vado con te.
 
-# Coniugazione 
+# Coniugazione
 
 ## Infinito: *-i*
-  
-- *labor__i__*          – lavorare
 
-## Tempo presente: *-as*
+- *labor__i__* – lavorare
 
-- *mi labor__as__*      – Io lavoro.
-- *vi labor__as__*      – Tu lavori. Voi lavorate.
-- *li/ŝi labor__as__*   – Egli/ella lavora.
-- *ni labor__as__*      – Noi lavoriamo.
-- *ili labor__as__*     – Essi lavorano.
+## Presente: *-as*
 
-## Tempo passato: *-is*
+- *mi labor__as__* – io lavoro
+- *vi labor__as__* – tu lavori, voi lavorate
+- *li/ŝi labor__as__* – egli/ella lavora
+- *ni labor__as__* – noi lavoriamo
+- *ili labor__as__* – essi lavorano
 
-Il verbo avere in esperanto non è ausiliare. Pertanto, per dire "io ho mangiato", si dirà semplicemente mi manĝis.
+## Passato: *-is*
 
-- *mi labor__is__*      – Io ho lavorato.
-- *vi labor__is__*      – Tu hai lavorato. Voi avete lavorato.
-- *li/ŝi labor__is__*   – Egli/ella ha lavorato.
-- *ni labor__is__*      – Noi abbiamo lavorato.
-- *ili labor__is__*     – Essi hanno lavorato.
+Il verbo "avere" non è ausiliare in esperanto: per "io ho mangiato" si dice semplicemente *mi manĝis*.
 
-## Tempo futuro: *-os*
+- *mi labor__is__* – io ho lavorato
+- *vi labor__is__* – tu hai lavorato, voi avete lavorato
+- *li/ŝi labor__is__* – egli/ella ha lavorato
+- *ni labor__is__* – noi abbiamo lavorato
+- *ili labor__is__* – essi hanno lavorato
 
-- *mi labor__os__*      – Io lavorerò.
-- *vi labor__os__*      – Tu lavorerai. Voi lavorerete.
-- *li/ŝi labor__os__*   – Egli/ella lavorerà.
-- *ni labor__os__*      – Noi lavoreremo.
-- *ili labor__os__*     – Essi lavoreranno.
+## Futuro: *-os*
+
+- *mi labor__os__* – io lavorerò
+- *vi labor__os__* – tu lavorerai, voi lavorerete
+- *li/ŝi labor__os__* – egli/ella lavorerà
+- *ni labor__os__* – noi lavoreremo
+- *ili labor__os__* – essi lavoreranno
+
+**💡 Suggerimento:** memorizza le vocali dei tempi nell'ordine **i – a – o**: passato (*-is*), presente (*-as*), futuro (*-os*).
 
 # Congiunzione *ke*
 
-Significa "che". In genere è preceduta da una virgola.
+*__ke__* significa "che"; di norma è preceduta da una virgola:
 
-- *Vi vidas __ke__ mi manĝas.* – Vedi che mangio.
-- *Li diras __ke__ li iros.* – Dice che andrà.
+- *Vi vidas, __ke__ mi manĝas.* – Vedi che mangio.
+- *Li diras, __ke__ li iros.* – Dice che andrà.
 
-# Prefisso *mal-*
+# Prefisso *__mal-__*
 
-Modifica il significato della parola nel suo opposto.
+trasforma il significato della parola nel suo esatto contrario:
 
-- *bona* – buono
-  - *__mal__bona* – cattivo
-- *granda* – grande
-  - *__mal__granda* – piccolo
-- *bela* – bello
-  - *__mal__bela* – brutto
+- *bona* – buono → *__mal__bona* – cattivo
+- *granda* – grande → *__mal__granda* – piccolo
+- *bela* – bello → *__mal__bela* – brutto
 
-# Prefisso *ge-*
+**💡 Suggerimento:** *mal-* rovescia il senso — un solo prefisso al posto di decine di contrari da imparare.
 
-Indica due o più persone di ambo i sessi.
+# Prefisso *__ge-__*
+
+indica due o più persone di ambo i sessi:
 
 - *__ge__fratoj* – fratelli e sorelle
 - *__ge__patroj* – genitori
-- *__ge__amikoj* – amici ed amiche
+- *__ge__amikoj* – amici e amiche
 
 # Alcune parole di cortesia
 
@@ -95,20 +98,21 @@ Indica due o più persone di ambo i sessi.
 
 # Ordine delle parole
 
-La struttura base della frase è Soggetto-Verbo-Oggetto, come in italiano. Tuttavia, dato che la -n dell'accusativo rende chiaro quale sia l'oggetto e quale il soggetto, l'ordine delle parole può essere variato per ragioni estetiche o per enfasi.
+La struttura base della frase è Soggetto-Verbo-Oggetto, come in italiano. Ma, poiché la *-n* dell'accusativo chiarisce quale sia l'oggetto e quale il soggetto, l'ordine può essere variato liberamente, per estetica o enfasi:
 
 - *Mi legas libron.* – Sto leggendo un libro.
 - *Libron mi legas.* – (Un libro è quello che sto leggendo.)
 
+**💡 Suggerimento:** come in italiano le desinenze portano il significato, qui è la *-n* (e non la posizione) a dire chi compie e chi subisce l'azione.
+
 # *Kio, Kion*
 
-*Kio* significa "che cosa", in forma soggetto:
+*__Kio__* significa "che cosa", come soggetto:
 
 - *__Kio__ estas tio?* – Che cos'è quello?
 - *__Kio__ estas sur la tablo?* – Che cosa c'è sul tavolo?
 
-Quando "che cosa" è l'oggetto diretto del verbo, in esperanto si usa *Kion*:
+Quando "che cosa" è l'oggetto diretto, si usa *__Kion__*:
 
 - *__Kion__ vi faras?* – Che cosa fai?
 - *__Kion__ ŝi diris?* – Che cosa ha detto?
-

--- a/enhavo/tradukenda/it/gramatiko/03.md
+++ b/enhavo/tradukenda/it/gramatiko/03.md
@@ -1,83 +1,88 @@
 # Avverbi
 
-Tutti gli avverbi hanno la desinenza -e, salvo alcune radici avverbiali quali ankaŭ, ankoraŭ, ecc.
-Adverbs may be formed by adding the ending *-e*.
+Gli avverbi hanno la desinenza *__-e__* (salvo alcune radici avverbiali come *ankaŭ*, *ankoraŭ*, ecc.):
 
-- *bel__e__*   – bellamente
-- *fort__e__*  – fortemente
-- *rapid__a__ aŭto*   – un'automobile veloce
-	- *veturi rapid__e__*   – viaggiare velocemente
-	
-Occorre capire bene la differenza tra aggettivi ed avverbi. Gli aggettivi determinano in modo più particolareggiato i sostantivi, mentre gli avverbi determinano in modo più particolareggiato i verbi.
+- *bel__e__* – bellamente
+- *fort__e__* – fortemente
+- *rapid__a__ aŭto* – un'automobile veloce
+  - *veturi rapid__e__* – viaggiare velocemente
 
-- *bon__a__ libro*   – un buon libro
-- *bon__e__ paroli*   – parlare bene
+Occorre distinguere bene aggettivi e avverbi: gli aggettivi precisano i sostantivi, gli avverbi precisano i verbi.
+
+- *bon__a__ libro* – un buon libro
+- *bon__e__ paroli* – parlare bene
+
+**💡 Suggerimento:** *-o* sostantivo, *-a* aggettivo, *-e* avverbio. Da una sola radice ottieni tutti e tre.
 
 # Preposizioni *per* e *kun*
 
-## *Per* - con (per mezzo di, mediante, tramite	)
-Si usa per indicare il mezzo o lo strumento col quale facciamo qualcosa.
+## *per* – con (per mezzo di, mediante)
+
+Indica il mezzo o lo strumento con cui si fa qualcosa:
 
 - *Manĝi __per__ kulero* – Mangiare con un cucchiaio.
 - *Ŝi kantis __per__ tre bela voĉo.* – Cantò con una voce bellissima.
- 
-## *Kun* - con (insieme a, in compagnia di)        
 
-- *Mi iris __kun__ la amiko.*    – Sono andato con un amico.
-- *Mi parolos __kun__ li.*       – Parlerò con lui.
+## *kun* – con (insieme a, in compagnia di)
+
+- *Mi iris __kun__ la amiko.* – Sono andato con l'amico.
+- *Mi parolos __kun__ li.* – Parlerò con lui.
+
+**⚠️ Attenzione:** il "con" italiano si divide in due: *per* (mezzo: *scrivere con la penna*) e *kun* (compagnia: *uscire con un amico*). Non confonderli.
 
 # Preposizione *post*
-Post ha per lo più un significato temporale (dopo, fra).
+
+*post* ha per lo più valore temporale (dopo, fra):
 
 - *Li venos __post__ tri horoj.* – Verrà fra tre ore.
 
-Può però anche avere un significato locale.
+Può avere anche valore locale:
 
-- *Mi iras __post__ li* – Vado dopo di lui. (dietro a lui)
+- *Mi iras __post__ li.* – Vado dopo di lui (dietro a lui).
 
-Tuttavia in questo secondo caso si preferisce usare *malantaŭ*.
+In questo secondo caso si preferisce però *malantaŭ*:
 
-- *Mi iras __malantaŭ__ li* – Vado dietro a lui.
+- *Mi iras __malantaŭ__ li.* – Vado dietro a lui.
 
-Post**e** significa "dopo", inteso come avverbio.
+*poste* significa "dopo", come avverbio:
 
-- *Mi manĝos __poste__* – Mangerò dopo.
+- *Mi manĝos __poste__.* – Mangerò dopo.
 
-# Suffisso *-ul*
+# Suffisso *__-ul__*
 
-Indica persona di una determinata caratteristica.
+indica una persona con una determinata caratteristica:
 
-- *grand__ul__o*  – persona grande, grand'uomo
+- *grand__ul__o* – persona grande, omone
 - *malbon__ul__o* – persona cattiva
-- *bel__ul__ino*  – donna brutta
+- *bel__ul__ino* – bella donna
 
-# Suffisso *-ej*
+# Suffisso *__-ej__*
 
-Indica luogo destinato a qualcosa.
+indica un luogo destinato a qualcosa:
 
-- *lern__ej__o*  – scuola
-- *kuir__ej__o*  – cucina
+- *lern__ej__o* – scuola
+- *kuir__ej__o* – cucina
 - *labor__ej__o* – posto di lavoro
- 
 
-# Suffisso *-ebl*
+# Suffisso *__-ebl__*
 
-Indica possibilità.
+indica possibilità (corrisponde a "-abile", "-ibile"):
 
 - *manĝ__ebl__a* – mangiabile
 - *vid__ebl__a* – visibile
 - *kompren__ebl__e* – comprensibilmente
-- *__ebl__e* – probabilmente, forse
+- *__ebl__e* – forse, possibilmente
 - *mal__ebl__a* – impossibile
-
 
 # Imperativo
 
-In esperanto si forma con la desinenza -u.
+Si forma con la desinenza *__-u__*:
 
-- *Manĝ__u__!*   – Mangia!
-- *Ir__u__!*   – Vai!
+- *Manĝ__u__!* – Mangia!
+- *Ir__u__!* – Vai!
 - *Li lern__u__!* – Che impari!
-- *Ni vid__u__.*  – Vediamo!
- 
-Il soggetto va sempre espresso tranne che nella seconda persona singolare e plurale (vi).
+- *Ni vid__u__.* – Vediamo!
+
+Il soggetto va sempre espresso, tranne nella seconda persona (*vi*).
+
+**💡 Suggerimento:** un'unica desinenza *-u* per tutte le persone — *mi iru*, *ni iru*, *li iru* ("che vada").

--- a/enhavo/tradukenda/it/gramatiko/04.md
+++ b/enhavo/tradukenda/it/gramatiko/04.md
@@ -1,75 +1,70 @@
 # Numeri
 
-I numeri si trovano nell'appendice. Studiandoli, potrete senza difficoltà comporre qualsiasi numero.
+I numeri si trovano nell'appendice. Studiandoli, potrai comporre senza difficoltà qualsiasi numero:
 
-- 1 238                     – *mil du-cent tri-dek ok*
-- 153 837                   – *cent kvin-dek tri mil ok-cent tri-dek sep*
-- Addizione:      8 + 3 = 11 – *ok plus tri estas dek-unu*
-- Sottrazione:    15 - 6 = 9 – *dek-kvin minus ses estas naŭ*
+- 1 238 – *mil du-cent tri-dek ok*
+- 153 837 – *cent kvin-dek tri mil ok-cent tri-dek sep*
+- addizione: 8 + 3 = 11 – *ok plus tri estas dek-unu*
+- sottrazione: 15 − 6 = 9 – *dek-kvin minus ses estas naŭ*
 
 # Accusativo di direzione
 
-Di norma un sostantivo o un pronome preceduti da una preposizione non ammettono la desinenza -n dell'accusativo.
+Di norma un sostantivo o un pronome preceduti da una preposizione non prendono la *-n* dell'accusativo:
 
 - *post mi* – dopo di me
 - *sen li* – senza di lui
 - *en domo* – in casa
 
-Tuttavia, se si tratta di esprimere il complemento di moto verso luogo, i sostantivi e i pronomi preceduti da preposizione, nonché gli avverbi di luogo, esigono la desinenza -n, la quale in questo caso serve a indicare la direzone di un movimento.
+Ma per esprimere il moto verso un luogo, i sostantivi, i pronomi e gli avverbi di luogo preceduti da preposizione prendono la *-n*, che qui indica la direzione del movimento:
 
-- *La knaboj kuras en la ĝardeno__n__* – I ragazzi corrono nel giardino.
+- *La knaboj kuras en la ĝardeno__n__.* – I ragazzi corrono dentro il giardino.
 - *Kie__n__ ili kuras?* – (Verso) dove corrono?
 - *Mi iras en la domo__n__.* – Vado dentro casa.
-- (Confronta: *Ili manĝas en la domo.* – Stanno mangiando in casa.)
+  - *Ili manĝas en la domo.* – Stanno mangiando in casa.
 
-Non si usa invece la desinenza -n per il complemento di moto in luogo circoscritto.
+Non si usa la *-n* per il moto entro un luogo circoscritto:
 
-- *La knaboj kuras en la ĝardeno* – I ragazzi corrono nel giardino.
+- *La knaboj kuras en la ĝardeno.* – I ragazzi corrono nel giardino.
 
-Con le preposizione **al** e **ĝis** non si usa la desinenza -n, perché queste contengono già in sé l'idea di direzione.
+Con *al* e *ĝis* non si usa la *-n*, perché contengono già l'idea di direzione:
 
-- *Li kuris __ĝis__ la strato* – Lui corse fino alla strada.
+- *Li kuris __ĝis__ la strato.* – Corse fino alla strada.
+
+**💡 Suggerimento:** è la stessa differenza dell'italiano tra *in casa* (stato) e *verso casa* / *dentro casa* (moto). L'esperanto marca la direzione con la *-n*: *en domo* / *en domon*.
 
 # Pronome impersonale *oni*
 
-Traduce il nostro "si" impersonale.
+*__oni__* traduce il "si" impersonale:
 
 - *__Oni__ manĝas.* – Si mangia.
-
-Traduce anche il soggetto di una frase italiana del tipo:
-
 - *__Oni__ parolas malbone pri vi.* – Dicono male di te.
- 
 
 # Pronome riflessivo *si*
 
-Il pronome riflessivo *si* (in accusativo *sin*) si usa per indicare il complemento oggetto dei verbi riflessivi, cioè quelli il cui soggetto compie e subisce l'azione.
+Il pronome riflessivo *__si__* (accusativo *__sin__*) indica il complemento oggetto dei verbi riflessivi, e si usa solo con la terza persona (singolare e plurale):
 
 - *Li lavas __sin__.* – Lui si lava.
 - *Ŝi rigardas __sin__.* – Lei si guarda.
- 
-*Si* (sin) è usato solo con la terza persona singolare e plurale. Per le altre persone si usano i pronomi *min*, *vin*, *nin*.
+
+Per le altre persone si usano *min*, *vin*, *nin*:
 
 - *Mi rigardas min.* – Io mi guardo.
 - *Vi rigardas vin.* – Tu ti guardi.
-- *Li/Ŝi/Ĝi rigardas sin.* – Lui/Lei/(Esso) si guarda.
-- *Ni rigardas nin.* – Noi ci guardiamo.
-- *Vi rigardas vin.* – Voi vi guardate.
 - *Ili rigardas sin.* – Loro si guardano.
+
+**💡 Suggerimento:** *si/sia* si riferisce sempre al soggetto della frase. *Li vidas __sian__ amikon* = vede il proprio amico; *Li vidas __lian__ amikon* = vede l'amico di un altro.
 
 # Congiunzione condizionale *se*
 
-Occorre fare attenzione a non usare la congiunzione temporale *kiam* ("quando") se si tratta di condizione. Confronta le seguenti frasi.
+Attenzione a non usare *kiam* ("quando") quando si tratta di una condizione. Confronta:
 
-- *__Se__ mi malsanas, mi malmulte manĝas.* – Quando (se) sono malato, mangio poco.
-- *__Kiam__ mi malsanis, mi malmulte manĝis* – Quando sono stato malato, ho mangiato poco.
+- *__Se__ mi malsanas, mi malmulte manĝas.* – Se (quando) sono malato, mangio poco.
+- *__Kiam__ mi malsanis, mi malmulte manĝis.* – Quando sono stato malato, ho mangiato poco.
 
-# Prefisso *re-*
+# Prefisso *__re-__*
 
-Ha il significato di "di nuovo", "ancora", "ritorno".
+significa "di nuovo", "ancora", "indietro":
 
-- *__re__vidi* – rivedere, vedere di nuovo
-- *__re__doni* – ridare, dare indietro, restituire
-- *__re__meti* – rimettere, mettere di nuovo
-
- 
+- *__re__vidi* – rivedere
+- *__re__doni* – restituire
+- *__re__meti* – rimettere

--- a/enhavo/tradukenda/it/gramatiko/05.md
+++ b/enhavo/tradukenda/it/gramatiko/05.md
@@ -1,113 +1,114 @@
 # Tabella dei correlativi
 
-Guardate la tabella dei correllativi nell'appendici ed imparatela. Qui vi facciamo notare solo alcune parole correlative tra le più frequentemente usate:
+Guarda la [tabella dei correlativi](/it/tabelvortoj/) nell'appendice e imparala. Qui segnaliamo solo alcune tra le più usate:
 
-- *ĉio*  – tutto
-- *ĉiu*  – ognuno, ogni
+- *ĉio* – tutto
+- *ĉiu* – ognuno, ogni
 - *ĉiuj* – tutti
 - *ĉiam* – sempre
-- *iom*  – poco, qualcosa
+- *iom* – un po', qualcosa
 
-Il plurale lo possono prendere i correlativi con le desinenze *-u* e *-a*, mentre l'accusativo lo possono prendere i correlativi terminanti in *-o*, *-u*, *-a* ed *-e*.
+**💡 Suggerimento:** i correlativi sono una griglia: l'inizio indica il tipo (*ki-* domanda, *ti-* indicazione, *i-* indefinito, *ĉi-* universalità, *neni-* negazione) e la fine indica la categoria (*-o* cosa, *-u* individuo, *-e* luogo, *-am* tempo…). Conoscendo le due, componi qualsiasi parola.
 
-- la *-j* finale puó essere aggiunta a quelli terminanti con *-u* e *-a*
-- la *-n* finale a quelli terminanti con *-o*, *-u*, *-a* e *-e*:
+Il plurale *-j* lo prendono i correlativi in *-u* e *-a*; l'accusativo *-n* quelli in *-o*, *-u*, *-a* ed *-e*:
 
-## Kio 
+## *kio*
 
-- *Kio* – che cosa
-- *kion* – che cosa (in accusativo) 
+- *kio* – che cosa
+- *kio__n__* – che cosa (in accusativo)
 
-- *Kion vi manĝas? Kukon mi manĝas.*
+- *__Kion__ vi manĝas? Kukon mi manĝas.* – Che cosa mangi? Mangio una torta.
 
-## Kiu
-- *Kiu* – chi, che, il quale
-- *kiun* – che, quale (in accusativo)
-- *kiuj* – che, i quali (al nominativo)
-- *kiujn* – che, i quali (in accusativo)
+## *kiu*
 
-## Kia
+- *kiu* – chi, che, il quale
+- *kiu__n__* – che, quale (in accusativo)
+- *kiu__j__* – che, i quali (nominativo)
+- *kiu__jn__* – che, i quali (accusativo)
 
-- *Kia* – che, quale (indica la specie)
+## *kia*
 
-- *Kia estas la vetero?* – "Com'è è il tempo?"
+- *kia* – che, quale (indica il tipo)
+
+- *Kia estas la vetero?* – Com'è il tempo?
 - *Kian aŭton vi havas?* – Che tipo di automobile hai?
 - *Kiaj estas ŝiaj leteroj?* – Come sono le sue lettere?
-- *Kiajn fotojn vi faris?* – Che di tipo di foto hai fatto?
+- *Kiajn fotojn vi faris?* – Che tipo di foto hai fatto?
 
-## Kie
+## *kie*
 
-- *Kie* – dove
-- *Kien* – dove (moto a luogo)
+- *kie* – dove
+- *kie__n__* – dove (moto a luogo)
 
 - *Kie mi estas?* – Dove sono?
 - *Kien vi iras?* – Dove stai andando?
 
 ## Con preposizione
 
-- *Al kiu* – a chi, a cui
+- *al kiu* – a chi, a cui
 - *kun kiu* – con chi, con cui
 - *al tiu* – a quello
-- *inter tiuj* – tra quegli
+- *inter tiuj* – tra quelli
 
 # Comparativi
 
-Il comparativo di *uguaglianza* (così... come, tanto... quanto) si forma con i correlativi "tiel... kiel" e "tiom... kiom".
+Il comparativo di *uguaglianza* (così… come, tanto… quanto) si forma con *tiel… kiel* e *tiom… kiom*:
 
-- *Mi naĝas __tiel__ rapide __kiel__ fiŝo* – Nuoto svelto come pesce.
-- *Mia onklo estas __tion__ riĉa __kiom__ mia edzo* – Mio zio è tanto ricco quanto mio marito.
+- *Mi naĝas __tiel__ rapide __kiel__ fiŝo.* – Nuoto veloce come un pesce.
+- *Mia onklo estas __tiom__ riĉa __kiom__ mia edzo.* – Mio zio è tanto ricco quanto mio marito.
 
-Il comparativo di *maggioranza* (più... di) si forma usando l'espressione "pli... ol".
+Il comparativo di *maggioranza* (più… di) si forma con *pli… ol*:
 
-- *Mia filo estas __pli__ alta __ol__ li* – Mio figlio è più alto di lui.
+- *Mia filo estas __pli__ alta __ol__ li.* – Mio figlio è più alto di lui.
 
-Il comparativo di *minoranza* (meno... di) si forma usando l'espressione "malpli... ol".
+Il comparativo di *minoranza* (meno… di) si forma con *malpli… ol*:
 
-- *Li estas __malpli__ alta __ol__ mia filo* – Lui è meno alto di mio figlio.
+- *Li estas __malpli__ alta __ol__ mia filo.* – Lui è meno alto di mio figlio.
+
+**💡 Suggerimento:** *pli … ol* = "più … di/che"; *malpli … ol* = "meno … di". Basta il prefisso *mal-* per rovesciare il confronto.
 
 # Superlativo relativo
 
-Il superlativo relativo (quello in cui c'è comparazione) si traduce con le espressioni "la plej... el" o "la **mal**plej... el", rispettivamente di maggioranza o di minoranza.
+Il superlativo relativo (con comparazione) si traduce con *la plej… el* o *la malplej… el*:
 
-- *Maria estas __la plej__ alta __el__ miaj filinoj* – Maria è la più alta delle (tra le) mie figlie.
+- *Maria estas __la plej__ alta __el__ miaj filinoj.* – Maria è la più alta delle mie figlie.
 
-Se il superlativo relativo si riferisce a due soli termini e non ad un gruppo, si traduce con "la pli... el" o "la malpli... el".
+Se riguarda due soli termini, si usa *la pli… el* o *la malpli… el*:
 
-- *Tiu ĉi libro estas __la pli__ interesa __el__ la du* – Questo libro è il più interessante dei due.
+- *Tiu ĉi libro estas __la pli__ interesa __el__ la du.* – Questo libro è il più interessante dei due.
 
 # Superlativo assoluto
 
-Il superlativo assoluto (quello che *non* indica comparazione) si esprime premettendo all'aggettivo o all'avverbio la parola **tre**, oppure inserendo tra la radice e la desinenza il suffisso **-eg**.
+Il superlativo assoluto (senza comparazione) si esprime premettendo *tre* all'aggettivo o all'avverbio, oppure inserendo il suffisso *-eg*:
 
 - *__tre__ bela* – bellissimo
-- *bel__eg__a*  – bellissimo
+- *bel__eg__a* – bellissimo
 
-# *Dum* 
+# *dum*
 
-Dum è una particella che può fungere sia da preposizione (con il significato di "durante"), sia da congiunzione (con il significato di "mentre").
+*__dum__* è preposizione ("durante") e congiunzione ("mentre"):
 
-- *Li lernas __dum__ la leciono* – Lui impara durante la lezione.
-- *Ŝi sidas __dum__ li legas*    – Lei siede mentre lui legge.
+- *Li lernas __dum__ la leciono.* – Impara durante la lezione.
+- *Ŝi sidas __dum__ li legas.* – Lei siede mentre lui legge.
 
-# *Ĉi*
+# *ĉi*
 
-Ĉi è una particella usata con i correlativi che indica vicinanza:
+La particella *__ĉi__* usata con i correlativi indica vicinanza:
 
-- *tiu* – quello / *tiu ĉi* o *ĉi tiu* – questo
-- *tie* – lì     / *tie ĉi* o *ĉi tie* – qui
+- *tiu* – quello → *ĉi tiu* (o *tiu ĉi*) – questo
+- *tie* – lì → *ĉi tie* (o *tie ĉi*) – qui
 
-# Suffisso *-ind*
+# Suffisso *__-ind__*
 
-Significa "degno di...", "che vale la pena...", "meritare".
+significa "degno di…", "che vale la pena…":
 
 - *aŭskult__ind__a* – degno di essere ascoltato
-- *leg__ind__a*     – che vale la pena leggere
-- *bedaŭr__ind__e*  – sfortunantamente, purtroppo (non vale la pena di penarsi)
-- *nedank__ind__e*  – polite reply to *dankon* (literally: not-thank-worthily)
+- *leg__ind__a* – che vale la pena leggere
+- *bedaŭr__ind__e* – purtroppo (lett.: da compiangere)
+- *nedank__ind__e* – prego, di niente (risposta cortese a *dankon*)
 
 # Di più
 
-"Di più" si traduce "pli multe".
+"Di più" si traduce *pli multe*:
 
 - *Studu __pli multe__!* – Studia di più!
- 

--- a/enhavo/tradukenda/it/gramatiko/06.md
+++ b/enhavo/tradukenda/it/gramatiko/06.md
@@ -1,59 +1,53 @@
-# Espressioni indicanti comando o desiderio
+# Espressioni che indicano comando o desiderio
 
-Tali espressioni sono costituite da una frase principale che contiene un verbo indicante comando o desiderio (deziri - desiderare; voli - volere; postuli - richiedere, esigere), dalla congiunzione *ke* e da una frase secondaria che ha il verbo terminante in -u (come l'imperativo).
+Sono formate da una frase principale con un verbo di comando o desiderio (*deziri* – desiderare; *voli* – volere; *postuli* – esigere), dalla congiunzione *ke* e da una frase secondaria con il verbo in *-u* (come l'imperativo):
 
-- *Mi deziras, __ke__ vi lern__u__.* – Desidero che impari.
-- *La patro insistas, __ke__ mi iru.* – Il padre vuole che io vada.
- 
+- *Mi deziras, __ke__ vi lern__u__.* – Desidero che tu impari.
+- *La patro insistas, __ke__ mi ir__u__.* – Il padre vuole che io vada.
+
+**💡 Suggerimento:** "che" + congiuntivo (*che tu impari*) diventa *ke* + desinenza *-u*: *ke vi lern__u__*.
+
 # Preposizione *je*
 
-Quando non si trova la preposizione adatta per tradurre le preposizioni italiane, si può usare la preposizione indefinita *je*, purché si mantenga la chiarezza di linguaggio. Si usa inoltre per indicare l'ora.
+Quando nessuna preposizione traduce esattamente quella italiana, si usa la preposizione indefinita *__je__*, purché resti chiaro il senso. Si usa anche per l'ora:
 
-- *__Je__ kioma horo vi venos?* – A quale ora verrai?
+- *__Je__ kioma horo vi venos?* – A che ora verrai?
 - *__Je__ la kvina horo.* – Alle cinque.
-- *La lando estas riĉa __je__ teo* – Il paese è ricco di te.
-- *__Je__ la fino ili revenis* – Alla fine tornarono.
+- *La lando estas riĉa __je__ teo.* – Il paese è ricco di tè.
 - *__Je__ via sano!* – Alla vostra salute!
- 
 
-# Verbo *Farti*
+# Verbo *farti*
 
-Questo verbo si usa per esprimere lo stato di salute di una persona
+Questo verbo esprime lo stato di salute di una persona:
 
 - *Bonan tagon, kiel vi __fartas__?* – Buongiorno, come sta?
 
+# Suffisso *__-et__*
 
-# Suffisso *-et*
-
-Si usa per indicare minor grandezza o intensità (diminutivo).
+indica minore grandezza o intensità (diminutivo):
 
 - *libr__et__o* – libretto
-- *bel__et__a*  – carino
-- *varm__et__a* – tipedio
- 
+- *bel__et__a* – carino
+- *varm__et__a* – tiepido
 
-# Suffisso *-eg*
+# Suffisso *__-eg__*
 
-Si usa per indicare maggior grandezza o intensità (accrescitivo).
+indica maggiore grandezza o intensità (accrescitivo):
 
-- *libr_ego_*    – librone, tomo
-- *varm__eg__a*  – caldissimo
-- *bel__eg__a*   – bellissimo
-- *bon__eg__a*   – eccellente
+- *libr__eg__o* – librone, tomo
+- *varm__eg__a* – caldissimo
+- *bel__eg__a* – bellissimo
+- *bon__eg__a* – eccellente
 
-Come si è visto in precedenza, e come si intuisce dagli esempi, questo suffisso può servire per indicare il superlativo assoluto.
- 
+**💡 Suggerimento:** *-et* rimpicciolisce, *-eg* ingrandisce — come l'italiano *-ino/-etto* e *-one*: *libro* → *libr__et__o* (libretto) → *libr__eg__o* (librone). Come si è visto, *-eg* può esprimere anche il superlativo assoluto.
 
-# Suffisso *-iĝ*
+# Suffisso *__-iĝ__*
 
-Significa: farsi, divenire.
+significa "farsi", "diventare":
 
-- *riĉiĝi*          – arricchirsi
-- *trankvil__iĝ__i* – tranquillizarsi, calmarsi
-- *resan__iĝ__i*    – guarire
-- *geedz__iĝ__i*    – sposarsi
-- *bel__iĝ__i*      – divenire bello, abbellirsi
-- *interes__iĝ__i*  – interessarsi
-- *terur__iĝ__i*    – terrorizzarsi, spaventarsi
- 
-
+- *riĉ__iĝ__i* – arricchirsi
+- *trankvil__iĝ__i* – calmarsi
+- *resan__iĝ__i* – guarire
+- *geedz__iĝ__i* – sposarsi
+- *bel__iĝ__i* – abbellirsi
+- *interes__iĝ__i* – interessarsi

--- a/enhavo/tradukenda/it/gramatiko/07.md
+++ b/enhavo/tradukenda/it/gramatiko/07.md
@@ -1,58 +1,53 @@
 # Negazione
 
-La nostra duplice negazione "né ... né" si traduce in esperanto nek ... nek.
+La nostra doppia negazione "né… né" si traduce con *nek… nek*:
 
-- *__Nek__ li __nek__ ŝi respondis.*   – Non ha risposto né lui né lei.
-- *Vi __nek__ sidas __nek__ rigardas.* – Non stai né seduto né stai guardando.
+- *__Nek__ li __nek__ ŝi respondis.* – Non ha risposto né lui né lei.
+- *Vi __nek__ sidas __nek__ rigardas.* – Non stai né seduto né guardi.
 
-Attenzione! In italiano noi a volte usiamo più negazioni nella stessa frase, ad es. "non lo dirò mai a nessuno". In esperanto non ci può essere più di una negazione, perciò lafrase considerata sarà così:
-
-- *Mi __neniam__ diros al iu.* – Non lo dirò mai a nessuno.
-
-Se diciamo *mi neniam ne diros*, otterremo il contrario di ciò che vogliamo dire, cioè un significato positivo.
+**⚠️ Attenzione:** in italiano usiamo spesso più negazioni nella stessa frase ("non lo dirò mai a nessuno"). In esperanto ne è ammessa una sola: *Mi __neniam__ diros al iu.* Se dici *mi neniam ne diros*, ottieni il contrario (un senso positivo).
 
 # *Mem*
 
-Mem significa: di persona, da sé stesso. Non si deve confondere con *sola* che significa "solo".
+*__mem__* significa "di persona", "da sé". Non confonderlo con *sola* ("solo"):
 
-- *Mi __mem__ faris tion.* – Questo l'ho fatto da solo (io stesso).
-- *Mi __sola__ faris tion* – Questo l'ho fatto da solo (mentre ero solo).
+- *Mi __mem__ faris tion.* – L'ho fatto io stesso.
+- *Mi __sola__ faris tion.* – L'ho fatto da solo (mentre ero solo).
 
 # Arrivederci
 
-Questo saluto ha due forme. Quando si saluta qualcuno sapendo esattamente quando ci si incontrerà di nuovo (ad esempio dopo aver fissato un appuntamento) si dice *ĝis la revido*. In tutti gli altri casi (cioè quando non si sa esattamente quando ci si rivedrà) si dice *ĝis revido*.
+Questo saluto ha due forme: quando si sa già quando ci si rivedrà (per esempio dopo un appuntamento) si dice *ĝis la revido*; in tutti gli altri casi *ĝis revido*.
 
-# Prefisso *ek-*
+# Prefisso *__ek-__*
 
-Indica l'inizio di un'azione o un'azione improvvisa.
+indica l'inizio di un'azione o un'azione improvvisa:
 
-- *__ek__paroli*  – cominciare a parlare
-- *__ek__silenti* – ammutolirsi
-- *__ek__salti*   – sobbalzare
-- *__ek__ridi*    – mettersi a ridere
+- *__ek__paroli* – cominciare a parlare
+- *__ek__silenti* – ammutolire
+- *__ek__salti* – sobbalzare
+- *__ek__ridi* – mettersi a ridere
 
-# Suffisso *-aĵ*
+# Suffisso *__-aĵ__*
 
-Indica cosa concreta, qualcosa di materiale.
+indica una cosa concreta, qualcosa di materiale:
 
-- *manĝ__aĵ__o*  – cibo
-- *trink__aĵ__o* – bibita, bevanda
-- *bel__aĵ__o*   – bellezza (qualcosa di bello)
-- *send__aĵ__o*  – spedizione
-- *vestaĵo*      – vestito, capo di vestiario
+- *manĝ__aĵ__o* – cibo
+- *trink__aĵ__o* – bevanda
+- *bel__aĵ__o* – qualcosa di bello
+- *send__aĵ__o* – spedizione, invio
+- *vest__aĵ__o* – vestito, capo di vestiario
 
 # Espressioni di cortesia più frequenti
 
-- bonan tagon      – buon giorno
-- bonan matenon    – buon mattino 
-- bonan nokton     – buona notte
-- bonan vesperon   – buona sera 
-- saluton          – ciao, salve
-- ĝis (la) revido  – arrivederci
-- dankon           – grazie
-- nedankinde       – prego, di niente
-- mi petas         – per favore
-- pardonu          – scusate
-- bonvolu          – prego, favorisca
-- bonan apetiton   – buon appetito
- 
+- *bonan tagon* – buongiorno
+- *bonan matenon* – buon mattino
+- *bonan nokton* – buonanotte
+- *bonan vesperon* – buonasera
+- *saluton* – ciao, salve
+- *ĝis (la) revido* – arrivederci
+- *dankon* – grazie
+- *nedankinde* – prego, di niente
+- *mi petas* – per favore
+- *pardonu* – scusa, scusate
+- *bonvolu* – prego, favorisca
+- *bonan apetiton* – buon appetito

--- a/enhavo/tradukenda/it/gramatiko/08.md
+++ b/enhavo/tradukenda/it/gramatiko/08.md
@@ -1,35 +1,39 @@
-# La preposizione *Da*
+# La preposizione *da*
 
-Quando la preposizione italiana "di" segue un nme o un avverbio di quantità e regge un nome di materia, un nome astratto o un nome al plurale, privi di articlo, in esperento essa viene tradotta con la preposizione da.
+Quando la preposizione italiana "di" segue un nome o un avverbio di quantità e regge un nome di materia, astratto o plurale (senza articolo), in esperanto si traduce con *__da__*:
 
 - *kilogramo __da__ sukero* – un chilo di zucchero
-- *iom __da__ akvo* – "un po' d'acqua"
+- *iom __da__ akvo* – un po' d'acqua
 - *multe __da__ ideoj* – molte idee
 - *glaso __da__ vino* – un bicchiere di vino
 
-"Un bicchiere *da* vino" corrisponde invece in esperanto a *glaso por vino* o *vinglaso*.
-Si noti che l'aggettivi interrogativo "quanto/a" viene reso in esperanto con l'avverbio quantitativo *kiom* seguito da *da*.
+"Un bicchiere *da* vino" corrisponde invece a *glaso por vino* o *vinglaso*.
 
-- *__Kiom da__ amikoj vi havas?* – quanti amici hai?
+L'aggettivo interrogativo "quanto/a" si rende con l'avverbio *kiom* seguito da *da*:
 
-# Suffisso *-ig*
+- *__Kiom da__ amikoj vi havas?* – Quanti amici hai?
 
-Significa rendere, fare, far diventare. I veri formati con questo suffisso sono sempre transitivi.
+**💡 Suggerimento:** dopo una misura (*chilo*, *bicchiere*, *molto*) l'italiano usa "di": "un bicchiere **di** vino". L'esperanto lo marca con *da*: *glaso da vino*.
+
+# Suffisso *__-ig__*
+
+significa "rendere", "fare diventare". I verbi formati con questo suffisso sono sempre transitivi:
 
 - *bel__ig__i* – abbellire
-- *malbon__ig__i* – rendere cattivo (inasprire), peggiorare
+- *malbon__ig__i* – peggiorare
 - *malplen__ig__i* – svuotare
 - *san__ig__i* – curare
 - *mort__ig__i* – uccidere
 
-# Suffiss *-aĉ*
+# Suffisso *__-aĉ__*
 
-Indica disprezzo (per qualità materiali)
+indica disprezzo (per qualità materiali):
 
-- *doma__aĉ__o* – tugurio
+- *dom__aĉ__o* – tugurio
 - *ĉeval__aĉ__o* – ronzino
 - *rid__aĉ__i* – sghignazzare
 - *hund__aĉ__o* – cagnaccio
 - *knab__aĉ__o* – ragazzaccio, monello
-- *srib__aĉ__i* – scarabocchiare
- 
+- *skrib__aĉ__i* – scarabocchiare
+
+**💡 Suggerimento:** *-aĉ* corrisponde ai suffissi dispregiativi italiani *-accio/-astro*: *hund__aĉ__o* = can-accio.

--- a/enhavo/tradukenda/it/gramatiko/09.md
+++ b/enhavo/tradukenda/it/gramatiko/09.md
@@ -1,68 +1,53 @@
 # Condizionale
 
-Il condizionale si forma con la desinenza -us:
+Il condizionale si forma con la desinenza *__-us__*:
 
-- *mi kred__us__* – io credrei
-- *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – Se stessi bene, sarei molto felice
+- *mi kred__us__* – io crederei
+- *Se mi est__us__ sana, mi est__us__ tre feliĉa.* – Se stessi bene, sarei molto felice.
+
+**💡 Suggerimento:** *-us* corrisponde al condizionale italiano in *-rei/-rebbe*: *mi farus* = "farei", *vi farus* = "faresti" — una sola desinenza per tutte le persone.
 
 # *Kvazaŭ*
 
-La preposizione coordinata kvazaŭ "come se, quasi come"	vuole il verbo al condizionale.
+La congiunzione *__kvazaŭ__* ("come se, quasi come") vuole il verbo al condizionale:
 
-- *Vi sidas tie __kvazaŭ__ vi estus reĝo.* – Stai lì seduto come fossi un re
+- *Vi sidas tie __kvazaŭ__ vi estus reĝo.* – Stai lì seduto come se fossi un re.
 
-Però la si può usare anche senza verbo e in questo caso non ci sarà naturalmente il condizionale.
+Può usarsi anche senza verbo, e allora non c'è il condizionale:
 
-- *Vi sidas __kvazaŭ__ reĝo.* – Siedi come un re
+- *Vi sidas __kvazaŭ__ reĝo.* – Siedi come un re.
 
+# Suffisso *__-ad__*
 
-# Suffisso *-ad*
+serve a sostantivare il verbo:
 
-Serve a sostantivizzare il verbo.
+- *kanti* – cantare → *kant__ad__o* – (l'atto del) cantare
+- *suferi* – soffrire → *sufer__ad__o* – sofferenza
 
-- *kanti* – cantare
-  - *kant__ad__o* – (l'atto del) cantare
-- *suferi* – soffire
-	- *sufer__ad__o* – sofferenza
+Indica anche azione ripetuta o continua:
 
-Indica anche azione ripetuta o continua.
+- *rigardi* – guardare → *rigard__ad__i* – fissare
+- *demandi* – domandare → *demand__ad__i* – continuare a fare domande
+- *informo* – informazione → *inform__ad__o* – pubblicità
 
-- *rigardi* – guardare
-  - *rigard__ad__i* – fissare
-- *demandi* – domandare
-	- *demand__ad__i* – continuare a fare domande
-- *informo* – informazione
-	- *inform__ad__o* – pubblicità
+# Suffisso *__-ar__*
 
+indica un insieme di persone o cose omogenee:
 
-# Suffisso *-ar*
+- *arbo* – albero → *arb__ar__o* – bosco, foresta
+- *vagono* – vagone → *vagon__ar__o* – treno
+- *vorto* – parola → *vort__ar__o* – dizionario
 
-Indica un insieme costituito da più persone o cose omogenee.
+# Suffisso *__-um__*
 
-- *arbo* – albero
-	- *arb__ar__o* – bosco, foresta
-- *vagono* – vagone
-	- *vagon__ar__o* – treno
-- *vorto* – parola
-	- *vort__ar__o* – dizionario
- 
+esprime un concetto genericamente affine a quello della radice:
 
-# Suffisso *-um*
+- *plena* – pieno → *plen__um__i* – adempiere, eseguire
+- *proksima* – vicino → *proksim__um__e* – approssimativamente
+- *suno* – sole → *sun__um__i* – abbronzarsi
+- *aĉeti* – comprare → *aĉet__um__i* – fare la spesa
+- *malvarmo* – freddo → *malvarm__um__o* – raffreddore
+- *buŝo* – bocca → *buŝ__um__o* – museruola
+- *okulo* – occhio → *okul__um__i* – occhieggiare
 
-Suffisso che serve ad esprimere un concetto genericamente affine a quello espresso dalla radice.
-
-- *plena* – pieno
-  -  *plen__um__i* – adempire, eseguire
-- *proksima* – vicino
-  -  *proksim__um__e* – approssimativamente, circa
-- *suno* – sole
-	- *sun__um__i* – abbronzarsi
-- *aĉeti* – comprare
-	- *aĉt__um__i* – fare la spesa
-- *malvarmo* – freddo
-	- *malvarm__um__o* – raffreddore
-- *buŝo* – bocca
-	- *buŝ__um__o* – museruola
-- *okulo* – occhio
-	- *okul__um__i* – occhieggiare
-
+**💡 Suggerimento:** *-um* è il suffisso "jolly", per i casi speciali — il suo senso va imparato parola per parola.

--- a/enhavo/tradukenda/it/gramatiko/10.md
+++ b/enhavo/tradukenda/it/gramatiko/10.md
@@ -1,30 +1,28 @@
-# Suffisso *-an*
+# Suffisso *__-an__*
 
-Indica membro, abitante, seguace.
+indica membro, abitante, seguace:
 
-- *klub__an__o*    – membro di un circolo/club
-- *amerik__an__o*  – americano
+- *klub__an__o* – membro di un circolo/club
+- *amerik__an__o* – americano
 - *samland__an__o* – conterraneo
-- *samide__an__o*  – un collega esperantista
- 
+- *samide__an__o* – compagno esperantista (di uno stesso ideale)
 
-# Suffisso *-ec*
+# Suffisso *__-ec__*
 
-Indica qualità astratta.
+indica una qualità astratta:
 
-- *bel__ec__o*   – bellezza
-- *varm__ec__o*  – calore
+- *bel__ec__o* – bellezza
+- *varm__ec__o* – calore
 - *simpl__ec__o* – semplicità
-- *bon__ec__o*   – bontà
- 
+- *bon__ec__o* – bontà
 
-# Suffisso *-uj*
+**💡 Suggerimento:** *-ec* corrisponde all'italiano "-ità", "-ezza": *bel__ec__o* → bell-ezza, *simpl__ec__o* → simpl-icità.
 
-Indica secondo i casi il contenitore, l'albero o il paese.
+# Suffisso *__-uj__*
+
+indica, secondo i casi, un contenitore, un albero o un paese:
 
 - *cindr__uj__o* – posacenere
 - *Aŭstr__uj__o* – Austria
-- *italo*  – italiano
-	- *Ital__uj__o*  – Italia
-- *pomo*   – mela
-	- *pom__uj__o*   – melo
+- *italo* – italiano → *Ital__uj__o* – Italia
+- *pomo* – mela → *pom__uj__o* – melo

--- a/enhavo/tradukenda/it/gramatiko/11.md
+++ b/enhavo/tradukenda/it/gramatiko/11.md
@@ -1,11 +1,13 @@
-# Suffisso *-il*
+# Suffisso *__-il__*
 
-Indica il mezzo con cui si fa qualcosa.
+indica il mezzo o lo strumento con cui si fa qualcosa:
 
-- *manĝ__il__o*     – posata
-- *tranĉ__il__o*    – coltello
-- *hak__il__o*      – ascia
-- *ŝlos__il__o*     – chiave
-- *timig__il__o*    – spaventapasseri, spauracchio
-- *skrib__il__o*    – penna
-- *lud__il__o*      – giocattolo
+- *manĝ__il__o* – posata
+- *tranĉ__il__o* – coltello
+- *hak__il__o* – ascia
+- *ŝlos__il__o* – chiave
+- *timig__il__o* – spaventapasseri
+- *skrib__il__o* – penna
+- *lud__il__o* – giocattolo
+
+**💡 Suggerimento:** *-il* è lo "strumento per…". Prendi un verbo e aggiungi *-ilo*: *tranĉi* (tagliare) → *tranĉ__il__o* (coltello); *kombi* (pettinare) → *komb__il__o* (pettine).

--- a/enhavo/tradukenda/it/gramatiko/12.md
+++ b/enhavo/tradukenda/it/gramatiko/12.md
@@ -1,28 +1,32 @@
-# *Ju … des*
+# *ju … des*
 
-- *Ju pli longe, des pli bone.* – quanto più a lungo, tanto meglio.
- 
+costruzione "quanto più… tanto più":
 
-# *Ajn*
+- *__Ju__ pli longe, __des__ pli bone.* – Quanto più a lungo, tanto meglio.
+
+**💡 Suggerimento:** è il nostro "quanto più… tanto più": *ju* = "quanto", *des* = "tanto".
+
+# *ajn*
+
+*__ajn__* significa "-unque" e accompagna i correlativi:
 
 - *kiu ajn* – chiunque
-- *kie ajn* – covunque
- 
+- *kie ajn* – ovunque
 
-# Prefisso *dis-*
+# Prefisso *__dis-__*
 
-Significa distribuzioni, separazione.
+indica dispersione, separazione (l'italiano "dis-"):
 
 - *__dis__ĵeti* – sparpagliare
 - *__dis__iri* – separarsi
- 
 
-# Suffisso *-on*
+# Suffisso *__-on__*
 
-Indica una frazione.
+indica una frazione:
 
-- *du__on__o*   – un mezzo, metà
-- *tri__on__o*  – un terzo
+- *du__on__o* – metà
+- *tri__on__o* – un terzo
 - *kvar__on__o* – un quarto
-- *ses__on__o*  – un sesto
- 
+- *ses__on__o* – un sesto
+
+**💡 Suggerimento:** *-on* trasforma un numero in frazione: *du* (2) → *du__on__o* (metà), *kvar* (4) → *kvar__on__o* (un quarto).

--- a/enhavo/tradukenda/it/vortaro/grava_esprimo.yml
+++ b/enhavo/tradukenda/it/vortaro/grava_esprimo.yml
@@ -2,7 +2,9 @@
 'iom post iom': "un po' alla volta"
 'pli-malpli': più o meno
 'mem kompreneble': ovviamente
-'temas pri': it is about
+'temas pri':
+- si tratta di
+- riguarda
 'iomete': un po'
 'rilate al': riguardo a
 'ni diru': diciamo

--- a/enhavo/tradukenda/it/vortaro/prepozicio.yml
+++ b/enhavo/tradukenda/it/vortaro/prepozicio.yml
@@ -22,7 +22,9 @@ kontraŭ:
 - di fronte
 krom: oltre a
 kun: con
-laŭ: secondo (avverbio)
+laŭ:
+- secondo
+- lungo
 per: 
 - mediante
 - tramite


### PR DESCRIPTION
## Resumo

Plibonigo de la itala traduko laŭ `ai/plibonigi-tradukon.md` — gramatiko, vortaro kaj ekzercoj.

## Gramatiko (01–12) — pedagogia rekonstruo
Konservante la temojn, la Esperanto-ekzemplojn kaj la riĉan enhavon, plibonigita prezento laŭ la modelo de en/fr/pt:
- **Memorhelpiloj 💡 kaj avertoj ⚠️ specifaj por italoj**: prononco (*c* = ts, *g* ĉiam dura, *s* neniam «z»); akcento (parole piane); *-as* sen persona fleksio + deviga pronomo; akuzativo *-n* kaj libera vortordo; pluralo *-j* (ne la itala *-i/-e*); *mal-*; **manko de duobla neado** (granda stumblilo por italoj); *-us* = *-rei*; *da*; *-ec* = -ità/-ezza; *-et/-eg* = -ino/-one; *ju…des*; *sia* vs *lia*.
- Esperanto kursiva, morfemoj grasaj; krucreferencoj kiel ligiloj (leciono 5, [tabelo de korelativoj](/it/tabelvortoj/)).
- **Riparitaj eraroj**: anglaj restaĵoj «Adverbs may be formed…» kaj «polite reply to…»; fuŝa markado `libr_ego_`; kaj multaj tajperaroj (*correllativi, nell'appendici, Com'è è, tion→tiom, tipedio→tiepido, tranquillizarsi, sfortunantamente, lafrase, un nme, articlo, esperento, Suffiss, doma__aĉ__o, srib, credrei, soffire, aĉt__um__i, covunque*).

## Vortaro
- `grava_esprimo.yml`: `temas pri` «it is about» (angla) → «si tratta di / riguarda».
- `prepozicio.yml`: `laŭ` «secondo (avverbio)» → «secondo / lungo».
- (`vorto.yml` kaj `radiko.yml` estis kontrolitaj — neniuj realaj eraroj.)

## Ekzercoj
- **traduku-kaj-respondu**: tajperaroj `programmado`→programmando, `uomoni`→uomini, `ideee`→idee.
- (La `traduku`-dosieroj estis kontrolitaj — bone plenigitaj, sen eraroj.)

`make check` sukcesas; la itala HTML konstruiĝas senerare; bildigon de la kestoj, ligiloj kaj titoloj kontrolita (neniu ikono en titoloj).

🤖 Generated with [Claude Code](https://claude.com/claude-code)