### PR TITLE
Apendico kiel «13. leciono» anstataŭ navbaro-menuo

### DIFF
--- a/fonto/html/afiksoj.html
+++ b/fonto/html/afiksoj.html
@@ -8,9 +8,9 @@
 
 {% block content %}
 
-<h2>
-	{{enhavo.fasado['Afiksoj']}}
-</h2>
+  {% include 'leciona-titolo.html' %}
+
+  {% include 'tabs.html' %}
 
 <h3>
 	{{enhavo.fasado['Prefiksoj']}}
@@ -45,5 +45,7 @@
 
 {% endfor %}
 </ul>
+
+  {% include 'pager.html' %}
 
 {% endblock %}

--- a/fonto/html/diversajxoj.html
+++ b/fonto/html/diversajxoj.html
@@ -8,9 +8,9 @@
 
 {% block content %}
 
-<h2>
-	{{enhavo.fasado['Diversaĵoj']}}
-</h2>
+  {% include 'leciona-titolo.html' %}
+
+  {% include 'tabs.html' %}
 
 <h3>
 	{{enhavo.fasado['Gravaj esprimoj']}}
@@ -101,5 +101,7 @@
 	</li>
 {% endfor %}
 </ul>
+
+  {% include 'pager.html' %}
 
 {% endblock %}

--- a/fonto/html/konjunkcioj.html
+++ b/fonto/html/konjunkcioj.html
@@ -8,9 +8,9 @@
 
 {% block content %}
 
-<h2>
-	{{enhavo.fasado['Konjunkcioj']}}
-</h2>
+  {% include 'leciona-titolo.html' %}
+
+  {% include 'tabs.html' %}
 
 <ul>
 {% for esperante in enhavo.vortaro|sort %}
@@ -24,5 +24,7 @@
 
 {% endfor %}
 </ul>
+
+  {% include 'pager.html' %}
 
 {% endblock %}

--- a/fonto/html/layout.html
+++ b/fonto/html/layout.html
@@ -61,46 +61,6 @@
               type="button"
               data-bs-toggle="dropdown"
               aria-expanded="false"
-              aria-label="{{enhavo.fasado['Aldono']}}"
-              title="{{enhavo.fasado['Aldono']}}"
-            >
-              📎
-            </button>
-            <ul class="dropdown-menu dropdown-menu-end">
-              <li>
-                <a class="dropdown-item" href="{{vojprefikso}}tabelvortoj">
-                  {{enhavo.fasado['Tabelvortoj']}}
-                </a>
-              </li>
-              <li>
-                <a class="dropdown-item" href="{{vojprefikso}}prepozicioj">
-                  {{enhavo.fasado['Prepozicioj']}}
-                </a>
-              </li>
-              <li>
-                <a class="dropdown-item" href="{{vojprefikso}}konjunkcioj">
-                  {{enhavo.fasado['Konjunkcioj']}}
-                </a>
-              </li>
-              <li>
-                <a class="dropdown-item" href="{{vojprefikso}}afiksoj">
-                  {{enhavo.fasado['Afiksoj']}}
-                </a>
-              </li>
-              <li>
-                <a class="dropdown-item" href="{{vojprefikso}}diversajxoj">
-                  {{enhavo.fasado['Diversaĵoj']}}
-                </a>
-              </li>
-            </ul>
-          </div>
-
-          <div class="dropdown">
-            <button
-              class="btn btn-dark navbar-ikona-butono dropdown-toggle"
-              type="button"
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
               aria-label="Elekti alian lingvon"
               title="Elekti alian lingvon"
             >

--- a/fonto/html/leciona-titolo.html
+++ b/fonto/html/leciona-titolo.html
@@ -5,10 +5,10 @@
     {%- endif %}
   </span>
 
-  <h2 id="leciono{{leciono_index}}" class="leciona-titolo" aria-label="{{leciono_index}}. {{leciono.teksto.titolo_string}}">
+  <h2 id="leciono{{leciono_index}}" class="leciona-titolo" aria-label="{% if apendico %}📎 {{enhavo.fasado['Aldono']}}{% else %}{{leciono_index}}. {{leciono.teksto.titolo_string}}{% endif %}">
     <span class="dropdown leciona-menuo">
       <button class="btn btn-light dropdown-toggle leciona-menuo-butono" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-        {{leciono_index}}.
+        {% if apendico %}📎{% else %}{{leciono_index}}.{% endif %}
       </button>
       <ul class="dropdown-menu leciona-menuo-listo">
         {% for menu_leciono in enhavo.lecionoj %}
@@ -18,12 +18,21 @@
             </a>
           </li>
         {% endfor %}
+        <li>
+          <a class="dropdown-item{% if apendico %} active{% endif %}" href="{{vojprefikso}}tabelvortoj">
+            📎 {{enhavo.fasado['Aldono']}}
+          </a>
+        </li>
       </ul>
     </span>
     <span class="leciona-titolo-teksto">
-      {% for vorto in leciono.teksto.titolo %}
-        {% include 'vorto.html' %}
-      {% endfor %}
+      {% if apendico %}
+        📎 {{enhavo.fasado['Aldono']}}
+      {% else %}
+        {% for vorto in leciono.teksto.titolo %}
+          {% include 'vorto.html' %}
+        {% endfor %}
+      {% endif %}
     </span>
   </h2>
 

--- a/fonto/html/prepozicioj.html
+++ b/fonto/html/prepozicioj.html
@@ -8,9 +8,9 @@
 
 {% block content %}
 
-<h2>
-	{{enhavo.fasado['Prepozicioj']}}
-</h2>
+  {% include 'leciona-titolo.html' %}
+
+  {% include 'tabs.html' %}
 
 <ul>
 {% for esperante in enhavo.vortaro|sort %}
@@ -24,5 +24,7 @@
 
 {% endfor %}
 </ul>
+
+  {% include 'pager.html' %}
 
 {% endblock %}

--- a/fonto/html/tabelvortoj.html
+++ b/fonto/html/tabelvortoj.html
@@ -8,9 +8,9 @@
 
 {% block content %}
 
-<h2>
-	{{enhavo.fasado['Tabelvortoj']}}
-</h2>
+  {% include 'leciona-titolo.html' %}
+
+  {% include 'tabs.html' %}
 
 <table class="table">
   <thead>
@@ -47,5 +47,7 @@
 		{% endfor %}
   </tbody>
 </table>
+
+  {% include 'pager.html' %}
 
 {% endblock %}

--- a/fonto/html/tabs.html
+++ b/fonto/html/tabs.html
@@ -4,7 +4,12 @@
   'gramatiko': '🧩',
   'ekzerco1': '1️⃣',
   'ekzerco2': '2️⃣',
-  'ekzerco3': '3️⃣'
+  'ekzerco3': '3️⃣',
+  'tabelvortoj': '▤',
+  'prepozicioj': '↗',
+  'konjunkcioj': '⋀',
+  'afiksoj': '⨁',
+  'diversajxoj': '❖'
 } %}
 <ul class="nav nav-tabs">
   {% for id, href, caption in tabs %}

--- a/fonto/py/html.py
+++ b/fonto/py/html.py
@@ -765,6 +765,15 @@ def generate_html(
         ('ekzerco3', 'ekzerco3/', enhavo['fasado']['Ekzerco 3'])
     ]
 
+    # La apendico aperas kiel «leciono 13» kun ĉi tiuj langetoj (flataj URL-oj).
+    apendicaj_langetoj = [
+        ('tabelvortoj', 'tabelvortoj/', enhavo['fasado']['Tabelvortoj']),
+        ('prepozicioj', 'prepozicioj/', enhavo['fasado']['Prepozicioj']),
+        ('konjunkcioj', 'konjunkcioj/', enhavo['fasado']['Konjunkcioj']),
+        ('afiksoj', 'afiksoj/', enhavo['fasado']['Afiksoj']),
+        ('diversajxoj', 'diversajxoj/', enhavo['fasado']['Diversaĵoj']),
+    ]
+
     if args.vojprefikso:
         vojprefikso = args.vojprefikso + lingvo + '/'
     else:
@@ -809,14 +818,18 @@ def generate_html(
 
     eligo[output_path / 'eksporto' / (enhavo['lingvo'] + '.apkg')] = create_anki(enhavo)
 
-    for tab_page in ALDONAJ_PAGXOJ:
+    # Memstaraj aldonaj paĝoj (ne parto de la langetoj nek de la antaŭen/malantaŭen-fluo).
+    for tab_page in ('auxtoroj', 'post'):
         pagxaj_ligiloj = redaktaj_ligiloj(lingvo, tab_page)
         eligo[output_path / tab_page / 'index.html'] = render_page(tab_page, enhavo, vojprefikso, env, pagxaj_ligiloj)
 
+    # La fluo: 12 lecionoj × langetoj, poste la apendicaj langetoj kiel «leciono 13».
     paths = []
     for i in range(1, 13):
         for id, href, caption in tabs:
             paths.append(vojprefikso + str(i).zfill(2) + '/' + href)
+    for id, href, caption in apendicaj_langetoj:
+        paths.append(vojprefikso + href)
 
     paths_index = 0
 
@@ -826,15 +839,8 @@ def generate_html(
 
         for tab, href, caption in tabs:
 
-            previous_path = None
-            next_path = None
-
-            tab_vojprefikso = vojprefikso + i_padded + '/'
-
-            if paths_index > 0:
-                previous_path = paths[paths_index - 1]
-            if paths_index < len(paths) - 1:
-                next_path = paths[paths_index + 1]
+            previous_path = paths[paths_index - 1] if paths_index > 0 else None
+            next_path = paths[paths_index + 1] if paths_index < len(paths) - 1 else None
             paths_index += 1
 
             tab_rendered = env.get_template(tab + '.html').render(
@@ -842,7 +848,7 @@ def generate_html(
                 leciono=enhavo['lecionoj'][i - 1],
                 leciono_index=i,
                 vojprefikso=vojprefikso,
-                tab_vojprefikso=tab_vojprefikso,
+                tab_vojprefikso=vojprefikso + i_padded + '/',
                 previous_path=previous_path,
                 next_path=next_path,
                 tabs=tabs,
@@ -853,6 +859,30 @@ def generate_html(
             )
 
             eligo[leciono_dir / href / 'index.html'] = tab_rendered
+
+    # La apendico: samaj langetoj sur ĉiu paĝo, kaj daŭrigo de la sama fluo.
+    for tab, href, caption in apendicaj_langetoj:
+
+        previous_path = paths[paths_index - 1] if paths_index > 0 else None
+        next_path = paths[paths_index + 1] if paths_index < len(paths) - 1 else None
+        paths_index += 1
+
+        apendica_rendered = env.get_template(tab + '.html').render(
+            enhavo=enhavo,
+            leciono_index=13,
+            apendico=True,
+            vojprefikso=vojprefikso,
+            tab_vojprefikso=vojprefikso,
+            previous_path=previous_path,
+            next_path=next_path,
+            tabs=apendicaj_langetoj,
+            active_tab=tab,
+            identigilo=href,
+            redaktaj_ligiloj=redaktaj_ligiloj(lingvo, 'vortoj'),
+            seo=seo_datenoj(enhavo, href),
+        )
+
+        eligo[output_path / tab / 'index.html'] = apendica_rendered
 
     # Forigu nunan dosierujon.
     shutil.rmtree(output_path, ignore_errors=True)


### PR DESCRIPTION
## Kio

La apendico (Correlatives, Prepositions, Conjunctions, Affixes, Miscellaneous) eliras el la 📎-menuo de la navbaro kaj aperas kiel **«13. leciono»** en la lecionlisto.

- Etikedo en la lecion-menuo: **📎 Appendix** (tradukita per `fasado['Aldono']`).
- Langetoj: ▤ Correlatives · ↗ Prepositions · ⋀ Conjunctions · ⨁ Affixes · ❖ Miscellaneous.
- La apendico nun estas parto de la klak-fluo: post `12/ekzerco3` la butono **antaŭen → Correlatives**; `Miscellaneous` estas la lasta paĝo (sen «antaŭen»).

## Kiel

- `layout.html`: forigita la 📎-fallisto el la navbaro (restas nur la 🌐-lingvofallisto).
- `tabs.html`: aldonitaj la kvin apendicaj ikonoj.
- `leciona-titolo.html`: subteno por la apendico (📎-butono, titolo, menuero «📎 Appendix»).
- `tabelvortoj/prepozicioj/konjunkcioj/afiksoj/diversajxoj.html`: `leciona-titolo` + `tabs` + `pager`.
- `html.py`: la apendicaj langetoj kun daŭrigo de la antaŭen/malantaŭen-fluo; `auxtoroj`/`post` restas memstaraj.

La flataj URL-oj (`/LINGVO/tabelvortoj/` ktp.) **restas** por ne rompi la gramatikajn krucreferencojn nek la retmapon.

## Testado

`make check` sukcesas. Sur la `en`-eligo kontrolita: `12/ekzerco3` antaŭen → `/en/tabelvortoj/`; la apendicaj paĝoj havas la langetojn, ĉiujn kvin ikonojn, la titolon «📎 Appendix» kaj ĝustajn antaŭen/malantaŭen-ligilojn; `diversajxoj` estas la lasta; la navbaro ne plu enhavas la 📎-menuon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)