### PR TITLE
Ripari RTL-bildigon: paĝo LTR, nur tradukitaj blokoj RTL

### DIFF
--- a/fonto/html/ekzerco3.html
+++ b/fonto/html/ekzerco3.html
@@ -42,7 +42,7 @@
       {% set form_id = leciono_index ~ '-' ~ ekzerco_index ~ '-' ~ vico_loop.index %}
     <div>
 
-      <h4>{{vico_loop.index}}. {{vico.demando}}</h4>
+      <h4 dir="{{enhavo.tekstodirekto}}">{{vico_loop.index}}. {{vico.demando}}</h4>
 
       <form id="form-{{form_id}}" class="form-horizontal">
 

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{enhavo.lingvo}}" dir="{{enhavo.tekstodirekto}}">
+<html lang="{{enhavo.lingvo}}" dir="ltr">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
## Problemo

Por RTL-lingvoj (ar, fa, he, ku, ur…) la tuta paĝo estis `<html dir="rtl">`. Tio:
- spegulis la tutan aranĝon, do la **antaŭen/malantaŭen-butonoj** aperis inversigitaj kaj konfuzaj;
- igis la **Esperantan leciontekston RTL** — do ĝi videble «saltis» de LTR al RTL meze de la paĝo.

## Solvo

Laŭ la propono: teni la **paĝon ĝenerale LTR**, kaj marki nur la **efektive tradukitajn (RTL) blokojn** kiel RTL.

- `layout.html`: `<html … dir="{{tekstodirekto}}">` → `dir="ltr"` (fiksa). La navigado, la butonoj, la langetoj kaj la Esperanta teksto restas normalaj (LTR).
- La tradukitaj blokoj jam havis `dir="{{tekstodirekto}}"` kaj do fariĝas RTL-insuloj: gramatiko (`.gramatika-korpo`), vortaro, la instrukciaj `alert`-oj, la lingva startpaĝo (`.lingva-startpagxo`) kaj la ekzercaj titoloj.
- `ekzerco3.html`: aldonita `dir` al la **demando** (plena traduka frazo, kiu antaŭe mankis).

Neniu CSS-regulo dependis de la ĝenerala `html[dir=rtl]` (nur `div[dir="rtl"] #eksporto`, kiu plu funkcias).

## Kontrolo (fa, vide)

- Leciona teksto: la **Esperanta teksto estas LTR** (maldekstre), la persaj instrukcioj RTL. ✅
- Gramatiko: la persa prozo kaj enhavtabelo estas RTL; paĝo/butonoj LTR. ✅
- La antaŭen/malantaŭen-butonoj estas en la ĝusta loko (◀ maldekstre, ▶ dekstre). ✅

`make check` sukcesas.

**Rimarko:** la apendicaj paĝoj (prepozicioj, tabelvortoj…) nun estas LTR-listoj «Esperanto-vorto – traduko», kio estas legebla kaj pure dulingva. Se vi preferas ilin RTL, tio estas facila posta aldono de `dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)