### PR TITLE
Forigu duoblan enkondukon el llms-indeksoj

### DIFF
--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -350,7 +350,6 @@ def render_lingva_llms(enhavo, enkonduko):
         markdown_link(
             fasada_etikedo(enhavo, 'Lerni Esperanton en 12 lecionoj'),
             absoluta_url(lingva_vojo(lingvo)),
-            priskribo,
         ),
         markdown_link(
             '01. ' + enhavo['lecionoj'][0]['teksto']['titolo_string'],

--- a/fonto/py/kontrolu_eligon.py
+++ b/fonto/py/kontrolu_eligon.py
@@ -38,6 +38,9 @@ LLMS_ROOT_BE_PATTERN = re.compile(r'https://esperanto12\.net/be/llms\.txt\)')
 LLMS_EN_FULL_PATTERN = re.compile(r'https://esperanto12\.net/en/llms-full\.txt\)')
 LLMS_EN_LESSON_PATTERN = re.compile(r'https://esperanto12\.net/en/01/')
 LLMS_EN_TABELVORTOJ_PATTERN = re.compile(r'https://esperanto12\.net/en/tabelvortoj/')
+LLMS_EN_DUPLICATE_INTRO_PATTERN = re.compile(
+    r'\(https://esperanto12\.net/en/\): Teaches the most important 500 words\.'
+)
 LLMS_FULL_LESSON_1_PATTERN = re.compile(r'Amiko\s+Marko')
 LLMS_FULL_LESSON_12_PATTERN = re.compile(r'Nokta\s+promeno')
 RAW_TEMPLATE_PATTERN = re.compile(r'\{\{[^}]+\}\}')
@@ -163,6 +166,7 @@ def main():
     require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_FULL_PATTERN)
     require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_LESSON_PATTERN)
     require_pattern(lingvo_dir / 'llms.txt', LLMS_EN_TABELVORTOJ_PATTERN)
+    forbid_pattern(lingvo_dir / 'llms.txt', LLMS_EN_DUPLICATE_INTRO_PATTERN)
     require_pattern(lingvo_dir / 'llms-full.txt', LLMS_FULL_LESSON_1_PATTERN)
     require_pattern(lingvo_dir / 'llms-full.txt', LLMS_FULL_LESSON_12_PATTERN)
     forbid_pattern(lingvo_dir / 'llms-full.txt', RAW_TEMPLATE_PATTERN)


### PR DESCRIPTION
Resumo: Forigas la ripetitan enkondukan priskribon de la startpaĝa ligilo en lingvaj llms.txt-dosieroj. La priskribo restas nur supre kiel blokcita resumo. Aldonas eligokontrolon kontraŭ la angla duobligo. Kontroloj: make check; make html-all; make check-pwa.